### PR TITLE
Fiks bruk av deprecated functions fra fp-ts

### DIFF
--- a/src/lib/arrayUtils.test.ts
+++ b/src/lib/arrayUtils.test.ts
@@ -1,4 +1,4 @@
-import { eqNumber } from 'fp-ts/lib/Eq';
+import { Eq as eqNumber } from 'fp-ts/lib/number';
 
 import { groupWhile, groupByEq, spanLeftWithIndex } from './arrayUtils';
 import { pipe } from './fp';

--- a/src/lib/arrayUtils.test.ts
+++ b/src/lib/arrayUtils.test.ts
@@ -1,11 +1,11 @@
-import { Eq as eqNumber } from 'fp-ts/lib/number';
+import * as N from 'fp-ts/lib/number';
 
 import { groupWhile, groupByEq, spanLeftWithIndex } from './arrayUtils';
 import { pipe } from './fp';
 
 describe('groupByEq', () => {
     it('returns an array with each group as array', () =>
-        expect(groupByEq(eqNumber)([1, 1, 2, 2, 3, 3, 4, 4])).toEqual([
+        expect(groupByEq(N.Eq)([1, 1, 2, 2, 3, 3, 4, 4])).toEqual([
             [1, 1],
             [2, 2],
             [3, 3],
@@ -13,7 +13,7 @@ describe('groupByEq', () => {
         ]));
 
     it('returns an array with each group as array 2', () =>
-        expect(groupByEq(eqNumber)([1, 1, 3, 3, 1, 1])).toEqual([
+        expect(groupByEq(N.Eq)([1, 1, 3, 3, 1, 1])).toEqual([
             [1, 1],
             [3, 3],
             [1, 1],

--- a/src/lib/arrayUtils.ts
+++ b/src/lib/arrayUtils.ts
@@ -1,6 +1,6 @@
 import { chop, spanLeft } from 'fp-ts/lib/Array';
 import { Eq } from 'fp-ts/lib/Eq';
-import { pipe } from 'fp-ts/lib/pipeable';
+import { pipe } from 'fp-ts/lib/function';
 
 /**
  * Grupperer elementer som er like (med @param eqT)

--- a/src/pages/saksbehandling/steg/beregningOgSimulering/beregning/Beregning.tsx
+++ b/src/pages/saksbehandling/steg/beregningOgSimulering/beregning/Beregning.tsx
@@ -2,8 +2,11 @@ import * as RemoteData from '@devexperts/remote-data-ts';
 import { formatISO } from 'date-fns';
 import { useFormik } from 'formik';
 import { getEq } from 'fp-ts/Array';
-import { eqBoolean, eqDate, eqString, getStructEq } from 'fp-ts/lib/Eq';
+import { Eq as eqBoolean } from 'fp-ts/lib/boolean';
+import { Eq as eqDate } from 'fp-ts/lib/Date';
+import { struct } from 'fp-ts/lib/Eq';
 import { pipe } from 'fp-ts/lib/function';
+import { Eq as eqString } from 'fp-ts/lib/string';
 import AlertStripe, { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { Feiloppsummering, Textarea } from 'nav-frontend-skjema';
@@ -367,18 +370,18 @@ function erFradragLike(fradrag: Fradrag[] | undefined, formFradrag: FradragFormD
     return getEq(eqFradragFormData).equals(formFradrag, fradragFraBasen);
 }
 
-const eqUtenlandskInntekt = getStructEq<UtenlandskInntektFormData>({
+const eqUtenlandskInntekt = struct<UtenlandskInntektFormData>({
     beløpIUtenlandskValuta: eqString,
     valuta: eqString,
     kurs: eqString,
 });
 
-const eqPeriode = getStructEq<{ fraOgMed: Nullable<Date>; tilOgMed: Nullable<Date> }>({
+const eqPeriode = struct<{ fraOgMed: Nullable<Date>; tilOgMed: Nullable<Date> }>({
     fraOgMed: eqNullable(eqDate),
     tilOgMed: eqNullable(eqDate),
 });
 
-const eqFradragFormData = getStructEq<FradragFormData>({
+const eqFradragFormData = struct<FradragFormData>({
     type: eqNullable(eqString),
     beløp: eqNullable(eqString),
     fraUtland: eqBoolean,

--- a/src/pages/saksbehandling/steg/beregningOgSimulering/beregning/Beregning.tsx
+++ b/src/pages/saksbehandling/steg/beregningOgSimulering/beregning/Beregning.tsx
@@ -2,11 +2,11 @@ import * as RemoteData from '@devexperts/remote-data-ts';
 import { formatISO } from 'date-fns';
 import { useFormik } from 'formik';
 import { getEq } from 'fp-ts/Array';
-import { Eq as eqBoolean } from 'fp-ts/lib/boolean';
-import { Eq as eqDate } from 'fp-ts/lib/Date';
+import * as B from 'fp-ts/lib/boolean';
+import * as D from 'fp-ts/lib/Date';
 import { struct } from 'fp-ts/lib/Eq';
 import { pipe } from 'fp-ts/lib/function';
-import { Eq as eqString } from 'fp-ts/lib/string';
+import * as S from 'fp-ts/lib/string';
 import AlertStripe, { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { Feiloppsummering, Textarea } from 'nav-frontend-skjema';
@@ -371,22 +371,22 @@ function erFradragLike(fradrag: Fradrag[] | undefined, formFradrag: FradragFormD
 }
 
 const eqUtenlandskInntekt = struct<UtenlandskInntektFormData>({
-    beløpIUtenlandskValuta: eqString,
-    valuta: eqString,
-    kurs: eqString,
+    beløpIUtenlandskValuta: S.Eq,
+    valuta: S.Eq,
+    kurs: S.Eq,
 });
 
 const eqPeriode = struct<{ fraOgMed: Nullable<Date>; tilOgMed: Nullable<Date> }>({
-    fraOgMed: eqNullable(eqDate),
-    tilOgMed: eqNullable(eqDate),
+    fraOgMed: eqNullable(D.Eq),
+    tilOgMed: eqNullable(D.Eq),
 });
 
 const eqFradragFormData = struct<FradragFormData>({
-    type: eqNullable(eqString),
-    beløp: eqNullable(eqString),
-    fraUtland: eqBoolean,
+    type: eqNullable(S.Eq),
+    beløp: eqNullable(S.Eq),
+    fraUtland: B.Eq,
     utenlandskInntekt: eqUtenlandskInntekt,
-    tilhørerEPS: eqBoolean,
+    tilhørerEPS: B.Eq,
     periode: eqNullable(eqPeriode),
 });
 

--- a/src/types/Beregning.ts
+++ b/src/types/Beregning.ts
@@ -1,7 +1,7 @@
 import * as Array from 'fp-ts/lib/Array';
 import { Eq, struct } from 'fp-ts/lib/Eq';
-import { Eq as eqNumber } from 'fp-ts/lib/number';
-import { Eq as eqString } from 'fp-ts/lib/string';
+import * as N from 'fp-ts/lib/number';
+import * as S from 'fp-ts/lib/string';
 
 import { Nullable } from '~lib/types';
 
@@ -34,11 +34,11 @@ export interface Månedsberegning {
 export const eqMånedsberegningBortsettFraPeriode: Eq<Månedsberegning> = struct<
     Omit<Månedsberegning, 'fraOgMed' | 'tilOgMed'>
 >({
-    beløp: eqNumber,
-    epsFribeløp: eqNumber,
+    beløp: N.Eq,
+    epsFribeløp: N.Eq,
     epsInputFradrag: Array.getEq(eqFradragBortsettFraPeriode),
     fradrag: Array.getEq(eqFradragBortsettFraPeriode),
-    grunnbeløp: eqNumber,
-    sats: eqString,
-    satsbeløp: eqNumber,
+    grunnbeløp: N.Eq,
+    sats: S.Eq,
+    satsbeløp: N.Eq,
 });

--- a/src/types/Beregning.ts
+++ b/src/types/Beregning.ts
@@ -1,5 +1,7 @@
 import * as Array from 'fp-ts/lib/Array';
-import { Eq, eqNumber, eqString, getStructEq } from 'fp-ts/lib/Eq';
+import { Eq, struct } from 'fp-ts/lib/Eq';
+import { Eq as eqNumber } from 'fp-ts/lib/number';
+import { Eq as eqString } from 'fp-ts/lib/string';
 
 import { Nullable } from '~lib/types';
 
@@ -29,7 +31,7 @@ export interface Månedsberegning {
     epsInputFradrag: Fradrag[];
 }
 
-export const eqMånedsberegningBortsettFraPeriode: Eq<Månedsberegning> = getStructEq<
+export const eqMånedsberegningBortsettFraPeriode: Eq<Månedsberegning> = struct<
     Omit<Månedsberegning, 'fraOgMed' | 'tilOgMed'>
 >({
     beløp: eqNumber,

--- a/src/types/Fradrag.ts
+++ b/src/types/Fradrag.ts
@@ -1,4 +1,6 @@
-import { eqNumber, eqString, getStructEq } from 'fp-ts/lib/Eq';
+import { struct } from 'fp-ts/lib/Eq';
+import { Eq as eqNumber } from 'fp-ts/lib/number';
+import { Eq as eqString } from 'fp-ts/lib/string';
 
 import { eqNullable, Nullable } from '~lib/types';
 
@@ -10,13 +12,13 @@ export interface Fradrag {
     tilhører: FradragTilhører;
 }
 
-const eqUtenlandskInntekt = getStructEq<UtenlandskInntekt>({
+const eqUtenlandskInntekt = struct<UtenlandskInntekt>({
     beløpIUtenlandskValuta: eqNumber,
     kurs: eqNumber,
     valuta: eqString,
 });
 
-export const eqFradragBortsettFraPeriode = getStructEq<Omit<Fradrag, 'periode'>>({
+export const eqFradragBortsettFraPeriode = struct<Omit<Fradrag, 'periode'>>({
     type: eqString,
     beløp: eqNumber,
     utenlandskInntekt: eqNullable(eqUtenlandskInntekt),

--- a/src/types/Fradrag.ts
+++ b/src/types/Fradrag.ts
@@ -1,6 +1,6 @@
 import { struct } from 'fp-ts/lib/Eq';
-import { Eq as eqNumber } from 'fp-ts/lib/number';
-import { Eq as eqString } from 'fp-ts/lib/string';
+import * as N from 'fp-ts/lib/number';
+import * as S from 'fp-ts/lib/string';
 
 import { eqNullable, Nullable } from '~lib/types';
 
@@ -13,16 +13,16 @@ export interface Fradrag {
 }
 
 const eqUtenlandskInntekt = struct<UtenlandskInntekt>({
-    beløpIUtenlandskValuta: eqNumber,
-    kurs: eqNumber,
-    valuta: eqString,
+    beløpIUtenlandskValuta: N.Eq,
+    kurs: N.Eq,
+    valuta: S.Eq,
 });
 
 export const eqFradragBortsettFraPeriode = struct<Omit<Fradrag, 'periode'>>({
-    type: eqString,
-    beløp: eqNumber,
+    type: S.Eq,
+    beløp: N.Eq,
     utenlandskInntekt: eqNullable(eqUtenlandskInntekt),
-    tilhører: eqString,
+    tilhører: S.Eq,
 });
 
 export interface Periode<T = Date> {


### PR DESCRIPTION
Ser ut som många av våra `Eq`-functions blev deprecated i den nya oppdateringen av pakkerna.