### PR TITLE
Update choices for personlig oppmøte

### DIFF
--- a/src/features/saksoversikt/utils.tsx
+++ b/src/features/saksoversikt/utils.tsx
@@ -158,12 +158,13 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
 function statusForPersonligOppmøte(personligOppmøte: Nullable<PersonligOppmøte>): VilkårVurderingStatus {
     switch (personligOppmøte?.status) {
         case PersonligOppmøteStatus.MøttPersonlig:
-        case PersonligOppmøteStatus.FullmektigMedLegeattest:
-        case PersonligOppmøteStatus.Verge:
+        case PersonligOppmøteStatus.IkkeMøttMenSykMedLegeerklæringOgFullmakt:
+        case PersonligOppmøteStatus.IkkeMøttMenVerge:
+        case PersonligOppmøteStatus.IkkeMøttMenKortvarigSykMedLegeerklæring:
+        case PersonligOppmøteStatus.IkkeMøttMenMidlertidigUnntakFraOppmøteplikt:
             return VilkårVurderingStatus.Ok;
 
-        case PersonligOppmøteStatus.FullmektigUtenLegeattest:
-        case PersonligOppmøteStatus.IkkeMøttOpp:
+        case PersonligOppmøteStatus.IkkeMøttPersonlig:
             return VilkårVurderingStatus.IkkeOk;
 
         default:

--- a/src/pages/saksbehandling/steg/personlig-oppmøte/personligOppmøte-nb.ts
+++ b/src/pages/saksbehandling/steg/personlig-oppmøte/personligOppmøte-nb.ts
@@ -3,9 +3,16 @@ export default {
     'display.fraSøknad.personligOppmøte': 'Personlig',
     'page.tittel': 'Personlig oppmøte',
 
-    'radio.legeattest.legend': 'Legeattest?',
-    'radio.personligOppmøte.legend': 'Har søker møtt personlig?',
+    'radio.personligOppmøte.legend': 'Har bruker møtt personlig?',
+    'radio.personligOppmøte.grunn.legend': 'Hvorfor har ikke bruker møtt personlig?',
 
-    'radio.label.søkerHarVerge': 'Søker har verge',
-    'radio.label.søkerHarFullmektig': 'Fullmektig har møtt på vegne av søker',
+    'radio.personligOppmøte.grunn.sykMedLegeerklæringOgFullmakt':
+        'Brukeren er for syk til å møte, og det foreligger legeerklæring og fullmakt',
+    'radio.personligOppmøte.grunn.oppnevntVergeSøktPerPost':
+        'Oppnevnt verge, og søkt per post i tråd med reglene for vergemål',
+    'radio.personligOppmøte.grunn.kortvarigSykMedLegeerklæring':
+        'Kortvarig sykdom som er dokumentert med legeerklæring',
+    'radio.personligOppmøte.grunn.midlertidigUnntakFraOppmøteplikt': 'Midlertidig unntak fra oppmøteplikten',
+    'radio.personligOppmøte.grunn.brukerIkkeMøttOppfyllerIkkeVilkår':
+        'Bruker har ikke møtt, og oppfyller ikke vilkåret',
 };

--- a/src/types/Behandlingsinformasjon.ts
+++ b/src/types/Behandlingsinformasjon.ts
@@ -88,10 +88,11 @@ export interface PersonligOppmøte {
 }
 export enum PersonligOppmøteStatus {
     MøttPersonlig = 'MøttPersonlig',
-    Verge = 'Verge',
-    FullmektigMedLegeattest = 'FullmektigMedLegeattest',
-    FullmektigUtenLegeattest = 'FullmektigUtenLegeattest',
-    IkkeMøttOpp = 'IkkeMøttOpp',
+    IkkeMøttMenVerge = 'IkkeMøttMenVerge',
+    IkkeMøttMenSykMedLegeerklæringOgFullmakt = 'IkkeMøttMenSykMedLegeerklæringOgFullmakt',
+    IkkeMøttMenKortvarigSykMedLegeerklæring = 'IkkeMøttMenKortvarigSykMedLegeerklæring',
+    IkkeMøttMenMidlertidigUnntakFraOppmøteplikt = 'IkkeMøttMenMidlertidigUnntakFraOppmøteplikt',
+    IkkeMøttPersonlig = 'IkkeMøttPersonlig',
 }
 
 export interface Bosituasjon {


### PR DESCRIPTION
Personlig oppmøte er endret fra 4 statuser + legeerklæring, til 1 spørsmål om hvorvidt bruker har møtt personlig, og en haug med valg dersom svaret på det er nei (hvor bare ett av de fører til avslag).