### PR TITLE
Fiksbar lint-regel for strukturering av imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,8 @@ module.exports = {
         'eslint:recommended',
         'plugin:react/recommended',
         'plugin:prettier/recommended',
-        'eslint:recommended',
+        'plugin:import/recommended',
+        'plugin:import/typescript',
         'plugin:@typescript-eslint/recommended',
         'prettier/@typescript-eslint',
     ],
@@ -29,12 +30,32 @@ module.exports = {
         react: {
             version: '16.0',
         },
+        'import/resolver': { typescript: {} },
+        'import/internal-regex': '^~',
     },
     plugins: ['react', '@typescript-eslint'],
     rules: {
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         'react/prop-types': 'off',
+        'import/order': [
+            1,
+            {
+                alphabetize: { order: 'asc', caseInsensitive: true },
+                'newlines-between': 'always',
+                groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+                pathGroups: [
+                    {
+                        pattern: '~*/**',
+                        group: 'internal',
+                    },
+                ],
+                pathGroupsExcludedImportTypes: [],
+            },
+        ],
+        // TypeScript passer på at vi ikke driter oss ut, så vi trenger ikke disse
+        'import/no-named-as-default-member': 0,
+        'import/no-named-as-default': 0,
     },
     overrides: [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2935,6 +2935,12 @@
             "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
             "dev": true
         },
+        "@types/json5": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "dev": true
+        },
         "@types/jsonwebtoken": {
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
@@ -3430,6 +3436,16 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.4"
+            }
+        },
+        "array.prototype.flat": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+            "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "array.prototype.flatmap": {
@@ -4752,6 +4768,12 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
+        "contains-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
         "convert-source-map": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -5946,6 +5968,172 @@
             "dev": true,
             "requires": {
                 "get-stdin": "^6.0.0"
+            }
+        },
+        "eslint-import-resolver-node": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+            "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.13.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-import-resolver-typescript": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.2.0.tgz",
+            "integrity": "sha512-/NhKEH1gbRlcb9RcaZJe5zRn5eIffGTf1qh3JAyvkEuPli3DEa5HQWWUO5OTfUjj7buUXsDq8lEsdwbbSeqywg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "glob": "^7.1.6",
+                "is-glob": "^4.0.1",
+                "resolve": "^1.17.0",
+                "tsconfig-paths": "^3.9.0"
+            }
+        },
+        "eslint-module-utils": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+            "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.9",
+                "pkg-dir": "^2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+                    "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.1.0"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.22.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
+            "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.1.1",
+                "array.prototype.flat": "^1.2.3",
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.9",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.3",
+                "eslint-module-utils": "^2.6.0",
+                "has": "^1.0.3",
+                "minimatch": "^3.0.4",
+                "object.values": "^1.1.1",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.17.0",
+                "tsconfig-paths": "^3.9.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^2.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^2.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^2.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^2.0.0"
+                    }
+                }
             }
         },
         "eslint-plugin-prettier": {
@@ -10249,6 +10437,41 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
+                }
+            }
+        },
+        "load-json-file": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.2.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
                 }
             }
         },
@@ -15169,6 +15392,26 @@
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
                     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                }
