### PR TITLE
Innlogging: håndter 403, unngå redirect-loop ved 401

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -16,6 +16,7 @@ import Saksoversikt from '~pages/saksoversikt/Saksoversikt';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import Lenke from 'nav-frontend-lenker';
 import styles from './root.module.less';
+import Header from '@navikt/nap-header';
 
 const Root = () => {
     return (
@@ -88,9 +89,7 @@ function ContentWrapper({ children }: { children: React.ReactChild }) {
 
     return (
         <div>
-            <div className={styles.headerContainer}>
-                <Innholdstittel className={styles.appName}>NAV Suse</Innholdstittel>
-            </div>
+            <Header title="Supplerende stønad Ufør" titleHref={'/'} />
             <div className={styles.contentContainer}>
                 {loginState === 'logging-in' ? (
                     <NavFrontendSpinner />

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -5,7 +5,7 @@ import 'reset-css';
 import ErrorBoundary from './components/ErrorBoundary';
 import 'nav-frontend-tabell-style';
 import './Root.less';
-import { BrowserRouter as Router, Switch, Route, useLocation, useHistory } from 'react-router-dom';
+import { BrowserRouter as Router, Switch, Route, useLocation, useHistory, useRouteMatch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import Store from './redux/Store';
 import Soknad from './pages/søknad';
@@ -13,36 +13,11 @@ import apiClient from '~/api/apiClient';
 import * as Cookies from './lib/cookies';
 import HomePage from '~pages/HomePage';
 import Saksoversikt from '~pages/saksoversikt/Saksoversikt';
+import NavFrontendSpinner from 'nav-frontend-spinner';
+import Lenke from 'nav-frontend-lenker';
+import styles from './root.module.less';
 
 const Root = () => {
-    const [configLoaded, setConfigLoaded] = useState(false);
-
-    useEffect(() => {
-        if (!window.BASE_URL || typeof window.BASE_URL !== 'string') {
-            fetch('/config.json').then((res) => {
-                if (res.ok) {
-                    res.json().then((config) => {
-                        window.BASE_URL = config.suSeBakoverUrl;
-                        setConfigLoaded(true);
-                    });
-                } else {
-                    console.error('klarte ikke hente config.json', res.statusText);
-                }
-            });
-        }
-    }, [window.BASE_URL]);
-
-    useEffect(() => {
-        if (!configLoaded || !window.BASE_URL || typeof window.BASE_URL !== 'string') {
-            return;
-        }
-        apiClient('/authenticated', { method: 'GET' }).then((res) => {
-            if (res.status === 'error' && res.error.statusCode === 401) {
-                window.location.href = `${window.BASE_URL}/login`;
-            }
-        });
-    }, [configLoaded]);
-
     return (
         <Provider store={Store}>
             <ErrorBoundary>
@@ -73,24 +48,60 @@ const Root = () => {
     );
 };
 
+type LoginState = 'logging-in' | 'logged-in' | 'unauthorized';
+
 function ContentWrapper({ children }: { children: React.ReactChild }) {
+    const [configLoaded, setConfigLoaded] = useState(window.BASE_URL && typeof window.BASE_URL === 'string');
+    const authCompleteRouteMatch = useRouteMatch('/auth/complete');
+    const [loginState, setLoginState] = useState<LoginState>('logging-in');
+
+    useEffect(() => {
+        if (!window.BASE_URL || typeof window.BASE_URL !== 'string') {
+            fetch('/config.json').then((res) => {
+                if (res.ok) {
+                    res.json().then((config) => {
+                        window.BASE_URL = config.suSeBakoverUrl;
+                        setConfigLoaded(true);
+                    });
+                } else {
+                    console.error('klarte ikke hente config.json', res.statusText);
+                }
+            });
+        }
+    }, [window.BASE_URL]);
+
+    useEffect(() => {
+        if (authCompleteRouteMatch || !configLoaded || !window.BASE_URL || typeof window.BASE_URL !== 'string') {
+            return;
+        }
+
+        apiClient('/authenticated', { method: 'GET' }).then((res) => {
+            if (res.status === 'error' && res.error.statusCode === 401) {
+                window.location.href = `${window.BASE_URL}/login`;
+            } else if (res.status === 'error' && res.error.statusCode === 403) {
+                setLoginState('unauthorized');
+            } else {
+                setLoginState('logged-in');
+            }
+        });
+    }, [configLoaded]);
+
     return (
         <div>
-            <div style={ContentWrapperStyle}>
-                <Innholdstittel style={appNameStyle}>NAV Suse</Innholdstittel>
+            <div className={styles.headerContainer}>
+                <Innholdstittel className={styles.appName}>NAV Suse</Innholdstittel>
             </div>
-            <div style={{ display: 'flex' }}>
-                <div
-                    style={{
-                        width: '100%',
-                        minHeight: '100vh',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                    }}
-                >
-                    {children}
-                </div>
+            <div className={styles.contentContainer}>
+                {loginState === 'logging-in' ? (
+                    <NavFrontendSpinner />
+                ) : loginState === 'unauthorized' ? (
+                    <div className={styles.ikkeTilgangContainer}>
+                        <Innholdstittel className={styles.overskrift}>Ikke tilgang</Innholdstittel>
+                        <Lenke href={`${window.BASE_URL}/login`}>Logg inn på nytt</Lenke>
+                    </div>
+                ) : (
+                    children
+                )}
             </div>
         </div>
     );
@@ -103,29 +114,13 @@ function AuthComplete() {
     const refreshToken = tokens[2];
     const history = useHistory();
 
-    Cookies.set(Cookies.CookieName.AccessToken, accessToken);
-    Cookies.set(Cookies.CookieName.RefreshToken, refreshToken);
-
     useEffect(() => {
-        if (accessToken !== undefined) {
-            history.push('/');
-        }
+        Cookies.set(Cookies.CookieName.AccessToken, accessToken);
+        Cookies.set(Cookies.CookieName.RefreshToken, refreshToken);
+        history.push('/');
     }, [accessToken, refreshToken]);
     return null;
 }
-
-const ContentWrapperStyle = {
-    backgroundColor: '#3E3832',
-    color: 'white',
-    height: '3em',
-    display: 'flex',
-    alignItems: 'center',
-};
-
-const appNameStyle = {
-    marginRight: '2em',
-    marginLeft: '1em',
-};
 
 /* eslint-disable-next-line no-undef */
 export default hot(module)(Root);

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -62,7 +62,7 @@ export default async function apiClient<T>(
 
     if (res.status === 401) {
         if (refreshToken) {
-            const refreshRes = await fetch('/auth/refresh', {
+            const refreshRes = await fetch(`${window.BASE_URL}/auth/refresh`, {
                 headers: {
                     refresh_token: refreshToken,
                     'X-Correlation-ID': correlationId,
@@ -78,10 +78,10 @@ export default async function apiClient<T>(
             if (nyttAccessToken) {
                 Cookies.set(CookieName.AccessToken, nyttAccessToken);
 
-                return apiClient(`${window.BASE_URL}${url}`, request, successStatusCodes, {
+                return apiClient(url, request, successStatusCodes, {
                     accessToken: nyttAccessToken,
                     correlationId,
-                    numAttempts: 1,
+                    numAttempts: (extraData?.numAttempts ?? 0) + 1,
                 });
             }
         }

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -84,23 +84,27 @@ const index = () => {
                 <div className={styles.sidetittelContainer}>
                     <Sidetittel>Søknad</Sidetittel>
                 </div>
-                <div className={styles.stegindikatorContainer}>
-                    <Stegindikator
-                        steg={steg.map((s) => ({
-                            index: s.index,
-                            label: s.label,
-                            aktiv: s.step === step,
-                        }))}
-                        visLabel={false}
-                        onChange={(index) => {
-                            const nyttSteg = steg[index];
-                            if (nyttSteg) {
-                                history.push(`/soknad/${nyttSteg.step}`);
-                            }
-                        }}
-                    />
-                </div>
-                <Innholdstittel>{steg.find((s) => s.step === step)?.label}</Innholdstittel>
+                {step !== Søknadsteg.Inngang && (
+                    <>
+                        <div className={styles.stegindikatorContainer}>
+                            <Stegindikator
+                                steg={steg.map((s) => ({
+                                    index: s.index,
+                                    label: s.label,
+                                    aktiv: s.step === step,
+                                }))}
+                                visLabel={false}
+                                onChange={(index) => {
+                                    const nyttSteg = steg[index];
+                                    if (nyttSteg) {
+                                        history.push(`/soknad/${nyttSteg.step}`);
+                                    }
+                                }}
+                            />
+                        </div>
+                        <Innholdstittel>{steg.find((s) => s.step === step)?.label}</Innholdstittel>
+                    </>
+                )}
             </div>
             {step === Søknadsteg.Inngang ? (
                 <Inngang nesteUrl={`/soknad/${Søknadsteg.Uførevedtak}`} />

--- a/src/root.module.less
+++ b/src/root.module.less
@@ -1,18 +1,5 @@
 @import '~/styles/variables.less';
 
-.headerContainer {
-    background-color: #3e3832;
-    color: white;
-    height: 3em;
-    display: flex;
-    align-items: center;
-
-    .appName {
-        margin-right: 2em;
-        margin-left: 1em;
-    }
-}
-
 .contentContainer {
     width: 100%;
     min-height: 100vh;

--- a/src/root.module.less
+++ b/src/root.module.less
@@ -1,0 +1,30 @@
+@import '~/styles/variables.less';
+
+.headerContainer {
+    background-color: #3e3832;
+    color: white;
+    height: 3em;
+    display: flex;
+    align-items: center;
+
+    .appName {
+        margin-right: 2em;
+        margin-left: 1em;
+    }
+}
+
+.contentContainer {
+    width: 100%;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.ikkeTilgangContainer {
+    padding: @spacing-l;
+
+    .overskrift {
+        margin-bottom: @spacing-l;
+    }
+}


### PR DESCRIPTION
- Flyttet styling fra rotkomponent til egen fil
- Viser fin melding om at man ikke har tilgang dersom man ikke har tilgang; får da også lenke om å logge inn på nytt
- Fikset bug i `apiClient` som ga uendelig redirect-loop dersom den fikk 401 (fordi vi glemte å inkrementere telleren for hvor mange ganger vi hadde prøvd 😅)
- Fjernet stegindikatoren fra inngangsiden på søknad