### PR TITLE
Make texts dynamic based on input for tidig avslag during saksbehandling

### DIFF
--- a/src/features/behandling/behandlingUtils.ts
+++ b/src/features/behandling/behandlingUtils.ts
@@ -17,8 +17,6 @@ import {
     PersonligOppmøte,
     Bosituasjon,
     FormueVerdier,
-    FlyktningStatus,
-    UførhetStatus,
 } from '~types/Behandlingsinformasjon';
 import { Sak } from '~types/Sak';
 import { Vilkårtype } from '~types/Vilkårsvurdering';
@@ -130,14 +128,4 @@ export const eqBosituasjon: Eq<Nullable<Bosituasjon>> = {
         sats1?.ektemakeEllerSamboerUnder67År === sats2?.ektemakeEllerSamboerUnder67År &&
         sats1?.ektemakeEllerSamboerUførFlyktning === sats2?.ektemakeEllerSamboerUførFlyktning &&
         sats1?.begrunnelse === sats2?.begrunnelse,
-};
-
-export const tidigAvslag = (behandlingsinformasjon?: Behandlingsinformasjon) => {
-    if (!behandlingsinformasjon) return false;
-
-    const { uførhet, flyktning } = behandlingsinformasjon;
-
-    return (
-        uførhet?.status === UførhetStatus.VilkårIkkeOppfylt || flyktning?.status === FlyktningStatus.VilkårIkkeOppfylt
-    );
 };

--- a/src/features/behandling/behandlingUtils.ts
+++ b/src/features/behandling/behandlingUtils.ts
@@ -17,6 +17,8 @@ import {
     PersonligOppmøte,
     Bosituasjon,
     FormueVerdier,
+    FlyktningStatus,
+    UførhetStatus,
 } from '~types/Behandlingsinformasjon';
 import { Sak } from '~types/Sak';
 import { Vilkårtype } from '~types/Vilkårsvurdering';
@@ -128,4 +130,14 @@ export const eqBosituasjon: Eq<Nullable<Bosituasjon>> = {
         sats1?.ektemakeEllerSamboerUnder67År === sats2?.ektemakeEllerSamboerUnder67År &&
         sats1?.ektemakeEllerSamboerUførFlyktning === sats2?.ektemakeEllerSamboerUførFlyktning &&
         sats1?.begrunnelse === sats2?.begrunnelse,
+};
+
+export const tidigAvslag = (behandlingsinformasjon?: Behandlingsinformasjon) => {
+    if (!behandlingsinformasjon) return false;
+
+    const { uførhet, flyktning } = behandlingsinformasjon;
+
+    return (
+        uførhet?.status === UførhetStatus.VilkårIkkeOppfylt || flyktning?.status === FlyktningStatus.VilkårIkkeOppfylt
+    );
 };

--- a/src/pages/saksbehandling/steg/Vurdering.tsx
+++ b/src/pages/saksbehandling/steg/Vurdering.tsx
@@ -2,9 +2,7 @@ import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import { Systemtittel } from 'nav-frontend-typografi';
 import React from 'react';
 
-import { tidigAvslag } from '~features/behandling/behandlingUtils';
 import { useI18n } from '~lib/hooks';
-import { Behandling } from '~types/Behandling';
 
 import sharedI18n from './sharedI18n-nb';
 import styles from './vurdering.module.less';
