### PR TITLE
Change routing in vedtak depending on status

### DIFF
--- a/src/features/behandling/behandlingUtils.ts
+++ b/src/features/behandling/behandlingUtils.ts
@@ -32,6 +32,12 @@ export function erAvslått(behandling: Behandling): boolean {
     ].some((status) => behandling.status === status);
 }
 
+export function harBeregning(behandling: Behandling): boolean {
+    return [Behandlingsstatus.BEREGNET_AVSLAG, Behandlingsstatus.BEREGNET_INVILGET, Behandlingsstatus.SIMULERT].some(
+        (status) => behandling.status === status
+    );
+}
+
 export const hentSisteVurderteVilkår = (behandlingsinformasjon: Behandlingsinformasjon) => {
     return pipe(
         behandlingsinformasjon,

--- a/src/features/saksoversikt/utils.tsx
+++ b/src/features/saksoversikt/utils.tsx
@@ -1,6 +1,7 @@
 import Ikon from 'nav-frontend-ikoner-assets';
 import React from 'react';
 
+import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import {
     Behandlingsinformasjon,
@@ -13,6 +14,13 @@ import {
     OppholdIUtlandetStatus,
 } from '~types/Behandlingsinformasjon';
 import { Vilkårtype, VilkårVurderingStatus } from '~types/Vilkårsvurdering';
+
+export const createVilkårUrl = (props: { sakId: string; behandlingId: string; vilkar: Vilkårtype }) =>
+    Routes.saksbehandlingVilkårsvurdering.createURL({
+        sakId: props.sakId,
+        behandlingId: props.behandlingId,
+        vilkar: props.vilkar,
+    });
 
 export const vilkårTittelFormatted = (type: Vilkårtype) => {
     switch (type) {

--- a/src/pages/saksbehandling/steg/Vilkår.tsx
+++ b/src/pages/saksbehandling/steg/Vilkår.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { createVilkårUrl } from '~features/saksoversikt/utils';
 import * as Routes from '~lib/routes';
 import { Behandlingsstatus } from '~types/Behandling';
 import { Sak } from '~types/Sak';
@@ -28,11 +29,11 @@ const Vilkår = (props: { sak: Sak }) => {
         return <div>404</div>;
     }
 
-    const createVilkårUrl = (v: Vilkårtype) =>
-        Routes.saksbehandlingVilkårsvurdering.createURL({
+    const vilkårUrl = (vilkårType: Vilkårtype) =>
+        createVilkårUrl({
             behandlingId: urlParams.behandlingId,
             sakId: urlParams.sakId,
-            vilkar: v,
+            vilkar: vilkårType,
         });
 
     return (
@@ -42,83 +43,83 @@ const Vilkår = (props: { sak: Sak }) => {
             </div>
             <div className={styles.content}>
                 <Switch>
-                    <Route path={createVilkårUrl(Vilkårtype.Uførhet)}>
+                    <Route path={vilkårUrl(Vilkårtype.Uførhet)}>
                         <Uførhet
                             behandling={behandling}
                             forrigeUrl={Routes.saksoversiktValgtSak.createURL({
                                 sakId: urlParams.sakId,
                             })}
-                            nesteUrl={createVilkårUrl(Vilkårtype.Flyktning)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Flyktning)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.Flyktning)}>
+                    <Route path={vilkårUrl(Vilkårtype.Flyktning)}>
                         <Flyktning
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.Uførhet)}
-                            nesteUrl={createVilkårUrl(Vilkårtype.LovligOpphold)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Uførhet)}
+                            nesteUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.LovligOpphold)}>
+                    <Route path={vilkårUrl(Vilkårtype.LovligOpphold)}>
                         <LovligOppholdINorge
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.Flyktning)}
-                            nesteUrl={createVilkårUrl(Vilkårtype.FastOppholdINorge)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Flyktning)}
+                            nesteUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.FastOppholdINorge)}>
+                    <Route path={vilkårUrl(Vilkårtype.FastOppholdINorge)}>
                         <FastOppholdINorge
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.LovligOpphold)}
-                            nesteUrl={createVilkårUrl(Vilkårtype.OppholdIUtlandet)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
+                            nesteUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.OppholdIUtlandet)}>
+                    <Route path={vilkårUrl(Vilkårtype.OppholdIUtlandet)}>
                         <OppholdIUtlandet
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.FastOppholdINorge)}
-                            nesteUrl={createVilkårUrl(Vilkårtype.Formue)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Formue)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.Formue)}>
+                    <Route path={vilkårUrl(Vilkårtype.Formue)}>
                         <Formue
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.OppholdIUtlandet)}
-                            nesteUrl={createVilkårUrl(Vilkårtype.PersonligOppmøte)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
+                            nesteUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.PersonligOppmøte)}>
+                    <Route path={vilkårUrl(Vilkårtype.PersonligOppmøte)}>
                         <PersonligOppmøte
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.Formue)}
-                            nesteUrl={createVilkårUrl(Vilkårtype.Sats)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Formue)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Sats)}
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.Sats)}>
+                    <Route path={vilkårUrl(Vilkårtype.Sats)}>
                         <Sats
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.PersonligOppmøte)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
                             nesteUrl={
                                 behandling.status == Behandlingsstatus.VILKÅRSVURDERT_AVSLAG
                                     ? Routes.saksbehandlingVedtak.createURL({
                                           sakId: urlParams.sakId,
                                           behandlingId: behandling.id,
                                       })
-                                    : createVilkårUrl(Vilkårtype.Beregning)
+                                    : vilkårUrl(Vilkårtype.Beregning)
                             }
                             sakId={urlParams.sakId}
                         />
                     </Route>
