### PR TITLE
Behandling: add status Uavklart for personlig oppmøte and utenlandsopphold

### DIFF
--- a/src/features/saksoversikt/utils.tsx
+++ b/src/features/saksoversikt/utils.tsx
@@ -122,6 +122,8 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
             status:
                 oppholdIUtlandet === null
                     ? VilkårVurderingStatus.IkkeVurdert
+                    : oppholdIUtlandet.status === OppholdIUtlandetStatus.Uavklart
+                    ? VilkårVurderingStatus.Uavklart
                     : oppholdIUtlandet.status === OppholdIUtlandetStatus.SkalHoldeSegINorge
                     ? VilkårVurderingStatus.Ok
                     : VilkårVurderingStatus.IkkeOk,
@@ -152,7 +154,10 @@ export const mapToVilkårsinformasjon = (behandlingsinformasjon: Behandlingsinfo
 };
 
 function statusForPersonligOppmøte(personligOppmøte: Nullable<PersonligOppmøte>): VilkårVurderingStatus {
-    switch (personligOppmøte?.status) {
+    if (!personligOppmøte?.status) {
+        return VilkårVurderingStatus.IkkeVurdert;
+    }
+    switch (personligOppmøte.status) {
         case PersonligOppmøteStatus.MøttPersonlig:
         case PersonligOppmøteStatus.IkkeMøttMenSykMedLegeerklæringOgFullmakt:
         case PersonligOppmøteStatus.IkkeMøttMenVerge:
@@ -162,8 +167,7 @@ function statusForPersonligOppmøte(personligOppmøte: Nullable<PersonligOppmøt
 
         case PersonligOppmøteStatus.IkkeMøttPersonlig:
             return VilkårVurderingStatus.IkkeOk;
-
-        default:
-            return VilkårVurderingStatus.IkkeVurdert;
+        case PersonligOppmøteStatus.Uavklart:
+            return VilkårVurderingStatus.Uavklart;
     }
 }

--- a/src/pages/saksbehandling/steg/opphold-i-utlandet/OppholdIUtlandet.tsx
+++ b/src/pages/saksbehandling/steg/opphold-i-utlandet/OppholdIUtlandet.tsx
@@ -40,13 +40,7 @@ const DatoFelt = (props: { label: React.ReactNode; verdi: string | React.ReactNo
 );
 
 const schema = yup.object<FormData>({
-    status: yup
-        .mixed()
-        .defined()
-        .oneOf(
-            [OppholdIUtlandetStatus.SkalVæreMerEnn90DagerIUtlandet, OppholdIUtlandetStatus.SkalHoldeSegINorge],
-            'Vennligst velg et alternativ '
-        ),
+    status: yup.mixed().defined().oneOf(Object.values(OppholdIUtlandetStatus), 'Vennligst velg et alternativ '),
     begrunnelse: yup.string().defined(),
 });
 
@@ -137,10 +131,10 @@ const OppholdIUtlandet = (props: VilkårsvurderingBaseProps) => {
                                 label={intl.formatMessage({ id: 'radio.label.ja' })}
                                 name="status"
                                 onChange={() =>
-                                    formik.setValues({
-                                        ...formik.values,
+                                    formik.setValues((v) => ({
+                                        ...v,
                                         status: OppholdIUtlandetStatus.SkalVæreMerEnn90DagerIUtlandet,
-                                    })
+                                    }))
                                 }
                                 checked={formik.values.status === OppholdIUtlandetStatus.SkalVæreMerEnn90DagerIUtlandet}
                             />
@@ -148,12 +142,23 @@ const OppholdIUtlandet = (props: VilkårsvurderingBaseProps) => {
                                 label={intl.formatMessage({ id: 'radio.label.nei' })}
                                 name="status"
                                 onChange={() =>
-                                    formik.setValues({
-                                        ...formik.values,
+                                    formik.setValues((v) => ({
+                                        ...v,
                                         status: OppholdIUtlandetStatus.SkalHoldeSegINorge,
-                                    })
+                                    }))
                                 }
                                 checked={formik.values.status === OppholdIUtlandetStatus.SkalHoldeSegINorge}
+                            />
+                            <Radio
+                                label={intl.formatMessage({ id: 'radio.label.uavklart' })}
+                                name="status"
+                                onChange={() =>
+                                    formik.setValues((v) => ({
+                                        ...v,
+                                        status: OppholdIUtlandetStatus.Uavklart,
+                                    }))
+                                }
+                                checked={formik.values.status === OppholdIUtlandetStatus.Uavklart}
                             />
                         </RadioGruppe>
                         <Textarea
@@ -162,10 +167,10 @@ const OppholdIUtlandet = (props: VilkårsvurderingBaseProps) => {
                             feil={formik.errors.begrunnelse}
                             value={formik.values.begrunnelse ?? ''}
                             onChange={(e) => {
-                                formik.setValues({
-                                    ...formik.values,
+                                formik.setValues((v) => ({
+                                    ...v,
                                     begrunnelse: e.target.value ? e.target.value : null,
-                                });
+                                }));
                             }}
                         />
                         {pipe(

--- a/src/pages/saksbehandling/steg/personlig-oppmøte/PersonligOppmøte.tsx
+++ b/src/pages/saksbehandling/steg/personlig-oppmøte/PersonligOppmøte.tsx
@@ -3,12 +3,13 @@ import { useFormik } from 'formik';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { Textarea } from 'nav-frontend-skjema';
 import NavFrontendSpinner from 'nav-frontend-spinner';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { eqPersonligOppmøte } from '~/features/behandling/behandlingUtils';
 import { SuperRadioGruppe } from '~components/FormElements';
 import { lagreBehandlingsinformasjon } from '~features/saksoversikt/sak.slice';
+import { mapToVilkårsinformasjon, Vilkårsinformasjon } from '~features/saksoversikt/utils';
 import { GrunnForPapirinnsending } from '~features/søknad/types';
 import { pipe } from '~lib/fp';
 import { useI18n } from '~lib/hooks';
@@ -17,8 +18,13 @@ import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
 import { Behandlingsstatus } from '~types/Behandling';
-import { PersonligOppmøteStatus, PersonligOppmøte as PersonligOppmøteType } from '~types/Behandlingsinformasjon';
+import {
+    PersonligOppmøteStatus,
+    PersonligOppmøte as PersonligOppmøteType,
+    Behandlingsinformasjon,
+} from '~types/Behandlingsinformasjon';
 import { Søknadstype } from '~types/Søknad';
+import { VilkårVurderingStatus } from '~types/Vilkårsvurdering';
 
 import Faktablokk from '../Faktablokk';
 import sharedI18n from '../sharedI18n-nb';
@@ -26,6 +32,7 @@ import { VilkårsvurderingBaseProps } from '../types';
 import { Vurdering, Vurderingknapper } from '../Vurdering';
 
 import messages from './personligOppmøte-nb';
+import styles from './personligOppmøte.module.less';
 
 enum GrunnForManglendePersonligOppmøte {
     SykMedLegeerklæringOgFullmakt = 'SykMedLegeerklæringOgFullmakt',
@@ -150,6 +157,41 @@ const toPersonligOppmøteStatus = (formData: FormData): Nullable<PersonligOppmø
     }
 };
 
+const tilOppdatertVilkårsinformasjon = (
+    values: FormData,
+    behandlingsinformasjon: Behandlingsinformasjon
+): Vilkårsinformasjon[] | 'personligOppmøteIkkeVurdert' => {
+    const s = toPersonligOppmøteStatus(values);
+    if (!s) {
+        return 'personligOppmøteIkkeVurdert';
+    }
+    return mapToVilkårsinformasjon({
+        ...behandlingsinformasjon,
+        personligOppmøte: {
+            status: s,
+            begrunnelse: values.begrunnelse,
+        },
+    });
+};
+
+const erAlleVilkårVurdert = (vilkårsinformasjon: Vilkårsinformasjon[]): boolean =>
+    vilkårsinformasjon.every((x) => x.status !== VilkårVurderingStatus.IkkeVurdert);
+
+const erVurdertUtenAvslagMenIkkeFerdigbehandlet = (vilkårsinformasjon: Vilkårsinformasjon[]): boolean => {
+    return (
+        erAlleVilkårVurdert(vilkårsinformasjon) &&
+        vilkårsinformasjon.every((x) => x.status !== VilkårVurderingStatus.IkkeOk) &&
+        vilkårsinformasjon.some((x) => x.status === VilkårVurderingStatus.Uavklart)
+    );
+};
+
+const erFerdigbehandletMedAvslag = (vilkårsinformasjon: Vilkårsinformasjon[]): boolean => {
+    return (
+        erAlleVilkårVurdert(vilkårsinformasjon) &&
+        vilkårsinformasjon.some((x) => x.status === VilkårVurderingStatus.IkkeOk)
+    );
+};
+
 const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
@@ -173,11 +215,24 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
         );
     };
 
+    const advarselRef = useRef<HTMLDivElement>(null);
+
     const formik = useFormik<FormData>({
         initialValues: getInitialFormValues(props.behandling.behandlingsinformasjon.personligOppmøte),
         async onSubmit(values) {
             const personligOppmøte = toPersonligOppmøteStatus(values);
             if (!personligOppmøte) {
+                return;
+            }
+
+            const vilkårsinformasjon = tilOppdatertVilkårsinformasjon(values, props.behandling.behandlingsinformasjon);
+
+            if (
+                vilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
+                erVurdertUtenAvslagMenIkkeFerdigbehandlet(vilkårsinformasjon) &&
+                advarselRef.current
+            ) {
+                advarselRef.current.focus();
                 return;
             }
 
@@ -206,6 +261,11 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
 
     const history = useHistory();
 
+    const oppdatertVilkårsinformasjon = tilOppdatertVilkårsinformasjon(
+        formik.values,
+        props.behandling.behandlingsinformasjon
+    );
+
     return (
         <Vurdering tittel={intl.formatMessage({ id: 'page.tittel' })}>
             {{
@@ -216,75 +276,83 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
                             formik.handleSubmit(e);
                         }}
                     >
-                        <SuperRadioGruppe
-                            legend={intl.formatMessage({ id: 'radio.personligOppmøte.legend' })}
-                            values={formik.values}
-                            errors={formik.errors}
-                            onChange={formik.setValues}
-                            property="møttPersonlig"
-                            options={[
-                                {
-                                    label: intl.formatMessage({ id: 'radio.label.ja' }),
-                                    radioValue: HarMøttPersonlig.Ja,
-                                },
-                                {
-                                    label: intl.formatMessage({ id: 'radio.label.nei' }),
-                                    radioValue: HarMøttPersonlig.Nei,
-                                },
-                                {
-                                    label: intl.formatMessage({ id: 'radio.label.uavklart' }),
-                                    radioValue: HarMøttPersonlig.Uavklart,
-                                },
-                            ]}
-                        />
-                        {formik.values.møttPersonlig === HarMøttPersonlig.Nei && (
+                        <div className={styles.formElement}>
                             <SuperRadioGruppe
-                                legend={intl.formatMessage({ id: 'radio.personligOppmøte.grunn.legend' })}
+                                legend={intl.formatMessage({ id: 'radio.personligOppmøte.legend' })}
                                 values={formik.values}
                                 errors={formik.errors}
                                 onChange={formik.setValues}
-                                property="grunnForManglendePersonligOppmøte"
+                                property="møttPersonlig"
                                 options={[
                                     {
-                                        label: intl.formatMessage({
-                                            id: 'radio.personligOppmøte.grunn.sykMedLegeerklæringOgFullmakt',
-                                        }),
-                                        radioValue: GrunnForManglendePersonligOppmøte.SykMedLegeerklæringOgFullmakt,
+                                        label: intl.formatMessage({ id: 'radio.label.ja' }),
+                                        radioValue: HarMøttPersonlig.Ja,
                                     },
                                     {
-                                        label: intl.formatMessage({
-                                            id: 'radio.personligOppmøte.grunn.oppnevntVergeSøktPerPost',
-                                        }),
-                                        radioValue: GrunnForManglendePersonligOppmøte.OppnevntVergeSøktPerPost,
+                                        label: intl.formatMessage({ id: 'radio.label.nei' }),
+                                        radioValue: HarMøttPersonlig.Nei,
                                     },
                                     {
-                                        label: intl.formatMessage({
-                                            id: 'radio.personligOppmøte.grunn.kortvarigSykMedLegeerklæring',
-                                        }),
-                                        radioValue: GrunnForManglendePersonligOppmøte.KortvarigSykMedLegeerklæring,
-                                    },
-                                    {
-                                        label: intl.formatMessage({
-                                            id: 'radio.personligOppmøte.grunn.midlertidigUnntakFraOppmøteplikt',
-                                        }),
-                                        radioValue: GrunnForManglendePersonligOppmøte.MidlertidigUnntakFraOppmøteplikt,
-                                    },
-                                    {
-                                        label: intl.formatMessage({
-                                            id: 'radio.personligOppmøte.grunn.brukerIkkeMøttOppfyllerIkkeVilkår',
-                                        }),
-                                        radioValue: GrunnForManglendePersonligOppmøte.BrukerIkkeMøttOppfyllerIkkeVilkår,
+                                        label: intl.formatMessage({ id: 'radio.label.uavklart' }),
+                                        radioValue: HarMøttPersonlig.Uavklart,
                                     },
                                 ]}
                             />
+                        </div>
+                        {formik.values.møttPersonlig === HarMøttPersonlig.Nei && (
+                            <div className={styles.formElement}>
+                                <SuperRadioGruppe
+                                    legend={intl.formatMessage({ id: 'radio.personligOppmøte.grunn.legend' })}
+                                    values={formik.values}
+                                    errors={formik.errors}
+                                    onChange={formik.setValues}
+                                    property="grunnForManglendePersonligOppmøte"
+                                    options={[
+                                        {
+                                            label: intl.formatMessage({
+                                                id: 'radio.personligOppmøte.grunn.sykMedLegeerklæringOgFullmakt',
+                                            }),
+                                            radioValue: GrunnForManglendePersonligOppmøte.SykMedLegeerklæringOgFullmakt,
+                                        },
+                                        {
+                                            label: intl.formatMessage({
+                                                id: 'radio.personligOppmøte.grunn.oppnevntVergeSøktPerPost',
+                                            }),
+                                            radioValue: GrunnForManglendePersonligOppmøte.OppnevntVergeSøktPerPost,
+                                        },
+                                        {
+                                            label: intl.formatMessage({
+                                                id: 'radio.personligOppmøte.grunn.kortvarigSykMedLegeerklæring',
+                                            }),
+                                            radioValue: GrunnForManglendePersonligOppmøte.KortvarigSykMedLegeerklæring,
+                                        },
+                                        {
+                                            label: intl.formatMessage({
+                                                id: 'radio.personligOppmøte.grunn.midlertidigUnntakFraOppmøteplikt',
+                                            }),
+                                            radioValue:
+                                                GrunnForManglendePersonligOppmøte.MidlertidigUnntakFraOppmøteplikt,
+                                        },
+                                        {
+                                            label: intl.formatMessage({
+                                                id: 'radio.personligOppmøte.grunn.brukerIkkeMøttOppfyllerIkkeVilkår',
+                                            }),
+                                            radioValue:
+                                                GrunnForManglendePersonligOppmøte.BrukerIkkeMøttOppfyllerIkkeVilkår,
+                                        },
+                                    ]}
+                                />
+                            </div>
                         )}
-                        <Textarea
-                            label={intl.formatMessage({ id: 'input.label.begrunnelse' })}
-                            name="begrunnelse"
-                            feil={formik.errors.begrunnelse}
-                            value={formik.values.begrunnelse ?? ''}
-                            onChange={formik.handleChange}
-                        />
+                        <div className={styles.formElement}>
+                            <Textarea
+                                label={intl.formatMessage({ id: 'input.label.begrunnelse' })}
+                                name="begrunnelse"
+                                feil={formik.errors.begrunnelse}
+                                value={formik.values.begrunnelse ?? ''}
+                                onChange={formik.handleChange}
+                            />
+                        </div>
                         {pipe(
                             lagreBehandlingsinformasjonStatus,
                             RemoteData.fold(
@@ -302,6 +370,22 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
                                 () => null
                             )
                         )}
+
+                        <div
+                            ref={advarselRef}
+                            tabIndex={0}
+                            aria-live="polite"
+                            aria-atomic="true"
+                            className={styles.alertstripe}
+                        >
+                            {oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
+                                erVurdertUtenAvslagMenIkkeFerdigbehandlet(oppdatertVilkårsinformasjon) && (
+                                    <AlertStripe type="advarsel">
+                                        {intl.formatMessage({ id: 'alert.ikkeFerdigbehandlet' })}
+                                    </AlertStripe>
+                                )}
+                        </div>
+
                         <Vurderingknapper
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
@@ -315,6 +399,12 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
                                     begrunnelse: formik.values.begrunnelse,
                                 });
                             }}
+                            nesteKnappTekst={
+                                oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
+                                erFerdigbehandletMedAvslag(oppdatertVilkårsinformasjon)
+                                    ? intl.formatMessage({ id: 'button.tilVedtak.label' })
+                                    : undefined
+                            }
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/steg/personlig-oppmøte/personligOppmøte-nb.ts
+++ b/src/pages/saksbehandling/steg/personlig-oppmøte/personligOppmøte-nb.ts
@@ -16,4 +16,9 @@ export default {
     'radio.personligOppmøte.grunn.midlertidigUnntakFraOppmøteplikt': 'Midlertidig unntak fra oppmøteplikten',
     'radio.personligOppmøte.grunn.brukerIkkeMøttOppfyllerIkkeVilkår':
         'Bruker har ikke møtt, og oppfyller ikke vilkåret',
+
+    'button.tilVedtak.label': 'Gå til vedtaket',
+
+    'alert.ikkeFerdigbehandlet':
+        'Ett eller flere av vilkårene står som uavklart. Disse må vurderes før du kan gå videre.',
 };

--- a/src/pages/saksbehandling/steg/personlig-oppmøte/personligOppmøte.module.less
+++ b/src/pages/saksbehandling/steg/personlig-oppmøte/personligOppmøte.module.less
@@ -1,0 +1,10 @@
+@import '~/styles/variables.less';
+@import '~/styles/utils.less';
+
+.formElement {
+    margin-bottom: @spacing;
+}
+
+.alertstripe:focus {
+    .focusOutline();
+}

--- a/src/styles/utils.less
+++ b/src/styles/utils.less
@@ -1,0 +1,6 @@
+@import './variables.less';
+
+.focusOutline() {
+    outline: none;
+    box-shadow: 0 0 0 3px @fokusFarge;
+}

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -10,3 +10,4 @@
 
 @navgra60: #78706a;
 @navbla: #0067c5;
+@fokusFarge: #254b6d;

--- a/src/types/Behandlingsinformasjon.ts
+++ b/src/types/Behandlingsinformasjon.ts
@@ -64,6 +64,7 @@ export interface OppholdIUtlandet {
 export enum OppholdIUtlandetStatus {
     SkalVæreMerEnn90DagerIUtlandet = 'SkalVæreMerEnn90DagerIUtlandet',
     SkalHoldeSegINorge = 'SkalHoldeSegINorge',
+    Uavklart = 'Uavklart',
 }
 
 export interface Formue {
@@ -100,6 +101,7 @@ export enum PersonligOppmøteStatus {
     IkkeMøttMenKortvarigSykMedLegeerklæring = 'IkkeMøttMenKortvarigSykMedLegeerklæring',
     IkkeMøttMenMidlertidigUnntakFraOppmøteplikt = 'IkkeMøttMenMidlertidigUnntakFraOppmøteplikt',
     IkkeMøttPersonlig = 'IkkeMøttPersonlig',
+    Uavklart = 'Uavklart',
 }
 
 export interface Bosituasjon {


### PR DESCRIPTION
Dersom man står på personlig oppmøte og vilkårene er ikke-oppfylt vil "neste-knappen" nå vise "Gå til vedtaket", som er den oppførselen den faktisk vil ha.

Har også lagt inn en advarsel og en sperre på det steget dersom vilkårsvurderingen ikke er ferdig. Man får da en melding om at ett eller flere av vilkårene må vurderes før man kan gå videre.

Avhenger av https://github.com/navikt/su-se-bakover/pull/118.