@@ -31,7 +29,7 @@ export const Vurderingknapper = (props: {
     onTilbakeClick(): void;
     onNesteClick?(): void;
     onLagreOgFortsettSenereClick(): void;
-    behandling?: Behandling;
+    nesteKnappTekst?: string;
 }) => {
     const intl = useI18n({ messages: { ...sharedI18n } });
 
@@ -42,11 +40,7 @@ export const Vurderingknapper = (props: {
                     {intl.formatMessage({ id: 'knapp.tilbake' })}
                 </Knapp>
                 <Hovedknapp onClick={props.onNesteClick} htmlType={props.onNesteClick ? 'button' : 'submit'}>
-                    {props.behandling
-                        ? tidigAvslag(props.behandling?.behandlingsinformasjon)
-                            ? intl.formatMessage({ id: 'knapp.tilVedtaket' })
-                            : intl.formatMessage({ id: 'knapp.neste' })
-                        : intl.formatMessage({ id: 'knapp.neste' })}
+                    {props.nesteKnappTekst ? props.nesteKnappTekst : intl.formatMessage({ id: 'knapp.neste' })}
                 </Hovedknapp>
             </div>
             <Knapp onClick={props.onLagreOgFortsettSenereClick} htmlType="button">

--- a/src/pages/saksbehandling/steg/Vurdering.tsx
+++ b/src/pages/saksbehandling/steg/Vurdering.tsx
@@ -2,8 +2,9 @@ import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import { Systemtittel } from 'nav-frontend-typografi';
 import React from 'react';
 
+import { tidigAvslag } from '~features/behandling/behandlingUtils';
 import { useI18n } from '~lib/hooks';
-import { Behandling, Behandlingsstatus } from '~types/Behandling';
+import { Behandling } from '~types/Behandling';
 
 import sharedI18n from './sharedI18n-nb';
 import styles from './vurdering.module.less';
@@ -41,8 +42,10 @@ export const Vurderingknapper = (props: {
                     {intl.formatMessage({ id: 'knapp.tilbake' })}
                 </Knapp>
                 <Hovedknapp onClick={props.onNesteClick} htmlType={props.onNesteClick ? 'button' : 'submit'}>
-                    {props.behandling?.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG
-                        ? intl.formatMessage({ id: 'knapp.tilVedtaket' })
+                    {props.behandling
+                        ? tidigAvslag(props.behandling?.behandlingsinformasjon)
+                            ? intl.formatMessage({ id: 'knapp.tilVedtaket' })
+                            : intl.formatMessage({ id: 'knapp.neste' })
                         : intl.formatMessage({ id: 'knapp.neste' })}
                 </Hovedknapp>
             </div>

--- a/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
@@ -6,7 +6,7 @@ import NavFrontendSpinner from 'nav-frontend-spinner';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { eqFlyktning, tidigAvslag } from '~features/behandling/behandlingUtils';
+import { eqFlyktning } from '~features/behandling/behandlingUtils';
 import { lagreBehandlingsinformasjon } from '~features/saksoversikt/sak.slice';
 import { pipe } from '~lib/fp';
 import { useI18n } from '~lib/hooks';
@@ -15,7 +15,7 @@ import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
 import { Behandlingsstatus } from '~types/Behandling';
-import { Behandlingsinformasjon, Flyktning as FlyktningType, FlyktningStatus } from '~types/Behandlingsinformasjon';
+import { Flyktning as FlyktningType, FlyktningStatus, UførhetStatus } from '~types/Behandlingsinformasjon';
 
 import Faktablokk from '../Faktablokk';
 import sharedI18n from '../sharedI18n-nb';
@@ -47,18 +47,11 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
     const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
 
-    const oppdatertBehandlingsinformasjon = (): Behandlingsinformasjon => {
-        if (!formik.values.status) {
-            return props.behandling.behandlingsinformasjon;
-        }
-
-        return {
-            ...props.behandling.behandlingsinformasjon,
-            flyktning: {
-                ...formik.values,
-                status: formik.values.status,
-            },
-        };
+    const vilGiTidligAvslag = (): boolean => {
+        return (
+            props.behandling.behandlingsinformasjon.uførhet?.status === UførhetStatus.VilkårIkkeOppfylt ||
+            formik.values?.status === FlyktningStatus.VilkårIkkeOppfylt
+        );
     };
     const goToVedtak = () => {
         history.push(
@@ -223,9 +216,7 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
                                 );
                             }}
                             nesteKnappTekst={
-                                tidigAvslag(oppdatertBehandlingsinformasjon())
-                                    ? intl.formatMessage({ id: 'knapp.tilVedtaket' })
-                                    : undefined
+                                vilGiTidligAvslag() ? intl.formatMessage({ id: 'knapp.tilVedtaket' }) : undefined
                             }
                         />
                     </form>

--- a/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
@@ -14,7 +14,7 @@ import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
-import { Behandlingsstatus } from '~types/Behandling';
+import { Behandling, Behandlingsstatus } from '~types/Behandling';
 import { Flyktning as FlyktningType, FlyktningStatus } from '~types/Behandlingsinformasjon';
 
 import Faktablokk from '../Faktablokk';
@@ -47,6 +47,22 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
     const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
 
+    const hentBehandlingForTidigAvslag = (nyStatus: Nullable<FlyktningStatus>): Behandling => {
+        if (!nyStatus) {
+            return props.behandling;
+        }
+
+        return {
+            ...props.behandling,
+            behandlingsinformasjon: {
+                ...props.behandling.behandlingsinformasjon,
+                flyktning: {
+                    ...formik.values,
+                    status: nyStatus,
+                },
+            },
+        };
+    };
     const goToVedtak = () => {
         history.push(
             Routes.saksbehandlingVedtak.createURL({
@@ -209,7 +225,7 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
                                     })
                                 );
                             }}
-                            behandling={props.behandling}
+                            behandling={hentBehandlingForTidigAvslag(formik.values.status)}
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
@@ -6,7 +6,7 @@ import NavFrontendSpinner from 'nav-frontend-spinner';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { eqFlyktning } from '~features/behandling/behandlingUtils';
+import { eqFlyktning, tidigAvslag } from '~features/behandling/behandlingUtils';
 import { lagreBehandlingsinformasjon } from '~features/saksoversikt/sak.slice';
 import { pipe } from '~lib/fp';
 import { useI18n } from '~lib/hooks';
@@ -14,8 +14,8 @@ import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
-import { Behandling, Behandlingsstatus } from '~types/Behandling';
-import { Flyktning as FlyktningType, FlyktningStatus } from '~types/Behandlingsinformasjon';
+import { Behandlingsstatus } from '~types/Behandling';
+import { Behandlingsinformasjon, Flyktning as FlyktningType, FlyktningStatus } from '~types/Behandlingsinformasjon';
 
 import Faktablokk from '../Faktablokk';
 import sharedI18n from '../sharedI18n-nb';
@@ -47,19 +47,16 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
     const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
 
-    const hentBehandlingForTidigAvslag = (nyStatus: Nullable<FlyktningStatus>): Behandling => {
-        if (!nyStatus) {
-            return props.behandling;
+    const oppdatertBehandlingsinformasjon = (): Behandlingsinformasjon => {
+        if (!formik.values.status) {
+            return props.behandling.behandlingsinformasjon;
         }
 
         return {
-            ...props.behandling,
-            behandlingsinformasjon: {
-                ...props.behandling.behandlingsinformasjon,
-                flyktning: {
-                    ...formik.values,
-                    status: nyStatus,
-                },
+            ...props.behandling.behandlingsinformasjon,
+            flyktning: {
+                ...formik.values,
+                status: formik.values.status,
             },
         };
     };
@@ -225,7 +222,11 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
                                     })
                                 );
                             }}
-                            behandling={hentBehandlingForTidigAvslag(formik.values.status)}
+                            nesteKnappTekst={
+                                tidigAvslag(oppdatertBehandlingsinformasjon())
+                                    ? intl.formatMessage({ id: 'knapp.tilVedtaket' })
+                                    : undefined
+                            }
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/steg/flyktning/flyktning-nb.ts
+++ b/src/pages/saksbehandling/steg/flyktning/flyktning-nb.ts
@@ -5,4 +5,6 @@ export default {
 
     'page.tittel': 'Flyktning',
     'radio.flyktning.legend': 'Er søker registrert flyktning etter utlendingslova §28?',
+
+    'knapp.tilVedtaket': 'Gå til vedtaket',
 };

--- a/src/pages/saksbehandling/steg/sharedI18n-nb.ts
+++ b/src/pages/saksbehandling/steg/sharedI18n-nb.ts
@@ -12,7 +12,6 @@ export default {
     'knapp.tilbake': 'Tilbake',
     'knapp.neste': 'Neste',
     'knapp.lagreOgfortsettSenere': 'Lagre og fortsett senere',
-    'knapp.tilVedtaket': 'Gå til vedtaket',
 
     'radio.label.ja': 'Ja',
     'radio.label.nei': 'Nei',


### PR DESCRIPTION
Nå skal all text och handlingar i samband med det tidiga avslaget basera sig på det som är i nuvarande tillstånd (`formik.values`) istället för i det som är lagret i backend.