-                    <Route path={createVilkårUrl(Vilkårtype.Beregning)}>
+                    <Route path={vilkårUrl(Vilkårtype.Beregning)}>
                         <Beregning
                             behandling={behandling}
-                            forrigeUrl={createVilkårUrl(Vilkårtype.Sats)}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Sats)}
                             nesteUrl={Routes.saksbehandlingVedtak.createURL({
                                 sakId: urlParams.sakId,
                                 behandlingId: behandling.id,

--- a/src/pages/saksbehandling/steg/formue/Formue.tsx
+++ b/src/pages/saksbehandling/steg/formue/Formue.tsx
@@ -99,7 +99,6 @@ function kalkulerFormueFraSøknad(f: SøknadInnhold['formue']) {
         f.verdipapirBeløp?.toString() ?? '0',
         f.skylderNoenMegPengerBeløp?.toString() ?? '0',
         f.kontanterBeløp?.toString() ?? '0',
-        f.depositumsBeløp?.toString() ?? '0',
     ];
 
     return (

--- a/src/pages/saksbehandling/vedtak/Vedtak.tsx
+++ b/src/pages/saksbehandling/vedtak/Vedtak.tsx
@@ -3,13 +3,18 @@ import AlertStripe, { AlertStripeFeil, AlertStripeSuksess } from 'nav-frontend-a
 import { Hovedknapp } from 'nav-frontend-knapper';
 import Lenke from 'nav-frontend-lenker';
 import Innholdstittel from 'nav-frontend-typografi/lib/innholdstittel';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { fetchBrev } from '~api/brevApi';
 import { erAvslått, erTilAttestering } from '~features/behandling/behandlingUtils';
 import * as sakSlice from '~features/saksoversikt/sak.slice';
-import { mapToVilkårsinformasjon, statusIcon, vilkårTittelFormatted } from '~features/saksoversikt/utils';
+import {
+    createVilkårUrl,
+    mapToVilkårsinformasjon,
+    statusIcon,
+    vilkårTittelFormatted,
+} from '~features/saksoversikt/utils';
 import * as routes from '~lib/routes.ts';
 import { Nullable } from '~lib/types';
 import { Simulering } from '~pages/saksbehandling/simulering/simulering';
@@ -23,6 +28,96 @@ import styles from './vedtak.module.less';
 
 type Props = {
     sak: Sak;
+};
+
+const Vedtak = (props: Props) => {
+    const { sak } = props;
+    const dispatch = useAppDispatch();
+    const sendtTilAttesteringStatus = useAppSelector((s) => s.sak.sendtTilAttesteringStatus);
+    const { sakId, behandlingId } = routes.useRouteParams<typeof routes.saksoversiktValgtBehandling>();
+    const behandling = sak.behandlinger.find((x) => x.id === behandlingId);
+
+    if (!behandling) {
+        return <AlertStripe type="feil">Fant ikke behandlingsid</AlertStripe>;
+    }
+
+    if (erTilAttestering(behandling)) {
+        return <div>Vedtak er sendt til Attestering</div>;
+    }
+
+    const lastNedBrev = useCallback(() => {
+        fetchBrev(sak.id, behandlingId).then((res) => {
+            if (res.status === 'ok') window.open(URL.createObjectURL(res.data));
+        });
+    }, [sak.id, behandlingId]);
+
+    const vilkårUrl = (vilkårType: Vilkårtype) =>
+        createVilkårUrl({
+            sakId: sakId,
+            behandlingId: behandlingId,
+            vilkar: vilkårType,
+        });
+
+    if (behandling.status === Behandlingsstatus.SIMULERT || erAvslått(behandling)) {
+        return (
+            <div>
+                <div className={styles.vedtakContainer}>
+                    <Innholdstittel>Vedtak</Innholdstittel>
+
+                    {behandling.status === Behandlingsstatus.SIMULERT && (
+                        <AlertStripeSuksess>{behandling.status}</AlertStripeSuksess>
+                    )}
+                    {erAvslått(behandling) && <AlertStripeFeil>{behandling.status}</AlertStripeFeil>}
+
+                    <VilkårsOppsummering behandling={behandling} />
+
+                    {behandling.status === Behandlingsstatus.SIMULERT ? (
+                        <VisSimuleringOgBeregning sak={sak} behandling={behandling} />
+                    ) : (
+                        <>Det er ikke gjort en beregning</>
+                    )}
+
+                    <div>
+                        <Innholdstittel>Vis brev kladd</Innholdstittel>
+                        <Lenke href={'#'} onClick={lastNedBrev}>
+                            Last ned brev
+                        </Lenke>
+                    </div>
+                </div>
+                <div className={styles.navigeringContainer}>
+                    <Link
+                        to={
+                            erAvslått(behandling) && behandling.status !== Behandlingsstatus.BEREGNET_AVSLAG
+                                ? vilkårUrl(Vilkårtype.PersonligOppmøte)
+                                : vilkårUrl(Vilkårtype.Beregning)
+                        }
+                        className="knapp"
+                    >
+                        Tilbake
+                    </Link>
+                    <Hovedknapp
+                        spinner={RemoteData.isPending(sendtTilAttesteringStatus)}
+                        onClick={() =>
+                            dispatch(sakSlice.sendTilAttestering({ sakId: sak.id, behandlingId: behandlingId }))
+                        }
+                        htmlType="button"
+                    >
+                        Send til attestering
+                    </Hovedknapp>
+                </div>
+                {RemoteData.isFailure(sendtTilAttesteringStatus) && (
+                    <AlertStripeFeil>
+                        <div>
+                            <p>Sendingen Failet</p>
+                            <p>Error code: {sendtTilAttesteringStatus.error.statusCode}</p>
+                        </div>
+                    </AlertStripeFeil>
+                )}
+            </div>
+        );
+    }
+
+    return <div>Behandlingen er ikke ferdig</div>;
 };
 
 const VilkårsvurderingInfoLinje = (props: {
@@ -63,9 +158,9 @@ const VilkårsOppsummering = (props: { behandling: Behandling }) => {
     );
 };
 
-const VisDersomSimulert = (props: { sak: Sak; behandling: Behandling }) => {
-    if (props.behandling.status === Behandlingsstatus.SIMULERT && props.behandling.beregning) {
-        return (
+const VisSimuleringOgBeregning = (props: { sak: Sak; behandling: Behandling }) => (
+    <div>
+        {props.behandling.beregning && (
             <>
                 <VisBeregning
                     beregning={props.behandling.beregning}
@@ -75,97 +170,8 @@ const VisDersomSimulert = (props: { sak: Sak; behandling: Behandling }) => {
                     <Simulering sak={props.sak} behandlingId={props.behandling.id} />
                 </div>
             </>
-        );
-    }
-    return <>Det er ikke gjort en beregning</>;
-};
-
-const Vedtak = (props: Props) => {
-    const sendtTilAttesteringStatus = useAppSelector((s) => s.sak.sendtTilAttesteringStatus);
-    const dispatch = useAppDispatch();
-
-    const { sak } = props;
-    const { behandlingId } = routes.useRouteParams<typeof routes.saksoversiktValgtBehandling>();
-
-    const behandling = sak.behandlinger.find((x) => x.id === behandlingId);
-
-    if (!behandling) {
-        return <AlertStripe type="feil">Fant ikke behandlingsid</AlertStripe>;
-    }
-
-    if (erTilAttestering(behandling)) {
-        return <div>Vedtak er sendt til Attestering</div>;
-    }
-
-    if (
-        behandling.status === Behandlingsstatus.SIMULERT ||
-        behandling.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG ||
-        behandling.status === Behandlingsstatus.BEREGNET_AVSLAG
-    ) {
-        return (
-            <div>
-                <div className={styles.vedtakContainer}>
-                    <Innholdstittel>Vedtak</Innholdstittel>
-                    <div>
-                        {behandling.status === Behandlingsstatus.SIMULERT && (
-                            <AlertStripeSuksess>{behandling.status}</AlertStripeSuksess>
-                        )}
-                        {erAvslått(behandling) && <AlertStripeFeil>{behandling.status}</AlertStripeFeil>}
-                    </div>
-                    <div>
-                        <VilkårsOppsummering behandling={behandling} />
-                    </div>
-                    <div>
-                        <VisDersomSimulert sak={sak} behandling={behandling} />
-                    </div>
-                    <div>
-                        <Innholdstittel>Vis brev kladd</Innholdstittel>
-                        <Lenke
-                            href={'#'}
-                            onClick={() =>
-                                fetchBrev(sak.id, behandlingId).then((res) => {
-                                    if (res.status === 'ok') window.open(URL.createObjectURL(res.data));
-                                })
-                            }
-                        >
-                            Last ned brev
-                        </Lenke>
-                    </div>
-                </div>
-                <div className={styles.navigeringContainer}>
-                    <Link
-                        to={routes.saksbehandlingVilkårsvurdering.createURL({
-                            sakId: sak.id,
-                            behandlingId: behandling.id,
-                            vilkar: Vilkårtype.Sats,
-                        })}
-                        className="knapp"
-                    >
-                        Tilbake
-                    </Link>
-                    <Hovedknapp
-                        spinner={RemoteData.isPending(sendtTilAttesteringStatus)}
-                        onClick={() =>
-                            dispatch(sakSlice.sendTilAttestering({ sakId: sak.id, behandlingId: behandlingId }))
-                        }
-                        htmlType="button"
-                    >
-                        Send til attestering
-                    </Hovedknapp>
-                </div>
-                {RemoteData.isFailure(sendtTilAttesteringStatus) && (
-                    <AlertStripeFeil>
-                        <div>
-                            <p>Sendingen Failet</p>
-                            <p>Error code: {sendtTilAttesteringStatus.error.statusCode}</p>
-                        </div>
-                    </AlertStripeFeil>
-                )}
-            </div>
-        );
-    }
-
-    return <div>Behandlingen er ikke ferdig</div>;
-};
+        )}
+    </div>
+);
 
 export default Vedtak;


### PR DESCRIPTION
Nå skal den gå tillbaks till riktig url när status på behandlingen er 'avslag' av något slag.

Refaktorert litt i Vedtakssiden i tillägg.