### PR TITLE
Diverse fix

### DIFF
--- a/src/pages/attestering/attestering.module.less
+++ b/src/pages/attestering/attestering.module.less
@@ -5,7 +5,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 80px;
+    margin-bottom: @spacing-xxl;
 
     .headerContainer {
         display: flex;

--- a/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
@@ -15,7 +15,7 @@ import { LukkSøknadBegrunnelse } from '~types/Søknad';
 
 import nb from './lukkSøknad-nb';
 import styles from './lukkSøknad.module.less';
-import { AvvistBrevtyper } from './lukkSøknadUtils';
+import { AvvistBrevtyper, LukkSøknadFormData } from './lukkSøknadUtils';
 
 interface AvvistFormData {
     sendBrevForAvvist: Nullable<boolean>;
@@ -26,6 +26,7 @@ interface AvvistFormData {
 interface AvvistProps {
     søknadId: string;
     lukkSøknadBegrunnelse: LukkSøknadBegrunnelse;
+    validateForm: () => Promise<FormikErrors<LukkSøknadFormData>>;
     avvistFormData: AvvistFormData;
     lukketSøknadBrevutkastStatus: RemoteData.RemoteData<ApiError, null>;
     søknadLukketStatus: RemoteData.RemoteData<ApiError, null>;
@@ -123,7 +124,11 @@ const Avvist = (props: AvvistProps) => {
                         className={styles.seBrevKnapp}
                         htmlType="button"
                         onClick={() => {
-                            onSeBrevClick();
+                            props.validateForm().then((res) => {
+                                if (Object.keys(res).length === 0) {
+                                    onSeBrevClick();
+                                }
+                            });
                         }}
                         spinner={RemoteData.isPending(props.lukketSøknadBrevutkastStatus)}
                     >

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -2,10 +2,10 @@ import * as RemoteData from '@devexperts/remote-data-ts';
 import classNames from 'classnames';
 import { useFormik } from 'formik';
 import { AlertStripeSuksess, AlertStripeFeil } from 'nav-frontend-alertstriper';
-import { Fareknapp, Knapp } from 'nav-frontend-knapper';
+import { Fareknapp } from 'nav-frontend-knapper';
+import Lenke from 'nav-frontend-lenker';
 import { Select } from 'nav-frontend-skjema';
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { lukkSøknad } from '~features/saksoversikt/sak.slice';
 import { useI18n } from '~lib/hooks';
@@ -27,7 +27,6 @@ import Trukket from './Trukket';
 
 const LukkSøknad = (props: { sak: Sak }) => {
     const dispatch = useAppDispatch();
-    const history = useHistory();
     const { søknadLukketStatus, lukketSøknadBrevutkastStatus } = useAppSelector((s) => s.sak);
     const urlParams = Routes.useRouteParams<typeof Routes.avsluttSøknadsbehandling>();
     const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
@@ -192,12 +191,9 @@ const LukkSøknad = (props: { sak: Sak }) => {
                 />
             )}
             <div className={styles.tilbakeKnappContainer}>
-                <Knapp
-                    htmlType="button"
-                    onClick={() => history.push(Routes.saksoversiktValgtSak.createURL({ sakId: urlParams.sakId }))}
-                >
+                <Lenke href={Routes.saksoversiktValgtSak.createURL({ sakId: urlParams.sakId })} className="knapp">
                     {intl.formatMessage({ id: 'knapp.tilbake' })}
-                </Knapp>
+                </Lenke>
             </div>
 
             <div>

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -1,9 +1,11 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
+import classNames from 'classnames';
 import { useFormik } from 'formik';
 import { AlertStripeSuksess, AlertStripeFeil } from 'nav-frontend-alertstriper';
-import { Fareknapp } from 'nav-frontend-knapper';
+import { Fareknapp, Knapp } from 'nav-frontend-knapper';
 import { Select } from 'nav-frontend-skjema';
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { lukkSøknad } from '~features/saksoversikt/sak.slice';
 import { useI18n } from '~lib/hooks';
@@ -25,6 +27,7 @@ import Trukket from './Trukket';
 
 const LukkSøknad = (props: { sak: Sak }) => {
     const dispatch = useAppDispatch();
+    const history = useHistory();
     const { søknadLukketStatus, lukketSøknadBrevutkastStatus } = useAppSelector((s) => s.sak);
     const urlParams = Routes.useRouteParams<typeof Routes.avsluttSøknadsbehandling>();
     const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
@@ -154,7 +157,7 @@ const LukkSøknad = (props: { sak: Sak }) => {
             )}
 
             {formik.values.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Bortfalt && (
-                <div className={styles.buttonsContainer}>
+                <div className={classNames(styles.bortfaltContainer, styles.buttonsContainer)}>
                     <Fareknapp spinner={RemoteData.isPending(søknadLukketStatus)}>
                         {intl.formatMessage({ id: 'knapp.lukkSøknad' })}
                     </Fareknapp>
@@ -164,6 +167,7 @@ const LukkSøknad = (props: { sak: Sak }) => {
             {formik.values.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Avvist && (
                 <Avvist
                     søknadId={søknad.id}
+                    validateForm={() => formik.validateForm()}
                     lukkSøknadBegrunnelse={formik.values.lukkSøknadBegrunnelse}
                     avvistFormData={{
                         sendBrevForAvvist: formik.values.sendBrevForAvvist,
@@ -187,6 +191,14 @@ const LukkSøknad = (props: { sak: Sak }) => {
                     lukketSøknadBrevutkastStatus={lukketSøknadBrevutkastStatus}
                 />
             )}
+            <div className={styles.tilbakeKnappContainer}>
+                <Knapp
+                    htmlType="button"
+                    onClick={() => history.push(Routes.saksoversiktValgtSak.createURL({ sakId: urlParams.sakId }))}
+                >
+                    {intl.formatMessage({ id: 'knapp.tilbake' })}
+                </Knapp>
+            </div>
 
             <div>
                 {RemoteData.isFailure(lukketSøknadBrevutkastStatus) && (

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -101,6 +101,7 @@ const LukkSøknad = (props: { sak: Sak }) => {
                 setHasSubmitted(true);
                 formik.handleSubmit(e);
             }}
+            className={styles.formContainer}
         >
             <div>
                 <p>

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad-nb.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad-nb.ts
@@ -23,6 +23,7 @@ export default {
 
     'display.trekking.datoSøkerTrakkSøknad': 'Dato søker trakk søknad',
 
+    'knapp.tilbake': 'Tilbake',
     'knapp.lukkSøknad': 'Lukk søknad',
     'knapp.seBrev': 'Se brev',
 

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
@@ -8,6 +8,10 @@
     margin-bottom: @spacing-s;
 }
 
+.bortfaltContainer {
+    margin-bottom: @spacing;
+}
+
 .trukketContainer {
     margin-bottom: @spacing;
 
@@ -37,4 +41,9 @@
     .textAreaContainer {
         margin-bottom: @spacing-s;
     }
+}
+
+.tilbakeKnappContainer {
+    display: flex;
+    justify-content: center;
 }

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
@@ -1,5 +1,9 @@
 @import '~/styles/variables.less';
 
+.formContainer {
+    margin-bottom: 80px;
+}
+
 .selectContainer {
     margin-bottom: @spacing-s;
 }

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
@@ -1,7 +1,7 @@
 @import '~/styles/variables.less';
 
 .formContainer {
-    margin-bottom: 80px;
+    margin-bottom: @spacing-xxl;
 }
 
 .selectContainer {

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
@@ -57,6 +57,7 @@ export const LukkSøknadValidationSchema = yup.object<LukkSøknadFormData>({
         .when('typeBrev', {
             is: AvvistBrevtyper.Fritekstsbrev,
             then: yup.string().required().min(1),
+            otherwise: yup.string().defined().nullable(),
         }),
 });
 

--- a/src/pages/saksbehandling/sakintro/sakintro.module.less
+++ b/src/pages/saksbehandling/sakintro/sakintro.module.less
@@ -4,7 +4,7 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    margin-bottom: 80px;
+    margin-bottom: @spacing-xxl;
     .tittel {
         padding: @spacing-xs 10rem;
         border-bottom: 1px solid @navLysGra;

--- a/src/pages/saksbehandling/steg/vurdering.module.less
+++ b/src/pages/saksbehandling/steg/vurdering.module.less
@@ -4,7 +4,7 @@
     display: flex;
     width: 100%;
     height: 100%;
-    margin-bottom: 80px;
+    margin-bottom: @spacing-xxl;
 }
 
 .tittel {

--- a/src/pages/saksbehandling/vedtak/vedtak.module.less
+++ b/src/pages/saksbehandling/vedtak/vedtak.module.less
@@ -1,7 +1,7 @@
 @import '~/styles/variables.less';
 
 .vedtakContainer {
-    margin-bottom: 80px;
+    margin-bottom: @spacing-xxl;
 
     .vedtakSendtTilAttesteringAlertStripe {
         margin-top: @spacing;

--- a/src/pages/søknad/index.module.less
+++ b/src/pages/søknad/index.module.less
@@ -7,7 +7,7 @@
     width: 100%;
     max-width: @container-sm;
     padding: @spacing-s @spacing-l;
-    margin-bottom: 80px;
+    margin-bottom: @spacing-xxl;
 }
 
 .headerContainer {

--- a/src/pages/søknad/index.module.less
+++ b/src/pages/søknad/index.module.less
@@ -28,8 +28,11 @@
 }
 
 .sidetittelContainer {
+    display: flex;
+    justify-content: center;
     margin-bottom: @spacing-xs;
 }
+
 .personkortContainer {
     font-size: initial;
     font-weight: initial;

--- a/src/pages/søknad/steg-shared.module.less
+++ b/src/pages/søknad/steg-shared.module.less
@@ -28,7 +28,7 @@
 }
 
 .fjernFeltLink {
-    align-self: center;
+    align-self: flex-end;
 }
 
 .marginBottom {

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
@@ -80,7 +80,7 @@ const schema = yup.object<FormData>({
                     .required()
                     .typeError('Feltet må fylles ut')
                     .test({
-                        name: 'fnr',
+                        name: 'erUførFlyktning',
                         message: 'Feltet må fylles ut',
                         test: function (value) {
                             return value !== null;
@@ -120,12 +120,8 @@ const schema = yup.object<FormData>({
                 const innlagtPåinstitusjon = this.parent.innlagtPåinstitusjon;
                 const fortsattInnlagt = this.parent.fortsattInnlagt;
 
-                if (innlagtPåinstitusjon) {
-                    if (fortsattInnlagt) {
-                        return true;
-                    } else {
-                        if (!val) return false;
-                    }
+                if (innlagtPåinstitusjon && !fortsattInnlagt && !val) {
+                    return false;
                 }
                 return true;
             },
@@ -274,25 +270,24 @@ const BoOgOppholdINorge = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     <Label htmlFor={'datoForInnleggelse'}>
                                         <FormattedMessage id="input.datoForInnleggelse.label" />
                                     </Label>
-                                    <div className={formik.errors.datoForInnleggelse && styles.datepickerContainer}>
-                                        <Datepicker
-                                            inputProps={{
-                                                name: 'datoForInnleggelse',
-                                                placeholder: 'dd.mm.åååå',
-                                            }}
-                                            value={formik.values.datoForInnleggelse ?? ''}
-                                            inputId={'datoForInnleggelse'}
-                                            onChange={(value) => {
-                                                if (!value) {
-                                                    return;
-                                                }
-                                                formik.setValues((v) => ({
-                                                    ...v,
-                                                    datoForInnleggelse: value,
-                                                }));
-                                            }}
-                                        />
-                                    </div>
+                                    <Datepicker
+                                        inputProps={{
+                                            name: 'datoForInnleggelse',
+                                            placeholder: 'dd.mm.åååå',
+                                            'aria-invalid': formik.errors.datoForInnleggelse ? true : false,
+                                        }}
+                                        value={formik.values.datoForInnleggelse ?? ''}
+                                        inputId={'datoForInnleggelse'}
+                                        onChange={(value) => {
+                                            if (!value) {
+                                                return;
+                                            }
+                                            formik.setValues((v) => ({
+                                                ...v,
+                                                datoForInnleggelse: value,
+                                            }));
+                                        }}
+                                    />
                                     {formik.errors.datoForInnleggelse && (
                                         <SkjemaelementFeilmelding>
                                             {formik.errors.datoForInnleggelse}
@@ -304,33 +299,32 @@ const BoOgOppholdINorge = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                         <Label htmlFor={'datoForUtskrivelse'}>
                                             <FormattedMessage id="input.datoForUtskrivelse.label" />
                                         </Label>
-                                        <div className={formik.errors.datoForUtskrivelse && styles.datepickerContainer}>
-                                            <Datepicker
-                                                inputProps={{
-                                                    name: 'datoForUtskrivelse',
-                                                    placeholder: 'dd.mm.åååå',
-                                                }}
-                                                value={formik.values.datoForUtskrivelse ?? ''}
-                                                inputId={'datoForUtskrivelse'}
-                                                onChange={(value) => {
-                                                    if (!value) {
-                                                        return;
-                                                    }
-                                                    formik.setValues((v) => ({
-                                                        ...v,
-                                                        datoForUtskrivelse: value,
-                                                    }));
-                                                }}
-                                                limitations={
-                                                    formik.values.datoForInnleggelse
-                                                        ? {
-                                                              minDate: formik.values.datoForInnleggelse,
-                                                          }
-                                                        : undefined
+                                        <Datepicker
+                                            inputProps={{
+                                                name: 'datoForUtskrivelse',
+                                                placeholder: 'dd.mm.åååå',
+                                                'aria-invalid': formik.errors.datoForUtskrivelse ? true : false,
+                                            }}
+                                            value={formik.values.datoForUtskrivelse ?? ''}
+                                            inputId={'datoForUtskrivelse'}
+                                            onChange={(value) => {
+                                                if (!value) {
+                                                    return;
                                                 }
-                                                disabled={formik.values.fortsattInnlagt}
-                                            />
-                                        </div>
+                                                formik.setValues((v) => ({
+                                                    ...v,
+                                                    datoForUtskrivelse: value,
+                                                }));
+                                            }}
+                                            limitations={
+                                                formik.values.datoForInnleggelse
+                                                    ? {
+                                                          minDate: formik.values.datoForInnleggelse,
+                                                      }
+                                                    : undefined
+                                            }
+                                            disabled={formik.values.fortsattInnlagt}
+                                        />
                                     </div>
                                     <Checkbox
                                         name={'fortsattInnlagt'}

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
@@ -75,17 +75,7 @@ const schema = yup.object<FormData>({
                             return fnrValidator.fnr(value).status === 'valid';
                         },
                     }),
-                erUførFlyktning: yup
-                    .boolean()
-                    .required()
-                    .typeError('Feltet må fylles ut')
-                    .test({
-                        name: 'erUførFlyktning',
-                        message: 'Feltet må fylles ut',
-                        test: function (value) {
-                            return value !== null;
-                        },
-                    }),
+                erUførFlyktning: yup.boolean().required().typeError('Feltet må fylles ut'),
             })
             .typeError('Feltene må fylles ut'),
         otherwise: yup.object<EPSFormData>().defined().nullable(),

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
@@ -56,7 +56,7 @@ const schema = yup.object<FormData>({
         }),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore: Siden EPS er Nullable, med verdier som er nullable, er det litt vanskelig å få riktig feilmelding på riktige inputs.
-    //Yup sin otherwise i when() fanger ikke denne opp noe godt.
+    //Yup sin otherwise i when() fanger ikke typingen godt nok, men valideringen i seg selv funker.
     ektefellePartnerSamboer: yup.object<EPSFormData>().when('delerBoligMed', {
         is: DelerBoligMed.EKTEMAKE_SAMBOER,
         then: yup

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
@@ -19,7 +19,7 @@ interface Props {
     id: string;
     onChange: (eps: EPSFormData) => void;
     value: Nullable<EPSFormData>;
-    feil?: string;
+    feil?: string | EPSFormData;
 }
 const EktefellePartnerSamboer = (props: Props) => {
     const epsFormData = props.value ?? { fnr: null, erUførFlyktning: null };
@@ -36,14 +36,14 @@ const EktefellePartnerSamboer = (props: Props) => {
                         fnr,
                     });
                 }}
-                feil={props.feil}
+                feil={(props.feil && typeof props.feil === 'object' && props.feil.fnr) || props.feil}
                 autoComplete="off"
             />
 
             <div className={styles.ufør}>
                 <RadioGruppe
                     legend={intl.formatMessage({ id: 'input.ektefelleEllerSamboerUførFlyktning.label' })}
-                    feil={epsFormData.erUførFlyktning === null && props.feil}
+                    feil={(props.feil && typeof props.feil === 'object' && props.feil.erUførFlyktning) || props.feil}
                 >
                     <Radio
                         checked={Boolean(epsFormData.erUførFlyktning)}

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
@@ -1,6 +1,6 @@
 import fnrValidator from '@navikt/fnrvalidator';
 import AlertStripe from 'nav-frontend-alertstriper';
-import { Input, Radio, RadioGruppe } from 'nav-frontend-skjema';
+import { Input, Radio, RadioGruppe, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
 import React, { useEffect, useState } from 'react';
 
 import * as personApi from '~api/personApi';
@@ -27,7 +27,7 @@ const EktefellePartnerSamboer = (props: Props) => {
     const intl = useI18n({ messages });
 
     return (
-        <div id={props.id} tabIndex={-1}>
+        <div id={props.id} tabIndex={-1} className={styles.epsFormContainer}>
             <FnrInput
                 fnr={epsFormData.fnr}
                 onFnrChange={(fnr) => {
@@ -36,14 +36,14 @@ const EktefellePartnerSamboer = (props: Props) => {
                         fnr,
                     });
                 }}
-                feil={(props.feil && typeof props.feil === 'object' && props.feil.fnr) || props.feil}
+                feil={typeof props.feil === 'object' && props.feil.fnr}
                 autoComplete="off"
             />
 
             <div className={styles.ufør}>
                 <RadioGruppe
                     legend={intl.formatMessage({ id: 'input.ektefelleEllerSamboerUførFlyktning.label' })}
-                    feil={(props.feil && typeof props.feil === 'object' && props.feil.erUførFlyktning) || props.feil}
+                    feil={typeof props.feil === 'object' && props.feil.erUførFlyktning}
                 >
                     <Radio
                         checked={Boolean(epsFormData.erUførFlyktning)}
@@ -69,6 +69,9 @@ const EktefellePartnerSamboer = (props: Props) => {
                     />
                 </RadioGruppe>
             </div>
+            {typeof props.feil === 'string' && (
+                <SkjemaelementFeilmelding>Feltene må fylles ut</SkjemaelementFeilmelding>
+            )}
         </div>
     );
 };

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/bo-og-opphold-i-norge.module.less
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/bo-og-opphold-i-norge.module.less
@@ -1,16 +1,32 @@
 @import '~/styles/variables.less';
 
+.innlagtPåInstitusjonFelter {
+    margin-bottom: @spacing;
+}
+
 .datoForInnleggelseContainer {
     margin-bottom: @spacing-s;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .datepickerContainer {
+        border: 2px solid #ba3a26;
+        border-radius: 7px;
+    }
 }
 
 .datoForUtskrivelseContainer {
     display: flex;
     align-items: flex-end;
-    margin-bottom: @spacing;
 
     .datoForUtskrivelse {
         margin-right: @spacing-s;
+
+        .datepickerContainer {
+            border: 2px solid #ba3a26;
+            border-radius: 7px;
+        }
     }
 }
 

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/bo-og-opphold-i-norge.module.less
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/bo-og-opphold-i-norge.module.less
@@ -9,11 +9,6 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-
-    .datepickerContainer {
-        border: 2px solid #ba3a26;
-        border-radius: 7px;
-    }
 }
 
 .datoForUtskrivelseContainer {
@@ -22,11 +17,6 @@
 
     .datoForUtskrivelse {
         margin-right: @spacing-s;
-
-        .datepickerContainer {
-            border: 2px solid #ba3a26;
-            border-radius: 7px;
-        }
     }
 }
 

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/ektefelle-partner-samboer.module.less
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/ektefelle-partner-samboer.module.less
@@ -1,5 +1,9 @@
 @import '~/styles/variables.less';
 
+.epsFormContainer {
+    margin-bottom: @spacing-s;
+}
+
 .fnrInput {
     display: flex;
     align-items: flex-end;

--- a/src/pages/søknad/steg/ektefelle/EktefellesFormue.tsx
+++ b/src/pages/søknad/steg/ektefelle/EktefellesFormue.tsx
@@ -1,6 +1,6 @@
 import { useFormik, FormikErrors } from 'formik';
 import { Knapp } from 'nav-frontend-knapper';
-import { Input, SkjemaelementFeilmelding, Feiloppsummering } from 'nav-frontend-skjema';
+import { Input, Feiloppsummering } from 'nav-frontend-skjema';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -191,6 +191,9 @@ const KjøretøyInputFelter = (props: {
                                 id={`${kjøretøyVerdiId}`}
                                 name={`${kjøretøyVerdiId}`}
                                 label={<FormattedMessage id="input.verdiPåKjøretøyTotal.label" />}
+                                feil={
+                                    errorForLinje && typeof errorForLinje === 'object' && errorForLinje.verdiPåKjøretøy
+                                }
                                 value={input.verdiPåKjøretøy}
                                 onChange={(e) => {
                                     props.onChange({
@@ -200,9 +203,6 @@ const KjøretøyInputFelter = (props: {
                                     });
                                 }}
                             />
-                            {errorForLinje && typeof errorForLinje === 'object' && (
-                                <SkjemaelementFeilmelding>{errorForLinje.verdiPåKjøretøy}</SkjemaelementFeilmelding>
-                            )}
                         </div>
                         <div>
                             <Input
@@ -210,6 +210,9 @@ const KjøretøyInputFelter = (props: {
                                 name={`${kjøretøyId}`}
                                 label={<FormattedMessage id="input.kjøretøyDeEier.label" />}
                                 value={input.kjøretøyDeEier}
+                                feil={
+                                    errorForLinje && typeof errorForLinje === 'object' && errorForLinje.kjøretøyDeEier
+                                }
                                 onChange={(e) =>
                                     props.onChange({
                                         index: idx,
@@ -218,9 +221,6 @@ const KjøretøyInputFelter = (props: {
                                     })
                                 }
                             />
-                            {errorForLinje && typeof errorForLinje === 'object' && (
-                                <SkjemaelementFeilmelding>{errorForLinje.kjøretøyDeEier}</SkjemaelementFeilmelding>
-                            )}
                         </div>
                         {props.arr.length > 1 && (
                             <Knapp
@@ -332,6 +332,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     name="verdiPåBolig"
                                     label={<FormattedMessage id="input.verdiPåBolig.label" />}
                                     value={formik.values.verdiPåBolig || ''}
+                                    feil={formik.errors.verdiPåBolig}
                                     onChange={formik.handleChange}
                                 />
                                 <Input
@@ -339,6 +340,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     name="boligBrukesTil"
                                     label={<FormattedMessage id="input.boligBrukesTil.label" />}
                                     value={formik.values.boligBrukesTil || ''}
+                                    feil={formik.errors.boligBrukesTil}
                                     onChange={formik.handleChange}
                                 />
                             </div>
@@ -369,6 +371,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     name="depositumsBeløp"
                                     label={<FormattedMessage id="input.depositumsBeløp.label" />}
                                     value={formik.values.depositumsBeløp || ''}
+                                    feil={formik.errors.depositumsBeløp}
                                     onChange={formik.handleChange}
                                 />
                                 <Input
@@ -376,6 +379,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     name="kontonummer"
                                     label={<FormattedMessage id="input.kontonummer.label" />}
                                     value={formik.values.kontonummer || ''}
+                                    feil={formik.errors.kontonummer}
                                     onChange={formik.handleChange}
                                 />
                             </div>
@@ -406,6 +410,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     name="verdiPåEiendom"
                                     label={<FormattedMessage id="input.verdiPåEiendom.label" />}
                                     value={formik.values.verdiPåEiendom || ''}
+                                    feil={formik.errors.verdiPåEiendom}
                                     onChange={formik.handleChange}
                                 />
                                 <Input
@@ -413,6 +418,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     name="eiendomBrukesTil"
                                     label={<FormattedMessage id="input.eiendomBrukesTil.label" />}
                                     value={formik.values.eiendomBrukesTil || ''}
+                                    feil={formik.errors.eiendomBrukesTil}
                                     onChange={formik.handleChange}
                                 />
                             </div>
@@ -494,6 +500,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 name="innskuddsBeløp"
                                 label={<FormattedMessage id="input.innskuddsBeløp.label" />}
                                 value={formik.values.innskuddsBeløp || ''}
+                                feil={formik.errors.innskuddsBeløp}
                                 onChange={formik.handleChange}
                             />
                         )}
@@ -520,6 +527,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 name="verdipapirBeløp"
                                 label={<FormattedMessage id="input.verdipapirBeløp.label" />}
                                 value={formik.values.verdipapirBeløp || ''}
+                                feil={formik.errors.verdipapirBeløp}
                                 onChange={formik.handleChange}
                             />
                         )}
@@ -546,6 +554,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 name="skylderNoenMegPengerBeløp"
                                 label={<FormattedMessage id="input.skylderNoenMegPengerBeløp.label" />}
                                 value={formik.values.skylderNoenMegPengerBeløp || ''}
+                                feil={formik.errors.skylderNoenMegPengerBeløp}
                                 onChange={formik.handleChange}
                             />
                         )}
@@ -572,6 +581,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 name="kontanterBeløp"
                                 label={<FormattedMessage id="input.kontanterBeløp.label" />}
                                 value={formik.values.kontanterBeløp || ''}
+                                feil={formik.errors.kontanterBeløp}
                                 onChange={formik.handleChange}
                             />
                         )}

--- a/src/pages/søknad/steg/ektefelle/EktefellesInntekt.tsx
+++ b/src/pages/søknad/steg/ektefelle/EktefellesInntekt.tsx
@@ -250,54 +250,64 @@ const EktefellesInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
     const pensjonsInntekter = () => {
         return (
             <div>
-                {formik.values.pensjonsInntekt.map((item: { ordning: string; beløp: string }, index: number) => (
-                    <div className={sharedStyles.inputFelterDiv} key={index}>
-                        <Input
-                            className={sharedStyles.inputFelt}
-                            label={<FormattedMessage id="input.pensjonsOrdning.label" />}
-                            value={item.ordning}
-                            onChange={(e) =>
-                                formik.setValues({
-                                    ...formik.values,
-                                    pensjonsInntekt: formik.values.pensjonsInntekt.map((i, idx) =>
-                                        idx === index ? { ordning: e.target.value, beløp: item.beløp } : i
-                                    ),
-                                })
-                            }
-                        />
-                        <Input
-                            className={sharedStyles.inputFelt}
-                            label={<FormattedMessage id="input.pensjonsBeløp.label" />}
-                            value={item.beløp}
-                            onChange={(e) =>
-                                formik.setValues({
-                                    ...formik.values,
-                                    pensjonsInntekt: formik.values.pensjonsInntekt.map((i, idx) =>
-                                        idx === index ? { ordning: item.ordning, beløp: e.target.value } : i
-                                    ),
-                                })
-                            }
-                        />
-                        {formik.values.pensjonsInntekt.length > 1 && (
-                            <Lenke
-                                href="#"
-                                className={sharedStyles.fjernFeltLink}
-                                onClick={(e) => {
-                                    e.preventDefault();
+                {formik.values.pensjonsInntekt.map((item: { ordning: string; beløp: string }, index: number) => {
+                    const feltId = (key: keyof typeof item) => `pensjonsInntekt[${index}].${key}`;
+                    const errorForLinje = Array.isArray(formik.errors.pensjonsInntekt)
+                        ? formik.errors.pensjonsInntekt[index]
+                        : null;
+                    return (
+                        <div className={sharedStyles.inputFelterDiv} key={index}>
+                            <Input
+                                id={feltId('ordning')}
+                                className={sharedStyles.inputFelt}
+                                label={<FormattedMessage id="input.pensjonsOrdning.label" />}
+                                value={item.ordning}
+                                feil={errorForLinje && typeof errorForLinje === 'object' && errorForLinje.ordning}
+                                onChange={(e) =>
                                     formik.setValues({
                                         ...formik.values,
-                                        pensjonsInntekt: [
-                                            ...formik.values.pensjonsInntekt.slice(0, index),
-                                            ...formik.values.pensjonsInntekt.slice(index + 1),
-                                        ],
-                                    });
-                                }}
-                            >
-                                Fjern felt
-                            </Lenke>
-                        )}
-                    </div>
-                ))}
+                                        pensjonsInntekt: formik.values.pensjonsInntekt.map((i, idx) =>
+                                            idx === index ? { ordning: e.target.value, beløp: item.beløp } : i
+                                        ),
+                                    })
+                                }
+                            />
+                            <Input
+                                id={feltId('beløp')}
+                                className={sharedStyles.inputFelt}
+                                label={<FormattedMessage id="input.pensjonsBeløp.label" />}
+                                value={item.beløp}
+                                feil={errorForLinje && typeof errorForLinje === 'object' && errorForLinje.beløp}
+                                onChange={(e) =>
+                                    formik.setValues({
+                                        ...formik.values,
+                                        pensjonsInntekt: formik.values.pensjonsInntekt.map((i, idx) =>
+                                            idx === index ? { ordning: item.ordning, beløp: e.target.value } : i
+                                        ),
+                                    })
+                                }
+                            />
+                            {formik.values.pensjonsInntekt.length > 1 && (
+                                <Lenke
+                                    href="#"
+                                    className={sharedStyles.fjernFeltLink}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        formik.setValues({
+                                            ...formik.values,
+                                            pensjonsInntekt: [
+                                                ...formik.values.pensjonsInntekt.slice(0, index),
+                                                ...formik.values.pensjonsInntekt.slice(index + 1),
+                                            ],
+                                        });
+                                    }}
+                                >
+                                    Fjern felt
+                                </Lenke>
+                            )}
+                        </div>
+                    );
+                })}
                 <div className={sharedStyles.leggTilFeltKnapp}>
                     <Knapp
                         onClick={(e) => {

--- a/src/pages/søknad/steg/ektefelle/EktefellesInntekt.tsx
+++ b/src/pages/søknad/steg/ektefelle/EktefellesInntekt.tsx
@@ -1,6 +1,5 @@
 import { useFormik, FormikErrors } from 'formik';
 import { Knapp } from 'nav-frontend-knapper';
-import Lenke from 'nav-frontend-lenker';
 import { Feiloppsummering, Input, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
@@ -288,8 +287,7 @@ const EktefellesInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 }
                             />
                             {formik.values.pensjonsInntekt.length > 1 && (
-                                <Lenke
-                                    href="#"
+                                <Knapp
                                     className={sharedStyles.fjernFeltLink}
                                     onClick={(e) => {
                                         e.preventDefault();
@@ -302,8 +300,8 @@ const EktefellesInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                         });
                                     }}
                                 >
-                                    Fjern felt
-                                </Lenke>
+                                    {intl.formatMessage({ id: 'button.fjernRad.label' })}
+                                </Knapp>
                             )}
                         </div>
                     );

--- a/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
+++ b/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
@@ -121,7 +121,7 @@ const ForVeileder = (props: { forrigeUrl: string; nesteUrl: string; søker: Pers
                     {formik.values.harSøkerMøttPersonlig === false && (
                         <RadioPanelGruppe
                             className={sharedStyles.sporsmal}
-                            feil={null}
+                            feil={formik.errors.harFullmektigEllerVerge}
                             legend={<FormattedMessage id={'input.fullmektigEllerVerge.label'} />}
                             name="fullmektigEllerVerge"
                             radios={[

--- a/src/pages/søknad/steg/formue/DinFormue.tsx
+++ b/src/pages/søknad/steg/formue/DinFormue.tsx
@@ -1,6 +1,6 @@
 import { useFormik, FormikErrors } from 'formik';
 import { Knapp } from 'nav-frontend-knapper';
-import { Input, SkjemaelementFeilmelding, Feiloppsummering } from 'nav-frontend-skjema';
+import { Input, Feiloppsummering } from 'nav-frontend-skjema';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -193,6 +193,9 @@ const KjøretøyInputFelter = (props: {
                                 name={kjøretøyId}
                                 label={<FormattedMessage id="input.kjøretøyDeEier.label" />}
                                 value={input.kjøretøyDeEier}
+                                feil={
+                                    errorForLinje && typeof errorForLinje === 'object' && errorForLinje.kjøretøyDeEier
+                                }
                                 onChange={(e) =>
                                     props.onChange({
                                         index: idx,
@@ -202,9 +205,6 @@ const KjøretøyInputFelter = (props: {
                                 }
                                 autoComplete="off"
                             />
-                            {errorForLinje && typeof errorForLinje === 'object' && (
-                                <SkjemaelementFeilmelding>{errorForLinje.kjøretøyDeEier}</SkjemaelementFeilmelding>
-                            )}
                         </div>
                         <div>
                             <Input
@@ -212,6 +212,9 @@ const KjøretøyInputFelter = (props: {
                                 name={kjøretøyVerdiId}
                                 label={<FormattedMessage id="input.verdiPåKjøretøyTotal.label" />}
                                 value={input.verdiPåKjøretøy}
+                                feil={
+                                    errorForLinje && typeof errorForLinje === 'object' && errorForLinje.verdiPåKjøretøy
+                                }
                                 onChange={(e) => {
                                     props.onChange({
                                         index: idx,
@@ -221,9 +224,6 @@ const KjøretøyInputFelter = (props: {
                                 }}
                                 autoComplete="off"
                             />
-                            {errorForLinje && typeof errorForLinje === 'object' && (
-                                <SkjemaelementFeilmelding>{errorForLinje.verdiPåKjøretøy}</SkjemaelementFeilmelding>
-                            )}
                         </div>
                         {props.arr.length > 1 && (
                             <Knapp

--- a/src/pages/søknad/steg/inntekt/Inntekt.tsx
+++ b/src/pages/søknad/steg/inntekt/Inntekt.tsx
@@ -336,7 +336,7 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                         });
                                     }}
                                 >
-                                    Fjern felt
+                                    {intl.formatMessage({ id: 'button.fjernRad.label' })}
                                 </Knapp>
                             )}
                         </div>

--- a/src/pages/søknad/steg/inntekt/Inntekt.tsx
+++ b/src/pages/søknad/steg/inntekt/Inntekt.tsx
@@ -286,6 +286,9 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
             <div>
                 {formik.values.pensjonsInntekt.map((item: { ordning: string; beløp: string }, index: number) => {
                     const feltId = (key: keyof typeof item) => `pensjonsInntekt[${index}].${key}`;
+                    const errorForLinje = Array.isArray(formik.errors.pensjonsInntekt)
+                        ? formik.errors.pensjonsInntekt[index]
+                        : null;
                     return (
                         <div className={sharedStyles.inputFelterDiv} key={index}>
                             <Input
@@ -293,6 +296,7 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 className={sharedStyles.inputFelt}
                                 label={<FormattedMessage id="input.pensjonsOrdning.label" />}
                                 value={item.ordning}
+                                feil={errorForLinje && typeof errorForLinje === 'object' && errorForLinje.ordning}
                                 onChange={(e) =>
                                     formik.setValues({
                                         ...formik.values,
@@ -308,6 +312,7 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 className={sharedStyles.inputFelt}
                                 label={<FormattedMessage id="input.pensjonsBeløp.label" />}
                                 value={item.beløp}
+                                feil={errorForLinje && typeof errorForLinje === 'object' && errorForLinje.beløp}
                                 onChange={(e) =>
                                     formik.setValues({
                                         ...formik.values,

--- a/src/pages/søknad/steg/inntekt/Inntekt.tsx
+++ b/src/pages/søknad/steg/inntekt/Inntekt.tsx
@@ -1,6 +1,5 @@
 import { useFormik, FormikErrors } from 'formik';
 import { Knapp } from 'nav-frontend-knapper';
-import Lenke from 'nav-frontend-lenker';
 import { Feiloppsummering, Input, SkjemaelementFeilmelding } from 'nav-frontend-skjema';
 import * as React from 'react';
 import { FormattedMessage, RawIntlProvider } from 'react-intl';
@@ -324,8 +323,7 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                 autoComplete="off"
                             />
                             {formik.values.pensjonsInntekt.length > 1 && (
-                                <Lenke
-                                    href="#"
+                                <Knapp
                                     className={sharedStyles.fjernFeltLink}
                                     onClick={(e) => {
                                         e.preventDefault();
@@ -339,7 +337,7 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string }) => {
                                     }}
                                 >
                                     Fjern felt
-                                </Lenke>
+                                </Knapp>
                             )}
                         </div>
                     );

--- a/src/pages/søknad/steg/kvittering/Kvittering.tsx
+++ b/src/pages/søknad/steg/kvittering/Kvittering.tsx
@@ -32,7 +32,11 @@ const Kvittering = () => {
                         return null;
                     },
                     () => {
-                        return <NavFrontendSpinner />;
+                        return (
+                            <div className={styles.senderSøknadSpinnerContainer}>
+                                <NavFrontendSpinner />
+                            </div>
+                        );
                     },
                     () => {
                         return (

--- a/src/pages/søknad/steg/kvittering/kvittering.module.less
+++ b/src/pages/søknad/steg/kvittering/kvittering.module.less
@@ -11,6 +11,11 @@
     margin-right: @spacing;
 }
 
+.senderSøknadSpinnerContainer {
+    display: flex;
+    justify-content: center;
+}
+
 .tilVeileder {
     margin-top: @spacing-l;
     h3 {

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -7,6 +7,7 @@
 @spacing: 2rem;
 @spacing-l: 2.5rem;
 @spacing-xl: 4rem;
+@spacing-xxl: 80px;
 
 @navgra60: #78706a;
 @navbla: #0067c5;


### PR DESCRIPTION
- Bottom margin på Lukksøknad, så den blir lik alle andre sider. 

- EPS i boforhold får validering på feltene de tilhører, istedenfor å bare vise 'ugyldig informasjon' på fødselsnummeret. 
   Samtidig bevarer feilmeldinger om at de må fylles ut om EPS i seg selv er null. 
- dato for utskrivelse har en test som sjekker om feltet er fyllt inn, og gir passende feilmelding om det. 

- Datepicker har ikke feil prop av noe slag. Wrapper den i en div som gir rød ramme hvis det er feil. 

- Litt styling fix

- Lagt til manglende feil-props på inputfelter