### PR TITLE
Vis en melding dersom det ikke finnes informasjon i DKIF/KRR

### DIFF
--- a/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
+++ b/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
@@ -81,8 +81,14 @@ const ForVeileder = (props: { forrigeUrl: string; nesteUrl: string; søker: Pers
                     <Panel border className={styles.panelMargin}>
                         <div className={styles.infoboks}>
                             <p className={styles.boldP}>{intl.formatMessage({ id: 'info.kontaktinfo.tittel' })}</p>
-                            <p>{telefonnummerKrr}</p>
-                            <p>{epostKrr}</p>
+                            {kontaktinfo ? (
+                                <div>
+                                    <p>{telefonnummerKrr}</p>
+                                    <p>{epostKrr}</p>
+                                </div>
+                            ) : (
+                                <p>{intl.formatMessage({ id: 'info.kontaktinfo.mangler' })}</p>
+                            )}
                         </div>
                         <div className={styles.infoboks}>
                             <p className={styles.boldP}>{intl.formatMessage({ id: 'info.telefon.tittel' })}</p>
@@ -96,7 +102,11 @@ const ForVeileder = (props: { forrigeUrl: string; nesteUrl: string; søker: Pers
                     <Panel border className={styles.panelMargin}>
                         <div className={styles.infoboks}>
                             <p className={styles.boldP}>{intl.formatMessage({ id: 'info.kontaktform.tittel' })}</p>
-                            <p>{digitalBruker ? 'Digital' : 'Reservert mot digital kommunikasjon'}</p>
+                            {kontaktinfo ? (
+                                <p>{digitalBruker ? 'Digital' : 'Reservert mot digital kommunikasjon'}</p>
+                            ) : (
+                                <p>{intl.formatMessage({ id: 'info.kontaktinfo.mangler' })}</p>
+                            )}
                         </div>
                         <AlertStripeInfo className={styles.marginTopXSS}>
                             {intl.formatMessage({ id: 'info.kontaktform.body' })}

--- a/src/pages/søknad/steg/for-veileder/forVeileder-nb.ts
+++ b/src/pages/søknad/steg/for-veileder/forVeileder-nb.ts
@@ -1,5 +1,6 @@
 export default {
     'info.kontaktinfo.tittel': 'Kontaktinformasjon i kontakt- og reservasjonsregisteret',
+    'info.kontaktinfo.mangler': 'Finner ingen registrert informasjon i kontakt- og reservasjonsregisteret',
     'info.telefon.tittel': 'Telefonnummer i NAV',
     'info.telefon.body':
         'Hvis telefonnummer eller e-post ikke stemmer må dette entes oppdateres i kontakt-og reservasjonsregisteret eller registreres i NAV sin persondataløsning (PDL)',


### PR DESCRIPTION
Hvis det mangler kontaktinfo i dag, så juger visningen litt og det er vanskelig for veileder å se at det mangler kontaktinfo i KRR.