### PR TITLE
Add a dropdown to select currency for utenlandsk inntekt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4754,6 +4754,14 @@
                 }
             }
         },
+        "country-data-list": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/country-data-list/-/country-data-list-1.2.0.tgz",
+            "integrity": "sha512-i4+8z7d9HPKX++2OSfxGZATTqAHn/HqlTOJ8CwJrDhfVFaIWWDrvNXpJTRSaETC+Uit5sveu0J/MoD5DhjN5zw==",
+            "requires": {
+                "currency-symbol-map": "~4"
+            }
+        },
         "create-ecdh": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -5203,6 +5211,11 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
             "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+        },
+        "currency-symbol-map": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-4.0.4.tgz",
+            "integrity": "sha512-hkSCCopJXVsvIZIiumJc6FoNXR5LQ646c3ufzF0yfv3155PYygysHw24JuzPSg4j86EFpvtgeX+vEhzRtcJ5Ag=="
         },
         "dashdash": {
             "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "babel-polyfill": "^6.26.0",
         "babel-runtime": "^6.26.0",
         "classnames": "^2.2.6",
+        "country-data-list": "^1.2.0",
         "date-fns": "^2.16.1",
         "formik": "^2.2.0",
         "fp-ts": "^2.8.4",

--- a/src/pages/saksbehandling/steg/beregning/InntektFraUtland.tsx
+++ b/src/pages/saksbehandling/steg/beregning/InntektFraUtland.tsx
@@ -1,5 +1,6 @@
+import { currencies } from 'country-data-list';
 import { FormikErrors } from 'formik';
-import { Input } from 'nav-frontend-skjema';
+import { Input, Select } from 'nav-frontend-skjema';
 import React from 'react';
 import { IntlShape } from 'react-intl';
 
@@ -13,13 +14,14 @@ const InntektFraUtland = (props: {
     valutaId: string;
     kursId: string;
     fradrag: FradragFormData;
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange: (e: React.ChangeEvent<HTMLElement>) => void;
     utenlandskInntektErrors: FormikErrors<UtenlandskInntekt> | undefined;
     intl: IntlShape;
 }) => {
     const beløpIUtenlandskValutaError = props.utenlandskInntektErrors?.beløpIUtenlandskValuta;
     const valutaError = props.utenlandskInntektErrors?.valuta;
     const kursError = props.utenlandskInntektErrors?.kurs;
+    const valuta = props.fradrag.utenlandskInntekt.valuta;
 
     return (
         <div className={styles.inntektFraUtlandContainer}>
@@ -31,14 +33,20 @@ const InntektFraUtland = (props: {
                 onChange={props.onChange}
                 feil={beløpIUtenlandskValutaError}
             />
-            <Input
+            <Select
                 label={props.intl.formatMessage({ id: 'display.input.valuta' })}
                 name={props.valutaId}
-                value={props.fradrag.utenlandskInntekt?.valuta ?? ''}
-                bredde={'S'}
+                value={valuta ?? ''}
                 onChange={props.onChange}
                 feil={valutaError}
-            />
+                bredde="s"
+            >
+                {Object.values(currencies).map((c, index) => (
+                    <option value={c.code} key={index}>
+                        {c.code}
+                    </option>
+                ))}
+            </Select>
             <Input
                 label={props.intl.formatMessage({ id: 'display.input.kurs' })}
                 name={props.kursId}

--- a/src/pages/saksbehandling/steg/beregning/InntektFraUtland.tsx
+++ b/src/pages/saksbehandling/steg/beregning/InntektFraUtland.tsx
@@ -41,8 +41,11 @@ const InntektFraUtland = (props: {
                 feil={valutaError}
                 bredde="s"
             >
-                {Object.values(currencies).map((c, index) => (
-                    <option value={c.code} key={index}>
+                <option value="" disabled={true}>
+                    Velg valuta..
+                </option>
+                {currencies.all.map((c) => (
+                    <option value={c.code} key={c.number}>
                         {c.code}
                     </option>
                 ))}

--- a/types/country-data-list.d.ts
+++ b/types/country-data-list.d.ts
@@ -1,0 +1,9 @@
+declare module 'country-data-list' {
+    interface Currency {
+        name: string;
+        code: string;
+        number: string;
+    }
+
+    export const currencies: Currency;
+}

--- a/types/country-data-list.d.ts
+++ b/types/country-data-list.d.ts
@@ -5,5 +5,5 @@ declare module 'country-data-list' {
         number: string;
     }
 
-    export const currencies: Currency;
+    export const currencies: { all: Currency[]; [key: string]: Currency };
 }


### PR DESCRIPTION
For å forhindre feilskriving fra saksbehandler ønsker vi at de heller skal velge valuta fra en liste. På sikt burde nok denne f.eks. ha type-ahead/søk og/eller mulighet for å velge land eller valutanavn, men vi putter den i første omgang kun inn med 3-bokstavs-valutakode: EUR, NOK, osv.