### PR TITLE
Remove grunndata from simulering view

### DIFF
--- a/src/pages/saksbehandling/simulering/simulering.tsx
+++ b/src/pages/saksbehandling/simulering/simulering.tsx
@@ -6,7 +6,6 @@ import NavFrontendSpinner from 'nav-frontend-spinner';
 import { Innholdstittel } from 'nav-frontend-typografi';
 import React from 'react';
 
-import { formatDateTime } from '~lib/dateUtils';
 import { combineOptions } from '~lib/fp';
 import { useI18n } from '~lib/hooks';
 import messages from '~pages/saksbehandling/steg/beregning/beregning-nb';
@@ -15,7 +14,6 @@ import { Sak } from '~types/Sak';
 import { Utbetaling } from '~types/Utbetaling';
 
 import { groupSimuleringsperioder } from '../delt/arrayUtils';
-import { InfoLinje } from '../delt/Infolinje/Infolinje';
 import styles from '../steg/beregning/visBeregning.module.less';
 
 interface Props {
@@ -30,14 +28,6 @@ const Utbetalingssimulering = (props: { utbetaling: Utbetaling }) => {
     return (
         <>
             <Innholdstittel className={styles.tittel}>Simulering:</Innholdstittel>
-            <div className={styles.grunndata}>
-                <InfoLinje tittel={'id:'} value={props.utbetaling.id} />
-                <InfoLinje tittel={'opprettet:'} value={formatDateTime(props.utbetaling.opprettet, intl)} />
-                <InfoLinje
-                    tittel="Totalbeløp:"
-                    value={intl.formatNumber(props.utbetaling.simulering.totalBruttoYtelse, { currency: 'NOK' })}
-                />
-            </div>
             {props.utbetaling.simulering.perioder && (
                 <table className="tabell">
                     <thead>


### PR DESCRIPTION
Vi ønsker å fjerne utbetalingsbiten fra simuleringa i behandlingsøyemed. Da mister vi utbetalingsid/opprettet. Ser ut som det rydder opp UIet litt og.

# Current view
![old_simulering_view](https://user-images.githubusercontent.com/1081740/95850296-e5454900-0d50-11eb-9a6c-195ac7ed9d87.png)

# PR view
![updated_view](https://user-images.githubusercontent.com/1081740/95850299-e5dddf80-0d50-11eb-99dd-6098509bd260.png)
