### PR TITLE
Framdriftsindikator uavklart fix

### DIFF
--- a/src/features/saksoversikt/utils.tsx
+++ b/src/features/saksoversikt/utils.tsx
@@ -56,6 +56,7 @@ type Vilkårsinformasjon = {
     status: VilkårVurderingStatus;
     vilkårtype: Vilkårtype;
     begrunnelse: Nullable<string>;
+    erStartet: boolean;
 };
 
 export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinformasjon): Vilkårsinformasjon[] => {
@@ -79,6 +80,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.Uførhet,
             begrunnelse: null,
+            erStartet: uførhet !== null,
         },
         {
             status:
@@ -89,6 +91,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.Flyktning,
             begrunnelse: behandlingsinformasjon.flyktning?.begrunnelse ?? null,
+            erStartet: flyktning !== null,
         },
         {
             status:
@@ -99,6 +102,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.LovligOpphold,
             begrunnelse: behandlingsinformasjon.lovligOpphold?.begrunnelse ?? null,
+            erStartet: lovligOpphold !== null,
         },
         {
             status:
@@ -109,6 +113,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.FastOppholdINorge,
             begrunnelse: behandlingsinformasjon.fastOppholdINorge?.begrunnelse ?? null,
+            erStartet: fastOppholdINorge !== null,
         },
         {
             status:
@@ -119,6 +124,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.OppholdIUtlandet,
             begrunnelse: behandlingsinformasjon.oppholdIUtlandet?.begrunnelse ?? null,
+            erStartet: oppholdIUtlandet !== null,
         },
         {
             status:
@@ -129,6 +135,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.Formue,
             begrunnelse: behandlingsinformasjon.formue?.begrunnelse ?? null,
+            erStartet: formue !== null,
         },
         {
             status:
@@ -139,6 +146,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
                     : VilkårVurderingStatus.IkkeOk,
             vilkårtype: Vilkårtype.PersonligOppmøte,
             begrunnelse: behandlingsinformasjon.personligOppmøte?.begrunnelse ?? null,
+            erStartet: personligOppmøte !== null,
         },
     ];
 };

--- a/src/features/saksoversikt/utils.tsx
+++ b/src/features/saksoversikt/utils.tsx
@@ -72,7 +72,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
     return [
         {
             status:
-                uførhet === null
+                uførhet === null || uførhet.status === UførhetStatus.HarUføresakTilBehandling
                     ? VilkårVurderingStatus.IkkeVurdert
                     : uførhet.status === UførhetStatus.VilkårOppfylt
                     ? VilkårVurderingStatus.Ok
@@ -82,7 +82,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
         },
         {
             status:
-                flyktning === null
+                flyktning === null || flyktning.status === FlyktningStatus.Uavklart
                     ? VilkårVurderingStatus.IkkeVurdert
                     : flyktning.status === FlyktningStatus.VilkårOppfylt
                     ? VilkårVurderingStatus.Ok
@@ -102,7 +102,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
         },
         {
             status:
-                fastOppholdINorge === null
+                fastOppholdINorge === null || fastOppholdINorge.status === FastOppholdINorgeStatus.Uavklart
                     ? VilkårVurderingStatus.IkkeVurdert
                     : fastOppholdINorge.status === FastOppholdINorgeStatus.VilkårOppfylt
                     ? VilkårVurderingStatus.Ok
@@ -122,7 +122,7 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
         },
         {
             status:
-                formue === null
+                formue === null || formue.status === FormueStatus.MåInnhenteMerInformasjon
                     ? VilkårVurderingStatus.IkkeVurdert
                     : formue.status === FormueStatus.VilkårOppfylt
                     ? VilkårVurderingStatus.Ok

--- a/src/pages/saksbehandling/steg/Framdriftsindikator.tsx
+++ b/src/pages/saksbehandling/steg/Framdriftsindikator.tsx
@@ -26,7 +26,7 @@ const Framdriftsindikator = (props: { behandling: Behandling; vilkår: Vilkårty
     return (
         <ol className={styles.container}>
             {vilkårrekkefølge
-                .filter((v) => v.status !== VilkårVurderingStatus.IkkeVurdert || props.vilkår === v.vilkårtype)
+                .filter((v) => v.erStartet || props.vilkår === v.vilkårtype)
                 .map((v) => (
                     <Item vilkar={v.vilkårtype} status={v.status} key={v.vilkårtype} />
                 ))}


### PR DESCRIPTION
Bug: Vi visade ikke uavklart status även om status var sett till 'uavklart' på objektet.