### PR TITLE
fjern ubrukte props

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         'react/prop-types': 'off',
+        'react/no-unused-prop-types': 'error',
         'import/order': [
             1,
             {

--- a/src/components/beregningOgSimulering/BeregningOgSimulering.tsx
+++ b/src/components/beregningOgSimulering/BeregningOgSimulering.tsx
@@ -4,19 +4,18 @@ import React from 'react';
 import { erBeregnetAvslag } from '~features/behandling/behandlingUtils';
 import { useI18n } from '~lib/hooks';
 import { Behandling } from '~types/Behandling';
-import { Sak } from '~types/Sak';
 
 import messages from './beregning/beregning-nb';
 import VisBeregning from './beregning/VisBeregning';
 import styles from './beregningOgSimulering.module.less';
 import { VisSimulering } from './simulering/simulering';
 
-const VisBeregningOgSimulering = (props: { sak: Sak; behandling: Behandling }) => {
+const VisBeregningOgSimulering = (props: { behandling: Behandling }) => {
     const intl = useI18n({ messages });
     return props.behandling.beregning ? (
         <div className={styles.beregningOgSimuleringContainer}>
             <VisBeregning beregning={props.behandling.beregning} />
-            {!erBeregnetAvslag(props.behandling) && <VisSimulering sak={props.sak} behandling={props.behandling} />}
+            {!erBeregnetAvslag(props.behandling) && <VisSimulering behandling={props.behandling} />}
             {props.behandling.beregning.begrunnelse && (
                 <div>
                     <Element>{intl.formatMessage({ id: 'display.visBeregning.begrunnelse' })}</Element>

--- a/src/components/beregningOgSimulering/beregning/FradragInputs.tsx
+++ b/src/components/beregningOgSimulering/beregning/FradragInputs.tsx
@@ -78,7 +78,6 @@ const FradragsSelection = (props: {
     onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
     feil: string | undefined;
     intl: IntlShape;
-    optionLabel: string;
 }) => (
     <div>
         <h3>{props.label}</h3>
@@ -201,7 +200,6 @@ export const FradragInputs = (props: {
                                             : undefined
                                     }
                                     className={styles.fradragtype}
-                                    optionLabel={props.intl.formatMessage({ id: 'fradrag.type.emptyLabel' })}
                                     intl={props.intl}
                                 />
                                 <InputWithFollowText

--- a/src/components/beregningOgSimulering/simulering/simulering.tsx
+++ b/src/components/beregningOgSimulering/simulering/simulering.tsx
@@ -16,7 +16,6 @@ import { combineOptions, pipe } from '~lib/fp';
 import { useI18n } from '~lib/hooks';
 import { useAppSelector } from '~redux/Store';
 import { Behandling } from '~types/Behandling';
-import { Sak } from '~types/Sak';
 import { Simulering, SimulertUtbetalingstype } from '~types/Simulering';
 
 import styles from '../beregning/visBeregning.module.less';
@@ -24,7 +23,6 @@ import styles from '../beregning/visBeregning.module.less';
 import messages from './simulering-nb';
 
 interface Props {
-    sak: Sak;
     behandling: Behandling;
 }
 

--- a/src/components/oppsummering/BehandlingHeader.tsx
+++ b/src/components/oppsummering/BehandlingHeader.tsx
@@ -25,75 +25,7 @@ const BehandlingHeader = (props: {
     vedtakForBehandling?: Vedtak;
     medBrevutkastknapp?: boolean;
 }) => {
-    const user = useUserContext();
     const intl = useI18n({ messages });
-    const [lastNedBrevStatus, lastNedBrev] = useBrevForhåndsvisning(PdfApi.fetchBrevutkastForSøknadsbehandling);
-
-    const hentBrev = React.useCallback(async () => {
-        lastNedBrev({
-            sakId: props.sakId,
-            behandlingId: props.behandling.id,
-        });
-    }, [props.sakId, props.behandling.id, lastNedBrevStatus._tag]);
-
-    const Tilleggsinfo = () => {
-        return (
-            <div>
-                <div className={styles.tilleggsinfoContainer}>
-                    <div>
-                        <Element>{intl.formatMessage({ id: 'vurdering.tittel' })}</Element>
-                        <p>{statusTilTekst(props.behandling.status, intl)}</p>
-                    </div>
-                    <div>
-                        <Element> {intl.formatMessage({ id: 'behandlet.av' })}</Element>
-                        <p>{props.behandling.saksbehandler || user.navn}</p>
-                    </div>
-                    {props.behandling.attestering?.attestant && (
-                        <div>
-                            <Element> {intl.formatMessage({ id: 'attestert.av' })}</Element>
-                            <p>{props.behandling.attestering.attestant}</p>
-                        </div>
-                    )}
-
-                    <div>
-                        <Element> {intl.formatMessage({ id: 'behandling.søknadsdato' })}</Element>
-                        <p>{søknadMottatt(props.behandling.søknad, intl)}</p>
-                    </div>
-                    <div>
-                        <Element> {intl.formatMessage({ id: 'behandling.saksbehandlingStartet' })}</Element>
-                        <p>{intl.formatDate(props.behandling.opprettet)}</p>
-                    </div>
-                    {erIverksatt(props.behandling) && (
-                        <div>
-                            <Element> {intl.formatMessage({ id: 'behandling.iverksattDato' })}</Element>
-                            <p>{intl.formatDate(props.vedtakForBehandling?.opprettet)}</p>
-                        </div>
-                    )}
-                    {props.medBrevutkastknapp && (
-                        <div>
-                            <Element>{intl.formatMessage({ id: 'brev.utkastVedtaksbrev' })}</Element>
-                            <Knapp
-                                spinner={RemoteData.isPending(lastNedBrevStatus)}
-                                mini
-                                htmlType="button"
-                                onClick={hentBrev}
-                            >
-                                {intl.formatMessage({ id: 'knapp.vis' })}
-                            </Knapp>
-                        </div>
-                    )}
-                </div>
-                <div className={styles.brevutkastFeil}>
-                    {RemoteData.isFailure(lastNedBrevStatus) && (
-                        <AlertStripeFeil>
-                            {lastNedBrevStatus.error?.body?.message ??
-                                intl.formatMessage({ id: 'feilmelding.ukjentFeil' })}
-                        </AlertStripeFeil>
-                    )}
-                </div>
-            </div>
-        );
-    };
 
     if (props.behandling?.attestering?.underkjennelse) {
         return (
@@ -112,12 +44,101 @@ const BehandlingHeader = (props: {
                         <p>{props.behandling.attestering.underkjennelse?.kommentar}</p>
                     </div>
                 </div>
-                <Tilleggsinfo />
+                <Tilleggsinfo
+                    sakId={props.sakId}
+                    behandling={props.behandling}
+                    vedtakForBehandling={props.vedtakForBehandling}
+                    medBrevutkastknapp={props.medBrevutkastknapp}
+                    intl={intl}
+                />
             </div>
         );
     }
 
-    return <Tilleggsinfo />;
+    return (
+        <Tilleggsinfo
+            sakId={props.sakId}
+            behandling={props.behandling}
+            vedtakForBehandling={props.vedtakForBehandling}
+            medBrevutkastknapp={props.medBrevutkastknapp}
+            intl={intl}
+        />
+    );
+};
+
+const Tilleggsinfo = (props: {
+    sakId: string;
+    behandling: Behandling;
+    vedtakForBehandling?: Vedtak;
+    medBrevutkastknapp?: boolean;
+    intl: IntlShape;
+}) => {
+    const user = useUserContext();
+
+    const [lastNedBrevStatus, lastNedBrev] = useBrevForhåndsvisning(PdfApi.fetchBrevutkastForSøknadsbehandling);
+    const hentBrev = React.useCallback(async () => {
+        lastNedBrev({
+            sakId: props.sakId,
+            behandlingId: props.behandling.id,
+        });
+    }, [props.sakId, props.behandling.id, lastNedBrevStatus._tag]);
+
+    return (
+        <div>
+            <div className={styles.tilleggsinfoContainer}>
+                <div>
+                    <Element>{props.intl.formatMessage({ id: 'vurdering.tittel' })}</Element>
+                    <p>{statusTilTekst(props.behandling.status, props.intl)}</p>
+                </div>
+                <div>
+                    <Element> {props.intl.formatMessage({ id: 'behandlet.av' })}</Element>
+                    <p>{props.behandling.saksbehandler || user.navn}</p>
+                </div>
+                {props.behandling.attestering?.attestant && (
+                    <div>
+                        <Element> {props.intl.formatMessage({ id: 'attestert.av' })}</Element>
+                        <p>{props.behandling.attestering.attestant}</p>
+                    </div>
+                )}
+
+                <div>
+                    <Element> {props.intl.formatMessage({ id: 'behandling.søknadsdato' })}</Element>
+                    <p>{søknadMottatt(props.behandling.søknad, props.intl)}</p>
+                </div>
+                <div>
+                    <Element> {props.intl.formatMessage({ id: 'behandling.saksbehandlingStartet' })}</Element>
+                    <p>{props.intl.formatDate(props.behandling.opprettet)}</p>
+                </div>
+                {erIverksatt(props.behandling) && (
+                    <div>
+                        <Element> {props.intl.formatMessage({ id: 'behandling.iverksattDato' })}</Element>
+                        <p>{props.intl.formatDate(props.vedtakForBehandling?.opprettet)}</p>
+                    </div>
+                )}
+                {props.medBrevutkastknapp && (
+                    <div>
+                        <Element>{props.intl.formatMessage({ id: 'brev.utkastVedtaksbrev' })}</Element>
+                        <Knapp
+                            spinner={RemoteData.isPending(lastNedBrevStatus)}
+                            mini
+                            htmlType="button"
+                            onClick={hentBrev}
+                        >
+                            {props.intl.formatMessage({ id: 'knapp.vis' })}
+                        </Knapp>
+                    </div>
+                )}
+            </div>
+            <div className={styles.brevutkastFeil}>
+                {RemoteData.isFailure(lastNedBrevStatus) && (
+                    <AlertStripeFeil>
+                        {lastNedBrevStatus.error?.body?.message ??
+                            props.intl.formatMessage({ id: 'feilmelding.ukjentFeil' })}
+                    </AlertStripeFeil>
+                )}
+            </div>
+        </div>
+    );
 };
 
 function statusTilTekst(behandlingsstatus: Behandlingsstatus, intl: IntlShape): string {

--- a/src/components/oppsummering/Behandlingsoppsummering.tsx
+++ b/src/components/oppsummering/Behandlingsoppsummering.tsx
@@ -59,7 +59,7 @@ const Behandlingsoppsummering = (props: Props) => {
                 behandlingsinformasjon={props.behandling.behandlingsinformasjon}
             />
             {props.behandling.beregning ? (
-                <VisBeregningOgSimulering sak={props.sak} behandling={props.behandling} />
+                <VisBeregningOgSimulering behandling={props.behandling} />
             ) : (
                 intl.formatMessage({ id: 'feilmelding.ikkeGjortEnBeregning' })
             )}

--- a/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
@@ -24,7 +24,6 @@ interface AvvistFormData {
 }
 
 interface AvvistProps {
-    søknadId: string;
     lukkSøknadBegrunnelse: LukkSøknadBegrunnelse;
     validateForm: () => Promise<FormikErrors<LukkSøknadFormData>>;
     avvistFormData: AvvistFormData;

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -136,7 +136,6 @@ const LukkSøknad = (props: { sak: Sak }) => {
 
             {formik.values.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Avvist && (
                 <Avvist
-                    søknadId={søknad.id}
                     validateForm={() => formik.validateForm()}
                     lukkSøknadBegrunnelse={formik.values.lukkSøknadBegrunnelse}
                     avvistFormData={{

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
@@ -49,7 +49,6 @@ const OppsummeringshandlingForm = (props: {
     forrigeUrl: string;
     førsteRevurderingstegUrl: string;
     revurdering: SimulertRevurdering | BeregnetIngenEndring | UnderkjentRevurdering;
-    grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
     feilmeldinger: ErrorMessage[];
 }) => {
     const history = useHistory();
@@ -296,7 +295,6 @@ const RevurderingOppsummeringPage = (props: {
                                         forrigeUrl={props.forrigeUrl}
                                         førsteRevurderingstegUrl={props.førsteRevurderingstegUrl}
                                         revurdering={props.revurdering}
-                                        grunnlagsdataOgVilkårsvurderinger={grunnlagsdataOgVilkårsvurderinger}
                                         feilmeldinger={beregning.feilmeldinger}
                                     />
                                 ) : (

--- a/src/pages/saksbehandling/revurdering/bosituasjon/BosituasjonForm.tsx
+++ b/src/pages/saksbehandling/revurdering/bosituasjon/BosituasjonForm.tsx
@@ -21,7 +21,6 @@ import yup, { hookFormErrorsTilFeiloppsummering } from '~lib/validering';
 import { useAppDispatch } from '~redux/Store';
 import { Bosituasjon } from '~types/grunnlagsdataOgVilkårsvurderinger/bosituasjon/Bosituasjongrunnlag';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
-import { Periode } from '~types/Periode';
 import { BosituasjonRequest, Revurdering } from '~types/Revurdering';
 
 import { RevurderingBunnknapper } from '../bunnknapper/RevurderingBunnknapper';
@@ -39,7 +38,7 @@ interface BosituasjonFormData {
     begrunnelse: Nullable<string>;
 }
 
-const GjeldendeBosituasjon = (props: { bosituasjon?: Bosituasjon[]; revurderingsperiode: Periode<string> }) => {
+const GjeldendeBosituasjon = (props: { bosituasjon?: Bosituasjon[] }) => {
     const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
 
     return (
@@ -447,10 +446,7 @@ const BosituasjonForm = (props: {
                     </form>
                 ),
                 right: (
-                    <GjeldendeBosituasjon
-                        bosituasjon={props.gjeldendeGrunnlagsdataOgVilkårsvurderinger.bosituasjon}
-                        revurderingsperiode={props.revurdering.periode}
-                    />
+                    <GjeldendeBosituasjon bosituasjon={props.gjeldendeGrunnlagsdataOgVilkårsvurderinger.bosituasjon} />
                 ),
             }}
         </ToKolonner>

--- a/src/pages/saksbehandling/sakintro/Sakintro.tsx
+++ b/src/pages/saksbehandling/sakintro/Sakintro.tsx
@@ -47,7 +47,7 @@ import { RevurderingSteg } from '../types';
 import messages from './sakintro-nb';
 import styles from './sakintro.module.less';
 
-const SuksessStatuser = (props: { locationState: Nullable<Routes.SuccessNotificationState>; intl: IntlShape }) => {
+const SuksessStatuser = (props: { locationState: Nullable<Routes.SuccessNotificationState> }) => {
     return (
         <div className={styles.suksessStatuserContainer}>
             {props.locationState?.notification && (
@@ -98,7 +98,7 @@ const Sakintro = (props: { sak: Sak; søker: Person }) => {
 
     return (
         <div className={styles.sakintroContainer}>
-            <SuksessStatuser locationState={locationState} intl={intl} />
+            <SuksessStatuser locationState={locationState} />
             <div className={styles.pageHeader}>
                 <Innholdstittel className={styles.tittel}>
                     {intl.formatMessage({ id: 'display.saksoversikt.tittel' })}: {props.sak.saksnummer}

--- a/src/pages/saksbehandling/steg/sats/Sats.tsx
+++ b/src/pages/saksbehandling/steg/sats/Sats.tsx
@@ -50,7 +50,6 @@ interface FormData {
 interface SatsProps {
     behandlingId: string;
     eps: Nullable<Person>;
-    søker: Person;
     bosituasjon: Nullable<Bosituasjon>;
     søknadInnhold: SøknadInnhold;
     forrigeUrl: string;
@@ -155,7 +154,6 @@ const Sats = (props: VilkårsvurderingBaseProps) => {
         return (
             <SatsForm
                 behandlingId={props.behandling.id}
-                søker={props.søker}
                 eps={null}
                 bosituasjon={hentBosituasjongrunnlag(props.behandling.grunnlagsdataOgVilkårsvurderinger) ?? null}
                 søknadInnhold={props.behandling.søknad.søknadInnhold}
@@ -186,7 +184,6 @@ const Sats = (props: VilkårsvurderingBaseProps) => {
             (eps) => (
                 <SatsForm
                     behandlingId={props.behandling.id}
-                    søker={props.søker}
                     eps={eps}
                     bosituasjon={hentBosituasjongrunnlag(props.behandling.grunnlagsdataOgVilkårsvurderinger) ?? null}
                     søknadInnhold={props.behandling.søknad.søknadInnhold}

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -4,7 +4,6 @@ import Stegindikator from 'nav-frontend-stegindikator';
 import { Undertittel, Feilmelding, Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
 import { useEffect } from 'react';
-import { IntlShape } from 'react-intl';
 import { useParams, useHistory, Link, Switch, Route } from 'react-router-dom';
 
 import { fetchMe } from '~api/meApi';
@@ -45,7 +44,6 @@ const Steg = (props: {
     step: Søknadsteg;
     søknad: SøknadState;
     søker: Person;
-    intl: IntlShape;
     erSaksbehandler: boolean;
     hjelpetekst?: string;
 }) => {
@@ -329,7 +327,6 @@ const StartUtfylling = () => {
                                 step={step}
                                 søknad={søknad}
                                 søker={søker}
-                                intl={intl}
                                 erSaksbehandler={user.roller.includes(Rolle.Saksbehandler)}
                                 hjelpetekst={steg.find((s) => s.step === step)?.hjelpetekst}
                             />


### PR DESCRIPTION
Den forstår ikke props hvis den ligger nøstet i en annen komponent, så da må den trekkes ut. Hvis det blir plagsomt, så kan vi bare fjerne regelen. Men kan være fin å skru på fra tid til annen. Eventuelt legge det som warning