### PR TITLE
Åpne for å kunne revurdere tilbake i tid.

### DIFF
--- a/src/features/revurdering/sharedMessages-nb.ts
+++ b/src/features/revurdering/sharedMessages-nb.ts
@@ -34,5 +34,4 @@ export default {
     'feil.simulering.feilet': 'Simulering feilet',
     'feil.ufullstendig.behandlingsinformasjon': 'Ufullstendig behandlingsinformasjon',
     'feil.g_regulering_kan_ikke_føre_til_opphør': 'G-regulering kan ikke føre til opphør',
-    'feil.periode.og.årsak.kombinasjon.er.ugyldig': 'Angitt periode og årsak er ugyldig',
 };

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/EndreRevurderingPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/EndreRevurderingPage.tsx
@@ -60,10 +60,10 @@ export const EndreRevurderingPage = (props: { sak: Sak; revurdering: Revurdering
         }
     };
 
-    const sortertUtbetalinger = [...props.sak.utbetalinger].sort(compareUtbetalingsperiode);
+    const sorterteUtbetalinger = [...props.sak.utbetalinger].sort(compareUtbetalingsperiode);
     const [førsteUtbetaling, sisteUtbetaling] = [
-        sortertUtbetalinger[0],
-        sortertUtbetalinger[sortertUtbetalinger.length - 1],
+        sorterteUtbetalinger[0],
+        sorterteUtbetalinger[sorterteUtbetalinger.length - 1],
     ];
 
     return (

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/EndreRevurderingPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/EndreRevurderingPage.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { oppdaterRevurderingsPeriode as oppdaterRevurdering } from '~features/revurdering/revurderingActions';
-import { startenPåForrigeMåned } from '~lib/dateUtils';
 import * as Routes from '~lib/routes';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
 import { InformasjonSomRevurderes, OpprettetRevurderingGrunn, Revurdering } from '~types/Revurdering';
@@ -67,17 +66,14 @@ export const EndreRevurderingPage = (props: { sak: Sak; revurdering: Revurdering
         sortertUtbetalinger[sortertUtbetalinger.length - 1],
     ];
 
-    const minFraOgMed = DateFns.max([new Date(førsteUtbetaling.fraOgMed), startenPåForrigeMåned(new Date())]);
-    const maxFraOgMed = new Date(sisteUtbetaling.tilOgMed);
-
     return (
         <RevurderingIntroForm
             onNesteClick={handleNesteClick}
             onLagreOgFortsettSenereClick={handleLagreOgFortsettSenereClick}
             tilbakeUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}
             revurdering={props.revurdering}
-            maxFraOgMed={maxFraOgMed}
-            minFraOgMed={minFraOgMed}
+            maxFraOgMed={DateFns.parseISO(sisteUtbetaling.tilOgMed)}
+            minFraOgMed={DateFns.parseISO(førsteUtbetaling.fraOgMed)}
             nesteClickStatus={oppdaterRevurderingStatus}
             lagreOgFortsettSenereClickStatus={oppdaterRevurderingStatus}
         />

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/NyRevurderingPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/NyRevurderingPage.tsx
@@ -60,10 +60,10 @@ export const NyRevurderingPage = (props: { sak: Sak }) => {
         }
     };
 
-    const sortertUtbetalinger = [...props.sak.utbetalinger].sort(compareUtbetalingsperiode);
+    const sorterteUtbetalinger = [...props.sak.utbetalinger].sort(compareUtbetalingsperiode);
     const [førsteUtbetaling, sisteUtbetaling] = [
-        sortertUtbetalinger[0],
-        sortertUtbetalinger[sortertUtbetalinger.length - 1],
+        sorterteUtbetalinger[0],
+        sorterteUtbetalinger[sorterteUtbetalinger.length - 1],
     ];
 
     return (

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/NyRevurderingPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/NyRevurderingPage.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { opprettRevurdering } from '~features/revurdering/revurderingActions';
-import { startenPåForrigeMåned } from '~lib/dateUtils';
 import * as Routes from '~lib/routes';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
 import { InformasjonSomRevurderes, OpprettetRevurderingGrunn } from '~types/Revurdering';
@@ -61,10 +60,11 @@ export const NyRevurderingPage = (props: { sak: Sak }) => {
         }
     };
 
-    const sortertUtbetalingsperioder = [...props.sak.utbetalinger].sort(compareUtbetalingsperiode);
-    const sisteUtbetalingsDato = new Date(sortertUtbetalingsperioder[sortertUtbetalingsperioder.length - 1].tilOgMed);
-
-    const minFraOgMed = DateFns.max([new Date(props.sak.utbetalinger[0].fraOgMed), startenPåForrigeMåned(new Date())]);
+    const sortertUtbetalinger = [...props.sak.utbetalinger].sort(compareUtbetalingsperiode);
+    const [førsteUtbetaling, sisteUtbetaling] = [
+        sortertUtbetalinger[0],
+        sortertUtbetalinger[sortertUtbetalinger.length - 1],
+    ];
 
     return (
         <RevurderingIntroForm
@@ -72,8 +72,8 @@ export const NyRevurderingPage = (props: { sak: Sak }) => {
             onLagreOgFortsettSenereClick={handleLagreOgFortsettSenereClick}
             tilbakeUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}
             revurdering={undefined}
-            maxFraOgMed={sisteUtbetalingsDato}
-            minFraOgMed={minFraOgMed}
+            maxFraOgMed={DateFns.parseISO(sisteUtbetaling.tilOgMed)}
+            minFraOgMed={DateFns.parseISO(førsteUtbetaling.fraOgMed)}
             nesteClickStatus={opprettRevurderingStatus}
             lagreOgFortsettSenereClickStatus={opprettRevurderingStatus}
         />

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroForm.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroForm.tsx
@@ -9,7 +9,6 @@ import DatePicker from 'react-datepicker';
 
 import { ApiError } from '~api/apiClient';
 import sharedMessages from '~features/revurdering/sharedMessages-nb';
-import { erDatoFørStartenPåNesteMåned, startenPåForrigeMåned } from '~lib/dateUtils';
 import { customFormikSubmit } from '~lib/formikUtils';
 import { useI18n } from '~lib/hooks';
 import { keyOf, Nullable } from '~lib/types';
@@ -34,26 +33,7 @@ interface OpprettRevurderingFormData {
 const gyldigeÅrsaker = Object.values(OpprettetRevurderingGrunn).filter((x) => x !== OpprettetRevurderingGrunn.MIGRERT);
 
 const schema = yup.object<OpprettRevurderingFormData>({
-    fraOgMed: yup
-        .date()
-        .nullable()
-        .required()
-        .test({
-            name: 'fraOgMed kan kun starte fra neste måned for årsaker som ikke er g-regulering',
-            message: 'Du kan ikke velge en dato bakover i tid for årsaker som ikke er G-regulering',
-            test: function (val) {
-                const årsak = this.parent.årsak;
-
-                if (
-                    !DateFns.isBefore(val, startenPåForrigeMåned(new Date())) &&
-                    årsak === OpprettetRevurderingGrunn.REGULER_GRUNNBELØP
-                ) {
-                    return true;
-                }
-
-                return !erDatoFørStartenPåNesteMåned(val);
-            },
-        }),
+    fraOgMed: yup.date().nullable().required(),
     årsak: yup.mixed<OpprettetRevurderingGrunn>().nullable().required(),
     begrunnelse: yup.string().nullable().required(),
     informasjonSomRevurderes: yup
@@ -182,19 +162,6 @@ const RevurderingIntroForm = (props: RevurderingIntroFormProps) => {
                             {intl.formatMessage({ id: 'input.årsak.value.default' })}
                         </option>
                         {gyldigeÅrsaker.map((grunn) => {
-                            if (
-                                formik.values.fraOgMed &&
-                                erDatoFørStartenPåNesteMåned(formik.values.fraOgMed) &&
-                                grunn !== OpprettetRevurderingGrunn.REGULER_GRUNNBELØP
-                            ) {
-                                return (
-                                    <option value={grunn} key={grunn} disabled>
-                                        {intl.formatMessage({
-                                            id: getRevurderingsårsakMessageId(grunn),
-                                        })}
-                                    </option>
-                                );
-                            }
                             return (
                                 <option value={grunn} key={grunn}>
                                     {intl.formatMessage({

--- a/src/pages/saksbehandling/revurdering/revurderingskallFeilet/RevurderingskallFeilet.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingskallFeilet/RevurderingskallFeilet.tsx
@@ -53,8 +53,6 @@ const feilkodeTilFeilmelding = (intl: IntlShape, feil?: Nullable<ErrorMessage>) 
         //perioder
         case RevurderingErrorCodes.INGENTING_Å_REVURDERE_I_PERIODEN:
             return intl.formatMessage({ id: 'feil.kan.ikke.revurdere' });
-        case RevurderingErrorCodes.PERIODE_OG_ÅRSAK_KOMBINASJON_ER_UGYLDIG:
-            return intl.formatMessage({ id: 'feil.periode.og.årsak.kombinasjon.er.ugyldig' });
         case RevurderingErrorCodes.VURDERINGSPERIODE_UTENFOR_REVURDERINGSPERIODE:
             return intl.formatMessage({ id: 'feil.vurderinger.utenfor.revurderingsperiode' });
         case RevurderingErrorCodes.HELE_REVURDERINGSPERIODEN_MÅ_HA_VURDERINGER:

--- a/src/pages/saksbehandling/revurdering/revurderingskallFeilet/revurderingskallFeilet-nb.ts
+++ b/src/pages/saksbehandling/revurdering/revurderingskallFeilet/revurderingskallFeilet-nb.ts
@@ -6,7 +6,6 @@ export default {
     'feil.kan.ikke.revurdere': 'Det finnes ingen perioder for revurdering',
     'feil.kan.ikke.oppdatere.revurdering.som.er.forhåndsvarslet':
         'Kan ikke oppdatere revurdering som er forhåndsvarslet',
-    'feil.periode.og.årsak.kombinasjon.er.ugyldig': 'Angitt periode og årsak er ugyldig',
 
     'feil.fant.ikke.sak': 'Fant ikke sak',
     'feil.fant.ikke.aktør.id': 'Fant ikke aktør id',

--- a/src/types/Revurdering.ts
+++ b/src/types/Revurdering.ts
@@ -132,7 +132,6 @@ export enum RevurderingErrorCodes {
     MANGLER_BESLUTNING_PÅ_FORHÅNDSVARSEL = 'mangler_beslutning_på_forhåndsvarsel',
 
     //perioder
-    PERIODE_OG_ÅRSAK_KOMBINASJON_ER_UGYLDIG = 'periode_og_årsak_kombinasjon_er_ugyldig',
     INGENTING_Å_REVURDERE_I_PERIODEN = 'ingenting_å_revurdere_i_perioden',
     OVERLAPPENDE_VURDERINGSPERIODER = 'overlappende_vurderingsperioder',
     HELE_REVURDERINGSPERIODEN_MÅ_HA_VURDERINGER = 'hele_behandlingsperioden_må_ha_vurderinger',


### PR DESCRIPTION
Fjerner sperrer som forhindrer opprettelse av revurderinger tilbake i tid.

Åpner for en del tilfeller som ikke støttes, må tas inn etter at nye sperringer lagt til av #324 er på plass. Se backend for denne oppgaven her: https://github.com/navikt/su-se-bakover/pull/325