### PR TITLE
Vis opphold-i-utlandet-datoblokker kun dersom datoer ble fylt inn i søknad

### DIFF
--- a/src/pages/saksbehandling/steg/faktablokk/faktablokker/UtenlandsOppholdFaktablokk.tsx
+++ b/src/pages/saksbehandling/steg/faktablokk/faktablokker/UtenlandsOppholdFaktablokk.tsx
@@ -7,7 +7,7 @@ import { kalkulerTotaltAntallDagerIUtlandet, Utlandsdatoer } from '~lib/dateUtil
 import { useI18n } from '~lib/hooks';
 import { Nullable } from '~lib/types';
 
-import Faktablokk from '../Faktablokk';
+import Faktablokk, { Fakta } from '../Faktablokk';
 
 import messages from './faktablokker-nb';
 import styles from './faktablokker.module.less';
@@ -16,32 +16,42 @@ import { FaktablokkProps } from './faktablokkUtils';
 const UtenlandsOppholdFaktablokk = (props: FaktablokkProps) => {
     const intl = useI18n({ messages });
 
+    const fakta: Fakta[] = [
+        {
+            tittel: intl.formatMessage({ id: 'utenlandsOpphold.antallDagerSiste90' }),
+            verdi: kalkulerTotaltAntallDagerIUtlandet(
+                props.søknadInnhold.utenlandsopphold.registrertePerioder
+            ).toString(),
+        },
+        {
+            tittel: intl.formatMessage({ id: 'utenlandsOpphold.antallDagerPlanlagt' }),
+            verdi: kalkulerTotaltAntallDagerIUtlandet(
+                props.søknadInnhold.utenlandsopphold.planlagtePerioder
+            ).toString(),
+        },
+    ];
+
+    const datoerSiste90 = props.søknadInnhold.utenlandsopphold.registrertePerioder;
+    if (datoerSiste90 && datoerSiste90.length > 0) {
+        fakta.push({
+            tittel: intl.formatMessage({ id: 'utenlandsOpphold.datoerSiste90' }),
+            verdi: visDatoer(datoerSiste90, intl),
+        });
+    }
+
+    const datoerPlanlagt = props.søknadInnhold.utenlandsopphold.planlagtePerioder;
+    if (datoerPlanlagt && datoerPlanlagt.length > 0) {
+        fakta.push({
+            tittel: intl.formatMessage({ id: 'utenlandsOpphold.datoerPlanlagt' }),
+            verdi: visDatoer(datoerPlanlagt, intl),
+        });
+    }
+
     return (
         <Faktablokk
             tittel={intl.formatMessage({ id: 'display.fraSøknad' })}
             brukUndertittel={props.brukUndertittel}
-            fakta={[
-                {
-                    tittel: intl.formatMessage({ id: 'utenlandsOpphold.antallDagerSiste90' }),
-                    verdi: kalkulerTotaltAntallDagerIUtlandet(
-                        props.søknadInnhold.utenlandsopphold.registrertePerioder
-                    ).toString(),
-                },
-                {
-                    tittel: intl.formatMessage({ id: 'utenlandsOpphold.antallDagerPlanlagt' }),
-                    verdi: kalkulerTotaltAntallDagerIUtlandet(
-                        props.søknadInnhold.utenlandsopphold.planlagtePerioder
-                    ).toString(),
-                },
-                {
-                    tittel: intl.formatMessage({ id: 'utenlandsOpphold.datoerSiste90' }),
-                    verdi: visDatoer(props.søknadInnhold.utenlandsopphold.registrertePerioder, intl),
-                },
-                {
-                    tittel: intl.formatMessage({ id: 'utenlandsOpphold.datoerPlanlagt' }),
-                    verdi: visDatoer(props.søknadInnhold.utenlandsopphold.planlagtePerioder, intl),
-                },
-            ]}
+            fakta={fakta}
         />
     );
 };


### PR DESCRIPTION
Før viste vi noe ala 
```
Planlagt oppholdet i utlandet: Ingen registrerte perioder
Datoer for opphold i siste 90 dager: Ingen registrerte perioder
```
Mens nå viser vi heller ingenting dersom det ikke ble fylt inn datoer for én eller begge av periodene.