### PR TITLE
Håndter false som nei i info fra søknaden om lovlig opphold i Norge

### DIFF
--- a/src/pages/saksbehandling/steg/faktablokk/faktablokker/LovligOppholdFaktablokk.tsx
+++ b/src/pages/saksbehandling/steg/faktablokk/faktablokker/LovligOppholdFaktablokk.tsx
@@ -65,7 +65,7 @@ function createListOfFakta(intl: IntlShape, søknadsInnhold: SøknadInnhold) {
 }
 
 const booleanToJaNei = (verdi: Nullable<boolean>, tittel: string, intl: IntlShape) => {
-    if (!verdi) return { tittel: tittel, verdi: '' };
+    if (verdi == null) return { tittel: tittel, verdi: '' };
 
     return {
         tittel: tittel,


### PR DESCRIPTION
False ble her tidligere maskert som om spørsmålet ikke hadde blitt besvart.