### PR TITLE
Bruk fødselsdato til å kalkulere alder

### DIFF
--- a/src/api/personApi.ts
+++ b/src/api/personApi.ts
@@ -42,6 +42,8 @@ export interface Person {
     aktorId: string;
     navn: Navn;
     kjønn: Nullable<Kjønn>;
+    fødselsdato: Nullable<Date>;
+    alder: Nullable<number>;
     telefonnummer: {
         landskode: string;
         nummer: string;

--- a/src/components/PersonAdvarsel.tsx
+++ b/src/components/PersonAdvarsel.tsx
@@ -2,7 +2,6 @@ import Etikett, { EtikettBaseProps } from 'nav-frontend-etiketter';
 import * as React from 'react';
 
 import { Person, Adressebeskyttelse } from '~api/personApi';
-import { EPSMedAlder } from '~pages/saksbehandling/steg/sats/utils';
 
 import styles from './personAdvarsel.module.less';
 
@@ -11,7 +10,7 @@ interface EtikettInfo {
     type: EtikettBaseProps['type'];
 }
 
-export const PersonAdvarsel = (props: { person: Person | EPSMedAlder }) => {
+export const PersonAdvarsel = (props: { person: Person }) => {
     const { adressebeskyttelse, skjermet } = props.person;
     const etiketter: EtikettInfo[] = [];
 

--- a/src/components/Personkort.tsx
+++ b/src/components/Personkort.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 
 import { Person, Kjønn } from '~api/personApi';
 import { KjønnKvinne, KjønnMann, KjønnUkjent } from '~assets/Icons';
-import { Nullable } from '~lib/types';
-import { EPSMedAlder } from '~pages/saksbehandling/steg/sats/utils';
 
 import { showName } from '../features/person/personUtils';
 
@@ -27,43 +25,10 @@ export const Personkort = (props: { person: Person }) => {
             <div>
                 <p>{showName(props.person.navn)}</p>
                 <div>
-                    <span>{`${props.person.fnr} - `}</span>
-                    <span>{`${props.person.fnr.substring(0, 2)}.`}</span>
-                    <span>{`${props.person.fnr.substring(2, 4)}.`}</span>
-                    <span>{`${props.person.fnr.substring(4, 6)}`}</span>
+                    <span>{`${props.person.fnr}, `}</span>
+                    <span>{props.person.alder} år</span>
                 </div>
                 <PersonAdvarsel person={props.person} />
-            </div>
-        </div>
-    );
-};
-
-export const PersonkortEPS = (props: { eps: Nullable<EPSMedAlder> }) => {
-    if (!props.eps || !props.eps.navn || !props.eps.fnr) {
-        return null;
-    }
-
-    return (
-        <div className={styles.personkortContainer}>
-            <div>
-                <span className={styles.personkortSVG}>
-                    {props.eps.kjønn === Kjønn.Kvinne ? (
-                        <KjønnKvinne />
-                    ) : props.eps.kjønn === Kjønn.Mann ? (
-                        <KjønnMann />
-                    ) : (
-                        <KjønnUkjent />
-                    )}
-                </span>
-            </div>
-            <div>
-                <p>{showName(props.eps.navn)}</p>
-                <div>
-                    <span>{`${props.eps.fnr.substring(0, 6)} `}</span>
-                    <span>{`${props.eps.fnr.substring(6, 11)}, `}</span>
-                    <span>{props.eps.alder} år</span>
-                </div>
-                <PersonAdvarsel person={props.eps} />
             </div>
         </div>
     );

--- a/src/features/behandling/behandlingUtils.ts
+++ b/src/features/behandling/behandlingUtils.ts
@@ -173,7 +173,7 @@ export const eqPersonligOppmøte: Eq<Nullable<PersonligOppmøte>> = {
 
 export const eqBosituasjon: Eq<Nullable<Bosituasjon>> = {
     equals: (sats1, sats2) =>
-        sats1?.epsFnr === sats2?.epsFnr &&
+        sats1?.epsAlder === sats2?.epsAlder &&
         sats1?.delerBolig === sats2?.delerBolig &&
         sats1?.ektemakeEllerSamboerUførFlyktning === sats2?.ektemakeEllerSamboerUførFlyktning &&
         sats1?.begrunnelse === sats2?.begrunnelse,

--- a/src/pages/saksbehandling/steg/faktablokk/faktablokker/SatsFaktablokk.tsx
+++ b/src/pages/saksbehandling/steg/faktablokk/faktablokker/SatsFaktablokk.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 
 import { useI18n } from '~lib/hooks';
 import { Nullable } from '~lib/types';
+import { Ektefelle } from '~types/Behandlingsinformasjon';
 
-import { EPSMedAlder, setSatsFaktablokk } from '../../sats/utils';
+import { setSatsFaktablokk } from '../../sats/utils';
 import Faktablokk from '../Faktablokk';
 
 import messages from './faktablokker-nb';
 import { FaktablokkProps } from './faktablokkUtils';
 
 interface SatsProps extends FaktablokkProps {
-    eps: Nullable<EPSMedAlder>;
+    eps: Nullable<Ektefelle>;
 }
 
 const SatsFaktablokk = (props: SatsProps) => {

--- a/src/pages/saksbehandling/steg/formue/Formue.tsx
+++ b/src/pages/saksbehandling/steg/formue/Formue.tsx
@@ -125,10 +125,15 @@ const Formue = (props: VilkårsvurderingBaseProps) => {
                               fnr: eps.value.fnr,
                               navn: eps.value.navn,
                               kjønn: eps.value.kjønn,
+                              fødselsdato: eps.value.fødselsdato,
+                              alder: eps.value.alder,
                               adressebeskyttelse: eps.value.adressebeskyttelse,
                               skjermet: eps.value.skjermet,
                           }
-                        : { fnr: values.epsFnr, navn: null, kjønn: null, adressebeskyttelse: null, skjermet: null },
+                        : {
+                              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                              fnr: values.epsFnr!,
+                          },
                 },
             })
         );

--- a/src/pages/saksbehandling/steg/sats/utils.ts
+++ b/src/pages/saksbehandling/steg/sats/utils.ts
@@ -1,27 +1,13 @@
-import { differenceInYears, parse } from 'date-fns';
 import { IntlShape } from 'react-intl';
 
 import { DelerBoligMed } from '~features/søknad/types';
 import { Nullable } from '~lib/types';
 import { Ektefelle } from '~types/Behandlingsinformasjon';
-import { EktefellePartnerSamboer, SøknadInnhold } from '~types/Søknad';
+import { SøknadInnhold } from '~types/Søknad';
 
 import { delerBoligMedFormatted } from '../sharedUtils';
 
-export interface EPSMedAlder extends Ektefelle {
-    alder: Nullable<number>;
-}
-
-export const hentEktefellesAlder = (ektefelle: EktefellePartnerSamboer) => {
-    const today = new Date();
-    const parseEktefellesFødselsdato = (ektefelleFødselsdato: string, format: string) =>
-        parse(ektefelleFødselsdato, format, new Date());
-
-    const fødselsdato = ektefelle.fnr.substr(0, 6);
-    return differenceInYears(today, parseEktefellesFødselsdato(fødselsdato, 'ddMMyy'));
-};
-
-export const setSatsFaktablokk = (søknadinnhold: SøknadInnhold, intl: IntlShape, eps: Nullable<EPSMedAlder>) => {
+export const setSatsFaktablokk = (søknadinnhold: SøknadInnhold, intl: IntlShape, eps: Nullable<Ektefelle>) => {
     const faktablokk = [];
 
     if (eps) {

--- a/src/pages/saksbehandling/vilkårsOppsummering/VilkårsOppsummering.tsx
+++ b/src/pages/saksbehandling/vilkårsOppsummering/VilkårsOppsummering.tsx
@@ -5,7 +5,7 @@ import VilkårvurderingStatusIcon from '~components/VilkårvurderingStatusIcon';
 import { mapToVilkårsinformasjon, vilkårTittelFormatted } from '~features/saksoversikt/utils';
 import { useI18n } from '~lib/hooks';
 import { Nullable } from '~lib/types';
-import { Behandlingsinformasjon } from '~types/Behandlingsinformasjon';
+import { Behandlingsinformasjon, Ektefelle } from '~types/Behandlingsinformasjon';
 import { Sats } from '~types/Sats';
 import { SøknadInnhold } from '~types/Søknad';
 import { Vilkårtype, VilkårVurderingStatus } from '~types/Vilkårsvurdering';
@@ -19,7 +19,6 @@ import PersonligOppmøteFaktablokk from '../steg/faktablokk/faktablokker/Personl
 import SatsFaktablokk from '../steg/faktablokk/faktablokker/SatsFaktablokk';
 import UførhetFaktablokk from '../steg/faktablokk/faktablokker/UførhetFaktablokk';
 import UtenlandsOppholdFaktablokk from '../steg/faktablokk/faktablokker/UtenlandsOppholdFaktablokk';
-import { EPSMedAlder } from '../steg/sats/utils';
 
 import messages from './vilkårsOppsummering-nb';
 import styles from './vilkårsOppsummering.module.less';
@@ -55,7 +54,7 @@ const VilkårsOppsummering = (props: {
                     vilkårFaktablokk={
                         <SatsFaktablokk
                             søknadInnhold={props.søknadInnhold}
-                            eps={props.behandlingsinformasjon.ektefelle as Nullable<EPSMedAlder>}
+                            eps={props.behandlingsinformasjon.ektefelle as Nullable<Ektefelle>}
                             brukUndertittel
                         />
                     }

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
@@ -125,6 +125,7 @@ const FnrInput = ({ inputId, fnr, onFnrChange, feil, autoComplete }: FnrInputPro
             />
 
             {person && (
+                // TODO: Burde bruke personkort?
                 <div className={styles.result}>
                     <GenderIcon kjønn={person.kjønn} />
                     <p className={styles.name}>{showName(person.navn)}</p>

--- a/src/types/Behandlingsinformasjon.ts
+++ b/src/types/Behandlingsinformasjon.ts
@@ -1,4 +1,4 @@
-import { Adressebeskyttelse, Kjønn, Navn } from '~api/personApi';
+import { Person } from '~api/personApi';
 import { Nullable } from '~lib/types';
 
 import { Sats } from './Sats';
@@ -119,16 +119,15 @@ export enum PersonligOppmøteStatus {
 }
 
 export interface Bosituasjon {
-    epsFnr: Nullable<string>;
+    epsAlder: Nullable<number>;
     delerBolig: Nullable<boolean>;
     ektemakeEllerSamboerUførFlyktning: Nullable<boolean>;
     begrunnelse: Nullable<string>;
 }
 
-export interface Ektefelle {
-    fnr: Nullable<string>;
-    navn: Nullable<Navn>;
-    kjønn: Nullable<Kjønn>;
-    adressebeskyttelse: Nullable<Adressebeskyttelse>;
-    skjermet: Nullable<boolean>;
+export type Ektefelle = Person | Pick<Person, 'fnr'>;
+// Ektefelle vil i noen tilfeller kun ha fnr, siden vi oppdaget diskresjonskode e.l.
+// når vi slo opp personen og da kun lagrer fnr og avbryter saksbehandlingen
+export function isPerson(ektefelle: Ektefelle): ektefelle is Person {
+    return 'navn' in ektefelle;
 }


### PR DESCRIPTION
Rydder også opp en del rariteter rundt ektefelle, bl.a. at alder ble satt på i en roundtrip til backend, og fjerner et nå unødvendig `EPSMedAlder`-objekt og spesifikt personkort.