+            }
+        },
+        "tsconfig-paths": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+            "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+            "dev": true,
+            "requires": {
+                "@types/json5": "^0.0.29",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -139,6 +139,8 @@
         "enzyme-adapter-react-16": "^1.15.2",
         "eslint": "^7.3.1",
         "eslint-config-prettier": "^6.11.0",
+        "eslint-import-resolver-typescript": "^2.2.0",
+        "eslint-plugin-import": "^2.22.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.20.3",
         "husky": "^4.2.5",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,22 +1,23 @@
-import { hot } from 'react-hot-loader';
-import React, { useEffect, useState, Fragment } from 'react';
+import Header from '@navikt/nap-header';
+import Lenke from 'nav-frontend-lenker';
+import NavFrontendSpinner from 'nav-frontend-spinner';
 import { Innholdstittel } from 'nav-frontend-typografi';
-import ErrorBoundary from './components/ErrorBoundary';
-
-import { BrowserRouter as Router, Switch, Route, useLocation, useHistory, useRouteMatch } from 'react-router-dom';
+import React, { useEffect, useState, Fragment } from 'react';
+import { hot } from 'react-hot-loader';
 import { Provider } from 'react-redux';
-import Store from './redux/Store';
-import Soknad from './pages/søknad';
+import { BrowserRouter as Router, Switch, Route, useLocation, useHistory, useRouteMatch } from 'react-router-dom';
+
 import apiClient from '~/api/apiClient';
-import * as Cookies from './lib/cookies';
 import HomePage from '~pages/HomePage';
 import Saksoversikt from '~pages/saksoversikt/Saksoversikt';
-import NavFrontendSpinner from 'nav-frontend-spinner';
-import Lenke from 'nav-frontend-lenker';
-import styles from './root.module.less';
+
+import ErrorBoundary from './components/ErrorBoundary';
 import Menyknapp from './components/Menyknapp';
-import Header from '@navikt/nap-header';
+import * as Cookies from './lib/cookies';
 import * as routes from './lib/routes';
+import Soknad from './pages/søknad';
+import Store from './redux/Store';
+import styles from './root.module.less';
 import './externalStyles';
 
 const ScrollToTop = () => {

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,5 @@
 import { guid } from 'nav-frontend-js-utils';
+
 import * as Cookies from '~lib/cookies';
 import { CookieName } from '~lib/cookies';
 

--- a/src/api/behandlingApi.ts
+++ b/src/api/behandlingApi.ts
@@ -1,9 +1,11 @@
 import { formatISO } from 'date-fns';
 
+import { Nullable } from '~lib/types';
+
+import { Sats } from '../pages/saksoversikt/beregning/Beregning';
+
 import apiClient, { ApiClientResult } from './apiClient';
 import { Søknad } from './søknadApi';
-import { Sats } from '../pages/saksoversikt/beregning/Beregning';
-import { Nullable } from '~lib/types';
 
 export enum VilkårVurderingStatus {
     IkkeVurdert = 'IKKE_VURDERT',

--- a/src/api/sakApi.ts
+++ b/src/api/sakApi.ts
@@ -1,6 +1,6 @@
 import apiClient, { ApiClientResult } from './apiClient';
-import { SøknadInnhold } from './søknadApi';
 import { Behandling } from './behandlingApi';
+import { SøknadInnhold } from './søknadApi';
 
 export interface Sak {
     id: string;

--- a/src/api/søknadApi.ts
+++ b/src/api/søknadApi.ts
@@ -1,6 +1,7 @@
 import { Vergemål } from '~features/søknad/types';
-import apiClient, { ApiClientResult } from './apiClient';
 import { Nullable } from '~lib/types';
+
+import apiClient, { ApiClientResult } from './apiClient';
 
 export interface Søknad {
     id: string;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
-import React, { ErrorInfo } from 'react';
+import * as Sentry from '@sentry/browser';
 import { Feilmelding } from 'nav-frontend-typografi';
-import Sentry from '@sentry/browser';
+import React, { ErrorInfo } from 'react';
+
 import styles from './errorBoundary.module.less';
 
 class ErrorBoundary extends React.Component<unknown, { hasError: boolean; error?: Error; eventId?: string }> {

--- a/src/components/FormElements.tsx
+++ b/src/components/FormElements.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import { RadioGruppe, RadioPanel } from 'nav-frontend-skjema';
-import AlertStripe from 'nav-frontend-alertstriper';
 import classNames from 'classnames';
-import styles from './formElements.module.less';
-import nb from './formElements-nb';
-import { useI18n } from '~lib/hooks';
+import AlertStripe from 'nav-frontend-alertstriper';
 import Lesmerpanel from 'nav-frontend-lesmerpanel';
+import { RadioGruppe, RadioPanel } from 'nav-frontend-skjema';
 import { Normaltekst } from 'nav-frontend-typografi';
+import React from 'react';
+
+import { useI18n } from '~lib/hooks';
+
+import nb from './formElements-nb';
+import styles from './formElements.module.less';
 
 export const JaNeiSpørsmål = (props: {
     id: string;

--- a/src/components/Menyknapp.tsx
+++ b/src/components/Menyknapp.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
 import Chevron from 'nav-frontend-chevron';
-import Popover, { PopoverOrientering } from 'nav-frontend-popover';
-import styles from './menyknapp.module.less';
 import { Knapp } from 'nav-frontend-knapper';
+import Popover, { PopoverOrientering } from 'nav-frontend-popover';
+import React, { useState } from 'react';
+
+import styles from './menyknapp.module.less';
 
 interface Props {
     navn: string;

--- a/src/components/Personkort.tsx
+++ b/src/components/Personkort.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { KjønnKvinne, KjønnMann, KjønnUkent } from '~assets/Icons';
+
 import { Person } from '~api/personApi';
+import { KjønnKvinne, KjønnMann, KjønnUkent } from '~assets/Icons';
+
 import styles from './personkort.module.less';
 
 export const Personkort = (props: { person: Person }) => {

--- a/src/components/TextProvider.tsx
+++ b/src/components/TextProvider.tsx
@@ -1,6 +1,6 @@
+import { MessageFormatElement } from 'intl-messageformat-parser';
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
-import { MessageFormatElement } from 'intl-messageformat-parser';
 
 export enum Languages {
     nb = 'nb-NO',

--- a/src/features/person/person.slice.ts
+++ b/src/features/person/person.slice.ts
@@ -1,5 +1,6 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
 import { ErrorCode, ApiError } from '~api/apiClient';
 import * as personApi from '~api/personApi';
 

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -1,8 +1,9 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-import * as sakApi from '~api/sakApi';
-import * as behandligApi from '~api/behandlingApi';
+
 import { ErrorCode, ApiError } from '~api/apiClient';
+import * as behandligApi from '~api/behandlingApi';
+import * as sakApi from '~api/sakApi';
 import { pipe } from '~lib/fp';
 import { Sats } from '~pages/saksoversikt/beregning/Beregning';
 

--- a/src/features/søknad/innsending.slice.ts
+++ b/src/features/søknad/innsending.slice.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-import { ErrorCode, ApiError } from '~api/apiClient';
-import * as søknadApi from '~api/søknadApi';
-import { SøknadState } from './søknad.slice';
-import * as personApi from '~api/personApi';
 import * as RemoteData from '@devexperts/remote-data-ts';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+import { ErrorCode, ApiError } from '~api/apiClient';
+import * as personApi from '~api/personApi';
+import * as søknadApi from '~api/søknadApi';
+
+import { SøknadState } from './søknad.slice';
 
 export const sendSøknad = createAsyncThunk<
     søknadApi.SøknadInnhold,

--- a/src/features/søknad/søknad.slice.ts
+++ b/src/features/søknad/søknad.slice.ts
@@ -1,6 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { DelerBoligMed, TypeOppholdstillatelse, Vergemål } from './types';
+
 import { Nullable } from '~lib/types';
+
+import { DelerBoligMed, TypeOppholdstillatelse, Vergemål } from './types';
 
 export interface SøknadState {
     harUførevedtak: Nullable<boolean>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
+import * as Sentry from '@sentry/browser';
 import * as React from 'react';
 import { render } from 'react-dom';
+
 import Root from './Root';
-import * as Sentry from '@sentry/browser';
 
 // eslint-disable-next-line no-undef
 if (process.env.NODE_ENV !== 'development') {

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,5 +1,5 @@
 import Cookies from 'js-cookie';
-import jwt from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
 
 export enum CookieName {
     AccessToken = 'access_token',

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,5 +1,5 @@
-import { IntlShape } from 'react-intl';
 import * as DateFns from 'date-fns';
+import { IntlShape } from 'react-intl';
 
 export const formatDateTime = (time: string, intl: IntlShape) => {
     return `${intl.formatDate(time)} ${intl.formatTime(time)}`;

--- a/src/lib/validering.ts
+++ b/src/lib/validering.ts
@@ -1,6 +1,6 @@
-import * as yup from 'yup';
 import { FormikErrors } from 'formik';
 import { FeiloppsummeringFeil } from 'nav-frontend-skjema';
+import * as yup from 'yup';
 
 function label(data: Partial<yup.TestMessageParams>) {
     return data.label ?? 'Feltet';

--- a/src/pages/saksoversikt/Saksoversikt.tsx
+++ b/src/pages/saksoversikt/Saksoversikt.tsx
@@ -1,28 +1,25 @@
+import * as RemoteData from '@devexperts/remote-data-ts';
+import { PersonCard } from '@navikt/nap-person-card';
+import classNames from 'classnames';
+import AlertStripe from 'nav-frontend-alertstriper';
+import NavFrontendSpinner from 'nav-frontend-spinner';
 import React, { useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import { useParams } from 'react-router-dom';
-import AlertStripe from 'nav-frontend-alertstriper';
-
-import * as RemoteData from '@devexperts/remote-data-ts';
-import { PersonCard } from '@navikt/nap-person-card';
-
-import NavFrontendSpinner from 'nav-frontend-spinner';
 
 import { Languages } from '~components/TextProvider';
-import { useAppSelector, useAppDispatch } from '~redux/Store';
+import * as personSlice from '~features/person/person.slice';
+import * as sakSlice from '~features/saksoversikt/sak.slice';
 import { pipe } from '~lib/fp';
+import { useAppSelector, useAppDispatch } from '~redux/Store';
 
+import Beregning from './beregning/Beregning';
+import Sakintro from './sakintro/Sakintro';
 import messages from './saksoversikt-nb';
+import styles from './saksoversikt.module.less';
 import Søkefelt from './søkefelt/Søkefelt';
 import { SaksbehandlingMenyvalg } from './types';
-
-import styles from './saksoversikt.module.less';
-import Sakintro from './sakintro/Sakintro';
 import Vilkår from './vilkår/Vilkår';
-import Beregning from './beregning/Beregning';
-import * as sakSlice from '~features/saksoversikt/sak.slice';
-import * as personSlice from '~features/person/person.slice';
-import classNames from 'classnames';
 
 const Meny = (props: { aktiv: SaksbehandlingMenyvalg }) => (
     <div className={styles.meny}>

--- a/src/pages/saksoversikt/beregning/Beregning.tsx
+++ b/src/pages/saksoversikt/beregning/Beregning.tsx
@@ -1,22 +1,24 @@
-import React from 'react';
-import { RadioPanelGruppe, Label, Feiloppsummering } from 'nav-frontend-skjema';
-import { useFormik } from 'formik';
-import { Hovedknapp } from 'nav-frontend-knapper';
-import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
-import { Beregning } from '~api/behandlingApi';
-import styles from './beregning.module.less';
-import { useI18n } from '~lib/hooks';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import * as sakSlice from '~features/saksoversikt/sak.slice';
-import { Sak } from '~api/sakApi';
-import AlertStripe from 'nav-frontend-alertstriper';
-import messages from './beregning-nb';
-import VisBeregning from './VisBeregning';
-import { Innholdstittel, Feilmelding } from 'nav-frontend-typografi';
 import * as RemoteData from '@devexperts/remote-data-ts';
-import DatePicker from 'react-datepicker';
-import { trackEvent, startBeregning } from '~lib/tracking/trackingEvents';
 import { lastDayOfMonth } from 'date-fns';
+import { useFormik } from 'formik';
+import AlertStripe from 'nav-frontend-alertstriper';
+import { Hovedknapp } from 'nav-frontend-knapper';
+import { RadioPanelGruppe, Label, Feiloppsummering } from 'nav-frontend-skjema';
+import { Innholdstittel, Feilmelding } from 'nav-frontend-typografi';
+import React from 'react';
+import DatePicker from 'react-datepicker';
+
+import { Beregning } from '~api/behandlingApi';
+import { Sak } from '~api/sakApi';
+import * as sakSlice from '~features/saksoversikt/sak.slice';
+import { useI18n } from '~lib/hooks';
+import { trackEvent, startBeregning } from '~lib/tracking/trackingEvents';
+import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
+import messages from './beregning-nb';
+import styles from './beregning.module.less';
+import VisBeregning from './VisBeregning';
 
 export enum Sats {
     Høy = 'HØY',

--- a/src/pages/saksoversikt/beregning/VisBeregning.tsx
+++ b/src/pages/saksoversikt/beregning/VisBeregning.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
-import { Beregning } from '~api/behandlingApi';
 import { Innholdstittel } from 'nav-frontend-typografi';
-import styles from './beregning.module.less';
-import { useI18n } from '~lib/hooks';
+import React from 'react';
+
+import { Beregning } from '~api/behandlingApi';
 import { formatDateTime } from '~lib/dateUtils';
+import { useI18n } from '~lib/hooks';
+
 import messages from './beregning-nb';
+import styles from './beregning.module.less';
 
 interface Props {
     beregning: Beregning;

--- a/src/pages/saksoversikt/sakintro/Sakintro.tsx
+++ b/src/pages/saksoversikt/sakintro/Sakintro.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
-import * as sakApi from 'api/sakApi';
-import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
-import Panel from 'nav-frontend-paneler';
-import { useHistory } from 'react-router-dom';
-import { Innholdstittel, Undertittel, Element } from 'nav-frontend-typografi';
-import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-
-import * as behandlingSlice from '~features/saksoversikt/sak.slice';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import styles from './sakintro.module.less';
 import * as RemoteData from '@devexperts/remote-data-ts';
 import AlertStripe from 'nav-frontend-alertstriper';
+import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
+import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
+import Panel from 'nav-frontend-paneler';
+import { Innholdstittel, Undertittel, Element } from 'nav-frontend-typografi';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+
+import * as sakApi from 'api/sakApi';
+import * as behandlingSlice from '~features/saksoversikt/sak.slice';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
+import styles from './sakintro.module.less';
 
 // TODO: Alle tekster her er placeholdere. Lag oversettelsesfil når vi er nærmere noe brukende.
 

--- a/src/pages/saksoversikt/søkefelt/Søkefelt.tsx
+++ b/src/pages/saksoversikt/søkefelt/Søkefelt.tsx
@@ -1,10 +1,10 @@
+import { Input } from 'nav-frontend-skjema';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Input } from 'nav-frontend-skjema';
 
-import { useAppDispatch } from '~redux/Store';
 import * as personSlice from '~features/person/person.slice';
 import * as sakSlice from '~features/saksoversikt/sak.slice';
+import { useAppDispatch } from '~redux/Store';
 
 const Søkefelt = () => {
     const dispatch = useAppDispatch();

--- a/src/pages/saksoversikt/vilkår/Vilkår.tsx
+++ b/src/pages/saksoversikt/vilkår/Vilkår.tsx
@@ -1,18 +1,20 @@
-import React, { useState } from 'react';
-import { Undertittel } from 'nav-frontend-typografi';
 import * as RemoteData from '@devexperts/remote-data-ts';
+import Alertstripe from 'nav-frontend-alertstriper';
+import { Hovedknapp } from 'nav-frontend-knapper';
+import { Undertittel } from 'nav-frontend-typografi';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import Vilkårsvurdering from '../vilkårsvurdering/Vilkårsvurdering';
-import styles from './vilkår.module.less';
 import { Behandling, Vilkårtype, VilkårVurderingStatus } from '~api/behandlingApi';
+import * as sakSlice from '~features/saksoversikt/sak.slice';
+import * as routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
-import * as sakSlice from '~features/saksoversikt/sak.slice';
-import { Hovedknapp } from 'nav-frontend-knapper';
-import Alertstripe from 'nav-frontend-alertstriper';
-import * as routes from '~lib/routes';
+
 import { SaksbehandlingMenyvalg } from '../types';
+import Vilkårsvurdering from '../vilkårsvurdering/Vilkårsvurdering';
+
+import styles from './vilkår.module.less';
 
 const boolTilJaNei = (val: Nullable<boolean>) => {
     if (val === null) {

--- a/src/pages/saksoversikt/vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/pages/saksoversikt/vilkårsvurdering/Vilkårsvurdering.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
 import { useFormik } from 'formik';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import { Undertittel, EtikettLiten } from 'nav-frontend-typografi';
-import { Hovedknapp } from 'nav-frontend-knapper';
+import Ikon from 'nav-frontend-ikoner-assets';
 import { guid } from 'nav-frontend-js-utils';
+import { Hovedknapp } from 'nav-frontend-knapper';
 import { Textarea } from 'nav-frontend-skjema';
+import { Undertittel, EtikettLiten } from 'nav-frontend-typografi';
+import React from 'react';
 
+import { VilkårVurderingStatus, Vilkårsvurdering } from '~api/behandlingApi';
 import { JaNeiSpørsmål } from '~components/FormElements';
 import { Nullable } from '~lib/types';
 
-import styles from './vilkårsvurdering.module.less';
-import { VilkårVurderingStatus, Vilkårsvurdering } from '~api/behandlingApi';
-import Ikon from 'nav-frontend-ikoner-assets';
 import yup from '../../../lib/validering';
+
+import styles from './vilkårsvurdering.module.less';
 
 interface FormData {
     vurdering: Nullable<boolean>;

--- a/src/pages/søknad/bunnknapper/Bunnknapper.tsx
+++ b/src/pages/søknad/bunnknapper/Bunnknapper.tsx
@@ -1,8 +1,10 @@
-import * as React from 'react';
 import { Knapp, Hovedknapp } from 'nav-frontend-knapper';
-import TextProvider, { Languages } from '~components/TextProvider';
-import messages from './bunnknapper-nb';
+import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
+
+import TextProvider, { Languages } from '~components/TextProvider';
+
+import messages from './bunnknapper-nb';
 import styles from './bunnknapper.module.less';
 
 const Bunnknapper = (props: {

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -1,24 +1,26 @@
+import * as RemoteData from '@devexperts/remote-data-ts';
+import Stegindikator from 'nav-frontend-stegindikator';
+import { Innholdstittel, Undertittel } from 'nav-frontend-typografi';
 import * as React from 'react';
 import { useParams, useHistory } from 'react-router-dom';
-import Stegindikator from 'nav-frontend-stegindikator';
-import { useAppSelector } from '~redux/Store';
-import styles from './index.module.less';
-import Inngang from './steg/inngang/Inngang';
-import { Søknadsteg } from './types';
-import Uførevedtak from './steg/uførevedtak/Uførevedtak';
-import FlyktningstatusOppholdstillatelse from './steg/flyktningstatus-oppholdstillatelse/Flyktningstatus-oppholdstillatelse';
-import BoOgOppholdINorge from './steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge';
-import Formue from './steg/formue/DinFormue';
-import Inntekt from './steg/inntekt/Inntekt';
-import Utenlandsopphold from './steg/utenlandsopphold/Utenlandsopphold';
-import ForVeileder from './steg/for-veileder/ForVeileder';
-import Oppsummering from './steg/oppsummering/Oppsummering';
-import { Innholdstittel, Undertittel } from 'nav-frontend-typografi';
+
+import { Personkort } from '~components/Personkort';
 import { useI18n } from '~lib/hooks';
 import * as routes from '~lib/routes';
+import { useAppSelector } from '~redux/Store';
+
+import styles from './index.module.less';
+import BoOgOppholdINorge from './steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge';
+import FlyktningstatusOppholdstillatelse from './steg/flyktningstatus-oppholdstillatelse/Flyktningstatus-oppholdstillatelse';
+import ForVeileder from './steg/for-veileder/ForVeileder';
+import Formue from './steg/formue/DinFormue';
+import Inngang from './steg/inngang/Inngang';
+import Inntekt from './steg/inntekt/Inntekt';
 import Kvittering from './steg/kvittering/Kvittering';
-import * as RemoteData from '@devexperts/remote-data-ts';
-import { Personkort } from '~components/Personkort';
+import Oppsummering from './steg/oppsummering/Oppsummering';
+import Uførevedtak from './steg/uførevedtak/Uførevedtak';
+import Utenlandsopphold from './steg/utenlandsopphold/Utenlandsopphold';
+import { Søknadsteg } from './types';
 
 const messages = {
     'steg.uforevedtak': 'Uførevedtak',

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
@@ -1,19 +1,22 @@
-import * as React from 'react';
 import { useFormik } from 'formik';
-import { AnbefalerIkkeSøke, JaNeiSpørsmål } from '~/components/FormElements';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import søknadSlice from '~/features/søknad/søknad.slice';
-import Bunnknapper from '../../bunnknapper/Bunnknapper';
 import { Feiloppsummering, RadioPanelGruppe } from 'nav-frontend-skjema';
-import { DelerBoligMed } from '~features/søknad/types';
-import sharedStyles from '../../steg-shared.module.less';
+import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
-import messages from './bo-og-opphold-i-norge-nb';
-import { Nullable } from '~lib/types';
 import { useHistory } from 'react-router-dom';
+
+import { AnbefalerIkkeSøke, JaNeiSpørsmål } from '~/components/FormElements';
+import søknadSlice from '~/features/søknad/søknad.slice';
+import { DelerBoligMed } from '~features/søknad/types';
+import { Nullable } from '~lib/types';
 import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
-import sharedI18n from '../steg-shared-i18n';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
 import { useI18n } from '../../../../lib/hooks';
+import Bunnknapper from '../../bunnknapper/Bunnknapper';
+import sharedStyles from '../../steg-shared.module.less';
+import sharedI18n from '../steg-shared-i18n';
+
+import messages from './bo-og-opphold-i-norge-nb';
 
 interface FormData {
     borOgOppholderSegINorge: Nullable<boolean>;

--- a/src/pages/søknad/steg/flyktningstatus-oppholdstillatelse/Flyktningstatus-oppholdstillatelse.tsx
+++ b/src/pages/søknad/steg/flyktningstatus-oppholdstillatelse/Flyktningstatus-oppholdstillatelse.tsx
@@ -1,21 +1,24 @@
+import { useFormik } from 'formik';
+import AlertStripe from 'nav-frontend-alertstriper';
+import { Feiloppsummering, RadioPanelGruppe } from 'nav-frontend-skjema';
+import Input from 'nav-frontend-skjema/lib/input';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
-import { useFormik } from 'formik';
-import { Feiloppsummering, RadioPanelGruppe } from 'nav-frontend-skjema';
+import { useHistory } from 'react-router-dom';
+
 import { AnbefalerIkkeSøke, JaNeiSpørsmål } from '~/components/FormElements';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
 import søknadSlice from '~/features/søknad/søknad.slice';
-import messages from './flyktningstatus-oppholdstillatelse-nb';
-import Bunnknapper from '../../bunnknapper/Bunnknapper';
-import sharedStyles from '../../steg-shared.module.less';
+import { TypeOppholdstillatelse } from '~features/søknad/types';
 import { Nullable } from '~lib/types';
 import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
-import { useHistory } from 'react-router-dom';
-import sharedI18n from '../steg-shared-i18n';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
 import { useI18n } from '../../../../lib/hooks';
-import { TypeOppholdstillatelse } from '~features/søknad/types';
-import AlertStripe from 'nav-frontend-alertstriper';
-import Input from 'nav-frontend-skjema/lib/input';
+import Bunnknapper from '../../bunnknapper/Bunnknapper';
+import sharedStyles from '../../steg-shared.module.less';
+import sharedI18n from '../steg-shared-i18n';
+
+import messages from './flyktningstatus-oppholdstillatelse-nb';
 
 interface FormData {
     erFlyktning: Nullable<boolean>;

--- a/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
+++ b/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
@@ -1,23 +1,27 @@
-import * as React from 'react';
-import sharedStyles from '../../steg-shared.module.less';
-import { JaNeiSpørsmål } from '~/components/FormElements';
-import { FormattedMessage } from 'react-intl';
-import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
-import { Nullable } from '~lib/types';
-import { Feiloppsummering, RadioPanelGruppe } from 'nav-frontend-skjema';
 import { useFormik } from 'formik';
-import Bunnknapper from '../../bunnknapper/Bunnknapper';
-import messages from './forVeileder-nb';
-import TextProvider, { Languages } from '~components/TextProvider';
-import { useHistory } from 'react-router-dom';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import søknadSlice from '~/features/søknad/søknad.slice';
-import { Vergemål } from '~features/søknad/types';
 import AlertStripe, { AlertStripeInfo } from 'nav-frontend-alertstriper';
-import sharedI18n from '../steg-shared-i18n';
-import { useI18n } from '../../../../lib/hooks';
 import Panel from 'nav-frontend-paneler';
+import { Feiloppsummering, RadioPanelGruppe } from 'nav-frontend-skjema';
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+
+import { JaNeiSpørsmål } from '~/components/FormElements';
+import søknadSlice from '~/features/søknad/søknad.slice';
+import TextProvider, { Languages } from '~components/TextProvider';
+import { Vergemål } from '~features/søknad/types';
+import { Nullable } from '~lib/types';
+import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
+import { useI18n } from '../../../../lib/hooks';
+import Bunnknapper from '../../bunnknapper/Bunnknapper';
+import sharedStyles from '../../steg-shared.module.less';
+import sharedI18n from '../steg-shared-i18n';
+
+import messages from './forVeileder-nb';
 import styles from './forVeileder.module.less';
+
 interface FormData {
     harSøkerMøttPersonlig: Nullable<boolean>;
     harFullmektigEllerVerge: Nullable<Vergemål>;

--- a/src/pages/søknad/steg/formue/DinFormue.tsx
+++ b/src/pages/søknad/steg/formue/DinFormue.tsx
@@ -1,20 +1,22 @@
-import * as React from 'react';
-import { Input, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
-import { FormattedMessage, RawIntlProvider } from 'react-intl';
 import { useFormik, FormikErrors } from 'formik';
+import { Knapp } from 'nav-frontend-knapper';
+import { Input, SkjemaelementFeilmelding, Feiloppsummering } from 'nav-frontend-skjema';
+import * as React from 'react';
+import { FormattedMessage, RawIntlProvider } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+
 import { JaNeiSpørsmål } from '~/components/FormElements';
-import { useAppSelector, useAppDispatch } from '~redux/Store';
 import søknadSlice from '~/features/søknad/søknad.slice';
+import { useI18n } from '~lib/hooks';
+import { Nullable } from '~lib/types';
+import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
+import { useAppSelector, useAppDispatch } from '~redux/Store';
+
 import Bunnknapper from '../../bunnknapper/Bunnknapper';
 import sharedStyles from '../../steg-shared.module.less';
-import messages from './dinformue-nb';
-import { Nullable } from '~lib/types';
-import { useHistory } from 'react-router-dom';
-import { Feiloppsummering } from 'nav-frontend-skjema';
-import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
-import { useI18n } from '~lib/hooks';
 import sharedI18n from '../steg-shared-i18n';
-import { Knapp } from 'nav-frontend-knapper';
+
+import messages from './dinformue-nb';
 
 interface FormData {
     eierBolig: Nullable<boolean>;

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -1,20 +1,23 @@
-import * as React from 'react';
+import * as RemoteData from '@devexperts/remote-data-ts';
 import { useFormik } from 'formik';
-import { Input, Feiloppsummering } from 'nav-frontend-skjema';
 import { Hovedknapp } from 'nav-frontend-knapper';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
+import { Input, Feiloppsummering } from 'nav-frontend-skjema';
+import NavFrontendSpinner from 'nav-frontend-spinner';
+import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
-import nb from './inngang-nb';
-import styles from './inngang.module.less';
 import { useHistory } from 'react-router-dom';
+
+import { Personkort } from '~components/Personkort';
+import * as personSlice from '~features/person/person.slice';
 import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
-import sharedI18n from '../steg-shared-i18n';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
 import { useI18n } from '../../../../lib/hooks';
 import sharedStyles from '../../steg-shared.module.less';
-import * as personSlice from '~features/person/person.slice';
-import * as RemoteData from '@devexperts/remote-data-ts';
-import NavFrontendSpinner from 'nav-frontend-spinner';
-import { Personkort } from '~components/Personkort';
+import sharedI18n from '../steg-shared-i18n';
+
+import nb from './inngang-nb';
+import styles from './inngang.module.less';
 
 interface FormData {
     fnr: string;

--- a/src/pages/søknad/steg/inntekt/Inntekt.tsx
+++ b/src/pages/søknad/steg/inntekt/Inntekt.tsx
@@ -1,21 +1,24 @@
-import * as React from 'react';
-import { Feiloppsummering, Input, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
-import { FormattedMessage, RawIntlProvider } from 'react-intl';
 import { useFormik, FormikErrors } from 'formik';
-import { useHistory } from 'react-router-dom';
-import { JaNeiSpørsmål } from '~/components/FormElements';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import søknadSlice from '~/features/søknad/søknad.slice';
-import Bunnknapper from '../../bunnknapper/Bunnknapper';
-import sharedStyles from '../../steg-shared.module.less';
-import styles from './inntekt.module.less';
-import { Nullable } from '../../../../lib/types';
-import messages from './inntekt-nb';
-import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
-import sharedI18n from '../steg-shared-i18n';
-import { useI18n } from '../../../../lib/hooks';
 import { Knapp } from 'nav-frontend-knapper';
 import Lenke from 'nav-frontend-lenker';
+import { Feiloppsummering, Input, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
+import * as React from 'react';
+import { FormattedMessage, RawIntlProvider } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+
+import { JaNeiSpørsmål } from '~/components/FormElements';
+import søknadSlice from '~/features/søknad/søknad.slice';
+import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
+import { useI18n } from '../../../../lib/hooks';
+import { Nullable } from '../../../../lib/types';
+import Bunnknapper from '../../bunnknapper/Bunnknapper';
+import sharedStyles from '../../steg-shared.module.less';
+import sharedI18n from '../steg-shared-i18n';
+
+import messages from './inntekt-nb';
+import styles from './inntekt.module.less';
 
 interface FormData {
     harForventetInntekt: Nullable<boolean>;

--- a/src/pages/søknad/steg/kvittering/Kvittering.tsx
+++ b/src/pages/søknad/steg/kvittering/Kvittering.tsx
@@ -1,15 +1,17 @@
-import * as React from 'react';
-import { useI18n } from '~lib/hooks';
-import { useHistory } from 'react-router-dom';
+import * as RemoteData from '@devexperts/remote-data-ts';
+import { pipe } from 'fp-ts/lib/function';
+import AlertStripe from 'nav-frontend-alertstriper';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
-import styles from './kvittering.module.less';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
+import NavFrontendSpinner from 'nav-frontend-spinner';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+
 import * as personSlice from '~features/person/person.slice';
 import * as søknadslice from '~features/søknad/søknad.slice';
-import { pipe } from 'fp-ts/lib/function';
-import * as RemoteData from '@devexperts/remote-data-ts';
-import AlertStripe from 'nav-frontend-alertstriper';
-import NavFrontendSpinner from 'nav-frontend-spinner';
+import { useI18n } from '~lib/hooks';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
+import styles from './kvittering.module.less';
 
 const messages = {
     'kvittering.søknadSendt': 'Søknaden er sendt!',

--- a/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
@@ -1,12 +1,14 @@
-import * as React from 'react';
-import Bunnknapper from '../../bunnknapper/Bunnknapper';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import sharedStyles from '../../steg-shared.module.less';
-import { useHistory } from 'react-router-dom';
-import * as innsendingSlice from '~features/søknad/innsending.slice';
-import { FormattedMessage } from 'react-intl';
-
 import * as RemoteData from '@devexperts/remote-data-ts';
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+
+import * as innsendingSlice from '~features/søknad/innsending.slice';
+import { useAppDispatch, useAppSelector } from '~redux/Store';
+
+import Bunnknapper from '../../bunnknapper/Bunnknapper';
+import sharedStyles from '../../steg-shared.module.less';
+
 import Søknadoppsummering from './Søknadoppsummering/Søknadoppsummering';
 
 const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string }) => {

--- a/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
@@ -1,14 +1,17 @@
+import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
+import React from 'react';
+import { RawIntlProvider, FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+
+import { PencilIcon } from '~assets/Icons';
 import { SøknadState } from '~features/søknad/søknad.slice';
 import { useI18n } from '~lib/hooks';
-import { RawIntlProvider, FormattedMessage } from 'react-intl';
-import React from 'react';
-import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import styles from './oppsummering.module.less';
-import { Element, Normaltekst } from 'nav-frontend-typografi';
-import messages from './oppsummering-nb';
+
 import sharedStyles from '../../../steg-shared.module.less';
-import { useHistory } from 'react-router-dom';
-import { PencilIcon } from '~assets/Icons';
+
+import messages from './oppsummering-nb';
+import styles from './oppsummering.module.less';
 
 const OppsummeringsFelt = (props: { label: React.ReactNode; verdi: string | React.ReactNode }) => (
     <div className={styles.oppsummeringsfelt}>

--- a/src/pages/søknad/steg/uførevedtak/Uførevedtak.tsx
+++ b/src/pages/søknad/steg/uførevedtak/Uførevedtak.tsx
@@ -1,19 +1,22 @@
+import { useFormik } from 'formik';
+import AlertStripe from 'nav-frontend-alertstriper';
+import { Feiloppsummering } from 'nav-frontend-skjema';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
-import { useFormik } from 'formik';
-import Bunnknapper from '../../bunnknapper/Bunnknapper';
-import { JaNeiSpørsmål } from '~/components/FormElements';
-import { useAppSelector, useAppDispatch } from '~redux/Store';
-import søknadSlice from '~/features/søknad/søknad.slice';
-import messages from './uførevedtak-nb';
-import sharedStyles from '../../steg-shared.module.less';
-import { Nullable } from '~lib/types';
-import { Feiloppsummering } from 'nav-frontend-skjema';
-import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
 import { useHistory } from 'react-router-dom';
-import sharedI18n from '../steg-shared-i18n';
+
+import { JaNeiSpørsmål } from '~/components/FormElements';
+import søknadSlice from '~/features/søknad/søknad.slice';
+import { Nullable } from '~lib/types';
+import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
+import { useAppSelector, useAppDispatch } from '~redux/Store';
+
 import { useI18n } from '../../../../lib/hooks';
-import AlertStripe from 'nav-frontend-alertstriper';
+import Bunnknapper from '../../bunnknapper/Bunnknapper';
+import sharedStyles from '../../steg-shared.module.less';
+import sharedI18n from '../steg-shared-i18n';
+
+import messages from './uførevedtak-nb';
 
 interface FormData {
     harUførevedtak: Nullable<boolean>;

--- a/src/pages/søknad/steg/utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/pages/søknad/steg/utenlandsopphold/Utenlandsopphold.tsx
@@ -1,24 +1,27 @@
+import { useFormik, FormikErrors } from 'formik';
+import { Datovelger } from 'nav-datovelger';
+import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
+import { guid } from 'nav-frontend-js-utils';
+import { Knapp } from 'nav-frontend-knapper';
+import { Feiloppsummering, Label, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
-import { guid } from 'nav-frontend-js-utils';
-import { useFormik, FormikErrors } from 'formik';
 import { useHistory } from 'react-router-dom';
+
 import { JaNeiSpørsmål } from '~/components/FormElements';
-import { useAppSelector, useAppDispatch } from '~redux/Store';
 import søknadSlice from '~/features/søknad/søknad.slice';
+import { kalkulerTotaltAntallDagerIUtlandet } from '~lib/dateUtils';
+import { useI18n } from '~lib/hooks';
+import { Nullable } from '~lib/types';
+import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
+import { useAppSelector, useAppDispatch } from '~redux/Store';
+
 import Bunnknapper from '../../bunnknapper/Bunnknapper';
 import sharedStyles from '../../steg-shared.module.less';
-import messages from './utenlandsopphold-nb';
-import { Datovelger } from 'nav-datovelger';
-import { Knapp } from 'nav-frontend-knapper';
-import { Nullable } from '~lib/types';
-import { kalkulerTotaltAntallDagerIUtlandet } from '~lib/dateUtils';
-import yup, { formikErrorsTilFeiloppsummering, formikErrorsHarFeil } from '~lib/validering';
-import { Feiloppsummering, Label, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
-import { useI18n } from '~lib/hooks';
 import sharedI18n from '../steg-shared-i18n';
+
+import messages from './utenlandsopphold-nb';
 import styles from './utenlandsopphold.module.less';
-import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 
 interface FormData {
     harReistTilUtlandetSiste90dager: Nullable<boolean>;

--- a/src/redux/Store.ts
+++ b/src/redux/Store.ts
@@ -1,10 +1,11 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { useDispatch, useSelector } from 'react-redux';
 
-import person from '../features/person/person.slice';
 import søknadSlice from '~/features/søknad/søknad.slice';
+import person from '~features/person/person.slice';
 import sakSlice from '~features/saksoversikt/sak.slice';
 import innsending from '~features/søknad/innsending.slice';
+
 const store = configureStore({
     reducer: {
         søker: person.reducer,


### PR DESCRIPTION
Jeg syns det er veldig rotete når imports havner veldig hulter-til-bulter. Denne lint-regelen lager en struktur for hvilken rekkefølge de skal komme i osv. Se diff for hvordan det blir.
Regelen er fiksbar, som vil si at hvis man setter på 
```
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": true
  },
```
i VSCode så vil det automatisk fikses når man lagrer filene.
Det vil uansett også valideres og fikses av `lint-staged` når man committer.