### PR TITLE
Fiks gruppering av perioder i simulering

### DIFF
--- a/src/pages/saksbehandling/steg/beregningOgSimulering/simulering/simulering.tsx
+++ b/src/pages/saksbehandling/steg/beregningOgSimulering/simulering/simulering.tsx
@@ -49,6 +49,7 @@ const Utbetalingssimulering = (props: { simulering: Simulering }) => {
                 props.simulering.perioder,
                 groupWhile(
                     (curr, prev) =>
+                        curr.bruttoYtelse === prev.bruttoYtelse &&
                         DateFns.differenceInCalendarMonths(
                             DateFns.parseISO(curr.fraOgMed),
                             DateFns.parseISO(prev.tilOgMed)


### PR DESCRIPTION
Vi klarte visst å glemme å også gruppere på beløpet.