### PR TITLE
Gotovedtak fix

### DIFF
--- a/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
@@ -101,7 +101,10 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
         };
 
         if (eqFlyktning.equals(flyktningValues, props.behandling.behandlingsinformasjon.flyktning)) {
-            if (props.behandling.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG) {
+            if (
+                props.behandling.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG ||
+                props.behandling.status === Behandlingsstatus.SIMULERT
+            ) {
                 goToVedtak();
                 return;
             }
@@ -141,7 +144,7 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
         validateOnChange: hasSubmitted,
     });
     const history = useHistory();
-
+    console.log(props.behandling);
     return (
         <Vurdering tittel={intl.formatMessage({ id: 'page.tittel' })}>
             {{

--- a/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
@@ -144,7 +144,7 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
         validateOnChange: hasSubmitted,
     });
     const history = useHistory();
-    console.log(props.behandling);
+
     return (
         <Vurdering tittel={intl.formatMessage({ id: 'page.tittel' })}>
             {{


### PR DESCRIPTION
https://trello.com/c/obX1LLGl/519-feil-g%C3%A5r-ikke-til-vedtaket-n%C3%A5r-man-trykker-g%C3%A5-til-vedtaket-p%C3%A5-flyktning-steget-hvis-en-behandling-er-sendt-tilbake-fra-attesteri

Tenkte det kunne kanskje vært åpent for en liten diskusjon for denne endringen. Gå til vedtak knappen fungerer litt rart når man sender tilbake fra attestering. Det viser seg slik at når man sender tilbake fra attestering, får behandlingen statusen SIMULERT. jeg antar at det er pga vi ikke har en måte å vite fra hvilken avslags-status den kom fra (vilkår, beregning), og vil da ikke gi feil avslags-status (selv om jeg mener at å få simulert er også feil). 

Man har mulighet å legge til 'hva var min siste status før X skjedde', men er kanskje en litt mer inngripende endring. 

Resultatet av denne endringen, kommer til å bli at hvis man går til flyktning steget for en eller annen grunn, så går vi til vedtak, selv om det ikke er en 'tidlig avslag'