### PR TITLE
Ikke refresh cookie ved toggles kall

### DIFF
--- a/server/session.ts
+++ b/server/session.ts
@@ -27,6 +27,7 @@ export default function setupSession(app: Express) {
     app.set('trust proxy', 1);
 
     app.use(
+        /^(?!\/api\/toggles)/,
         session({
             cookie: {
                 maxAge: SESSION_MAX_AGE_MILLIS,


### PR DESCRIPTION
Gjør et forsøk på å ekskludere cookie-middleware for /api/toggles kallet