### PR TITLE
Forbedre useI18n-hook-en

### DIFF
--- a/src/components/FnrInput/FnrInput.tsx
+++ b/src/components/FnrInput/FnrInput.tsx
@@ -36,7 +36,7 @@ export const FnrInput = ({
 }: FnrInputProps) => {
     const [person, setPerson] = useState<RemoteData.RemoteData<ApiError, personApi.Person>>(RemoteData.initial);
     const [harIkkeTilgang, setHarIkkeTilgang] = useState<boolean>(false);
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     async function fetchPerson(fødselsnummer: string) {
         setHarIkkeTilgang(false);

--- a/src/components/FormElements.tsx
+++ b/src/components/FormElements.tsx
@@ -23,7 +23,7 @@ export const JaNeiSpørsmål = (props: {
     hjelpetekstBody?: string;
     description?: string;
 }) => {
-    const intl = useI18n({ messages: nb });
+    const { intl } = useI18n({ messages: nb });
     return (
         <RadioGruppe
             className={classNames(styles.janeisporsmal, props.className)}

--- a/src/components/Personsøk/Personsøk.tsx
+++ b/src/components/Personsøk/Personsøk.tsx
@@ -28,7 +28,7 @@ interface PersonsøkProps {
 const Personsøk = (props: PersonsøkProps) => {
     const [hasSubmitted, setHasSubmitted] = React.useState(false);
 
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const [input, setInput] = React.useState('');
     const [fnrValidation, setFnrValidation] = React.useState<ValidationResult | null>(null);

--- a/src/components/beregningOgSimulering/BeregningOgSimulering.tsx
+++ b/src/components/beregningOgSimulering/BeregningOgSimulering.tsx
@@ -11,7 +11,7 @@ import styles from './beregningOgSimulering.module.less';
 import { VisSimulering } from './simulering/simulering';
 
 const VisBeregningOgSimulering = (props: { behandling: Behandling }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     return props.behandling.beregning ? (
         <div className={styles.beregningOgSimuleringContainer}>
             <VisBeregning beregning={props.behandling.beregning} />

--- a/src/components/beregningOgSimulering/beregning/Beregning.tsx
+++ b/src/components/beregningOgSimulering/beregning/Beregning.tsx
@@ -79,7 +79,7 @@ function getInitialValues(beregning: Nullable<Beregning>): FormData {
 
 const Beregning = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages, ...fradragstypeMessages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages, ...fradragstypeMessages } });
     const [needsBeregning, setNeedsBeregning] = useState(false);
 
     const { beregningStatus, simuleringStatus } = useAppSelector((state) => state.sak);

--- a/src/components/beregningOgSimulering/beregning/VisBeregning.tsx
+++ b/src/components/beregningOgSimulering/beregning/VisBeregning.tsx
@@ -126,7 +126,7 @@ const VisBenyttetEpsFradrag = ({
 );
 
 const VisBeregning = (props: Props) => {
-    const intl = useI18n({ messages: { ...messages, ...fradragstypeMessages } });
+    const { intl } = useI18n({ messages: { ...messages, ...fradragstypeMessages } });
 
     return (
         <div className={styles.beregningdetaljer}>

--- a/src/components/beregningOgSimulering/simulering/simulering.tsx
+++ b/src/components/beregningOgSimulering/simulering/simulering.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 export const Utbetalingssimulering = (props: { simulering: Simulering; utenTittel?: boolean }) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
 
     return (
         <div className={styles.simuleringsdetaljer}>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -16,9 +16,9 @@ interface Props {
 }
 
 const Header = (props: Props) => {
-    const i18n = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     return (
-        <NavHeader title={i18n.formatMessage({ id: 'title' })} titleHref={'/'}>
+        <NavHeader title={intl.formatMessage({ id: 'title' })} titleHref={'/'}>
             {props.user && (
                 <div className={styles.content}>
                     {props.user.roller.includes(Rolle.Saksbehandler) && (
@@ -28,7 +28,7 @@ const Header = (props: Props) => {
                             })}
                             className={styles.papirsoknad}
                         >
-                            {i18n.formatMessage({ id: 'link.papirsøknad' })}
+                            {intl.formatMessage({ id: 'link.papirsøknad' })}
                         </Lenke>
                     )}
                     <Menyknapp

--- a/src/components/oppsummering/BehandlingHeader.tsx
+++ b/src/components/oppsummering/BehandlingHeader.tsx
@@ -25,7 +25,7 @@ const BehandlingHeader = (props: {
     vedtakForBehandling?: Vedtak;
     medBrevutkastknapp?: boolean;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     if (props.behandling?.attestering?.underkjennelse) {
         return (

--- a/src/components/oppsummering/Behandlingsoppsummering.tsx
+++ b/src/components/oppsummering/Behandlingsoppsummering.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const Behandlingsoppsummering = (props: Props) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const periode = props.behandling.stønadsperiode ? getPeriode(props.behandling.stønadsperiode) : null;
 
     return (
@@ -36,7 +36,7 @@ const Behandlingsoppsummering = (props: Props) => {
             />
             <div className={styles.virkningstidspunkt}>
                 <Systemtittel className={styles.tittel}>
-                    {`${intl.formatMessage({ id: 'virkningstidspunkt.tittel' })}: 
+                    {`${intl.formatMessage({ id: 'virkningstidspunkt.tittel' })}:
                     ${
                         periode
                             ? DateUtils.formatPeriode(periode, intl)

--- a/src/components/oppsummering/vilkårsOppsummering/VilkårsBlokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/VilkårsBlokk.tsx
@@ -16,7 +16,7 @@ const Vilkårsblokk = (props: {
     saksbehandlingfaktablokk: JSX.Element;
     begrunnelse: Nullable<string>;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <div className={styles.blokkContainer}>

--- a/src/components/oppsummering/vilkårsOppsummering/VilkårsOppsummering.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/VilkårsOppsummering.tsx
@@ -39,7 +39,7 @@ const VilkårsOppsummering = (props: {
     behandlingstatus: Behandlingsstatus;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const vilkårsinformasjon = mapToVilkårsinformasjon(props.behandlingsinformasjon);
 
     return (

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/BeregningFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/BeregningFaktablokk.tsx
@@ -8,7 +8,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps } from './faktablokkUtils';
 
 const BeregningFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <div>

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FastOppholdFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FastOppholdFaktablokk.tsx
@@ -20,7 +20,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const FastOppholdFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...flyktningstatusSøknadMessages,
@@ -77,7 +77,7 @@ const createFaktaBlokkArray = (søknadsInnhold: SøknadInnhold, intl: IntlShape)
 };
 
 export const FastOppholdVilkårsblokk = (props: VilkårsblokkProps<'fastOppholdINorge'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FlyktningFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FlyktningFaktablokk.tsx
@@ -15,7 +15,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const FlyktningFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...søknadMessages,
@@ -38,7 +38,7 @@ export const FlyktningFaktablokk = (props: FaktablokkProps) => {
 };
 
 export const FlyktningVilkårsblokk = (props: VilkårsblokkProps<'flyktning'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FormueFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FormueFaktablokk.tsx
@@ -22,7 +22,7 @@ import styles from './faktablokker.module.less';
 import { FaktablokkProps } from './faktablokkUtils';
 
 export const FormueFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const totalFormueFraSøknad = useMemo(() => {
         const søkersFormueFraSøknad = kalkulerFormueFraSøknad(props.søknadInnhold.formue);
@@ -213,7 +213,7 @@ export const FormueVilkårsblokk = (props: {
     formue: Behandlingsinformasjon['formue'];
     ektefelle: { fnr: Nullable<string> };
 }) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/InstitusjonsoppholdBlokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/InstitusjonsoppholdBlokk.tsx
@@ -15,7 +15,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const InstitusjonsoppholdBlokk = (props: FaktablokkProps) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...søknadMessages,
@@ -56,7 +56,7 @@ export const InstitusjonsoppholdBlokk = (props: FaktablokkProps) => {
 };
 
 export const InstitusjonsoppholdVilkårsblokk = (props: VilkårsblokkProps<'institusjonsopphold'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/LovligOppholdFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/LovligOppholdFaktablokk.tsx
@@ -16,7 +16,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const LovligOppholdFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...søknadMessages,
@@ -88,7 +88,7 @@ const createFakta = (verdi: Nullable<string>, tittel: string) => {
 };
 
 export const LovligOppholdVilkårsblokk = (props: VilkårsblokkProps<'lovligOpphold'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/PersonligOppmøteFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/PersonligOppmøteFaktablokk.tsx
@@ -15,7 +15,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const PersonligOppmøteFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <Faktablokk
@@ -56,7 +56,7 @@ export const PersonligOppmøteFaktablokk = (props: FaktablokkProps) => {
 };
 
 export const PersonligOppmøteVilkårsblokk = (props: VilkårsblokkProps<'personligOppmøte'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/SatsFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/SatsFaktablokk.tsx
@@ -18,7 +18,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps } from './faktablokkUtils';
 
 export const SatsFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const fakta = [];
 
@@ -71,7 +71,7 @@ export const SatsFaktablokk = (props: FaktablokkProps) => {
 };
 
 export const SatsVilkårsblokk = (props: { bosituasjon: Bosituasjon; søknadInnhold: SøknadInnhold }) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/UførhetFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/UførhetFaktablokk.tsx
@@ -13,7 +13,7 @@ import messages from './faktablokker-nb';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const UførhetFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages,
     });
 
@@ -33,7 +33,7 @@ export const UførhetFaktablokk = (props: FaktablokkProps) => {
 };
 
 export const UførhetVilkårsblokk = (props: VilkårsblokkProps<'uførhet'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/UtenlandsOppholdFaktablokk.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/UtenlandsOppholdFaktablokk.tsx
@@ -17,7 +17,7 @@ import styles from './faktablokker.module.less';
 import { FaktablokkProps, VilkårsblokkProps } from './faktablokkUtils';
 
 export const UtenlandsOppholdFaktablokk = (props: FaktablokkProps) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
         },
@@ -69,7 +69,7 @@ function formatDate(date: string) {
 }
 
 export const UtenlandsoppholdVilkårsblokk = (props: VilkårsblokkProps<'oppholdIUtlandet'>) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...messages,
             ...saksbehandlingMessages,

--- a/src/components/personlinje/Personlinje.tsx
+++ b/src/components/personlinje/Personlinje.tsx
@@ -20,7 +20,7 @@ const Separator = () => (
 );
 
 const Personlinje = (props: { søker: Person; sak: Sak }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <div className={styles.container}>

--- a/src/components/revurdering/RevurderingÅrsakOgBegrunnelse.tsx
+++ b/src/components/revurdering/RevurderingÅrsakOgBegrunnelse.tsx
@@ -7,7 +7,7 @@ import { useI18n } from '~lib/hooks';
 import { Revurdering } from '~types/Revurdering';
 
 const RevurderingÅrsakOgBegrunnelse = (props: { revurdering: Revurdering; className?: string }) => {
-    const intl = useI18n({ messages: sharedMessages });
+    const { intl } = useI18n({ messages: sharedMessages });
     return (
         <div className={props.className}>
             <p>

--- a/src/features/revurdering/formuestatus/Formuestatus.tsx
+++ b/src/features/revurdering/formuestatus/Formuestatus.tsx
@@ -9,7 +9,7 @@ import messages from './formuestatus-nb';
 import styles from './formuestatus.module.less';
 
 const Formuestatus = (props: { bekreftetFormue: number; erVilkårOppfylt: boolean }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <div className={styles.statusContainer}>

--- a/src/features/revurdering/revurderingoppsummering/beregningblokk/Beregningblokk.tsx
+++ b/src/features/revurdering/revurderingoppsummering/beregningblokk/Beregningblokk.tsx
@@ -15,7 +15,7 @@ import messages from './beregningblokk-nb';
 import styles from './beregningblokk.module.less';
 
 const Beregningblokk = (props: { revurdering: Revurdering }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const alert = React.useMemo(() => {
         if (erRevurderingIngenEndring(props.revurdering)) {

--- a/src/features/revurdering/revurderingoppsummering/formuevilkåroppsummering/FormuevilkårOppsummering.tsx
+++ b/src/features/revurdering/revurderingoppsummering/formuevilkåroppsummering/FormuevilkårOppsummering.tsx
@@ -22,7 +22,7 @@ const FormuevilkårOppsummering = (props: { gjeldendeFormue: FormueVilkår }) =>
 };
 
 export const Formuevurdering = ({ vurdering }: { vurdering: VurderingsperiodeFormue }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <div>

--- a/src/features/revurdering/revurderingoppsummering/oppsummeringsblokk/Oppsummeringsblokk.tsx
+++ b/src/features/revurdering/revurderingoppsummering/oppsummeringsblokk/Oppsummeringsblokk.tsx
@@ -15,7 +15,7 @@ import messages from './oppsummeringsblokk-nb';
 import styles from './oppsummeringsblokk.module.less';
 
 const Intro = (props: { revurdering: Revurdering }) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
     return (
         <div className={styles.intro}>
             {[
@@ -55,7 +55,7 @@ const Oppsummeringsblokk = (props: {
     revurdering: Revurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     return (
         <Oppsummeringspanel
             tittel={intl.formatMessage({ id: 'heading' })}

--- a/src/features/revurdering/revurderingoppsummering/vedtaksinformasjon/Vedtaksinformasjon.tsx
+++ b/src/features/revurdering/revurderingoppsummering/vedtaksinformasjon/Vedtaksinformasjon.tsx
@@ -60,21 +60,21 @@ const Uførevilkårblokk = (props: {
     revurdering: Revurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
-    const intl = useI18n({ messages });
+    const i18n = useI18n({ messages });
     return pipe(
         O.fromNullable(props.revurdering.grunnlagsdataOgVilkårsvurderinger.uføre),
         O.fold(
             () => null,
             (uførevilkår) => (
-                <Rad radTittel={intl.formatMessage({ id: 'radTittel.uførhet' })}>
+                <Rad radTittel={i18n.formatMessage('radTittel.uførhet')}>
                     {{
-                        venstre: <Vilkårvisning grunnlagsblokker={getUførevilkårgrunnlagsblokker(uførevilkår, intl)} />,
+                        venstre: <Vilkårvisning grunnlagsblokker={getUførevilkårgrunnlagsblokker(uførevilkår, i18n)} />,
                         høyre: pipe(
                             O.fromNullable(props.grunnlagsdataOgVilkårsvurderinger.uføre),
                             O.fold(
                                 () => null,
                                 (grunnlag) => (
-                                    <Vilkårvisning grunnlagsblokker={getUførevilkårgrunnlagsblokker(grunnlag, intl)} />
+                                    <Vilkårvisning grunnlagsblokker={getUførevilkårgrunnlagsblokker(grunnlag, i18n)} />
                                 )
                             )
                         ),
@@ -89,18 +89,18 @@ const Bosituasjonblokk = (props: {
     revurdering: Revurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
-    const intl = useI18n({ messages });
+    const i18n = useI18n({ messages });
 
     return pipe(
         O.fromNullable(hentBosituasjongrunnlag(props.revurdering.grunnlagsdataOgVilkårsvurderinger)),
         O.fold(
             () => null,
             (bosituasjongrunnlag) => (
-                <Rad radTittel={intl.formatMessage({ id: 'radTittel.bosituasjon' })}>
+                <Rad radTittel={i18n.formatMessage('radTittel.bosituasjon')}>
                     {{
                         venstre: (
                             <Vilkårvisning
-                                grunnlagsblokker={getBosituasjongrunnlagsblokker(bosituasjongrunnlag, intl)}
+                                grunnlagsblokker={getBosituasjongrunnlagsblokker(bosituasjongrunnlag, i18n)}
                             />
                         ),
                         høyre: pipe(
@@ -108,7 +108,7 @@ const Bosituasjonblokk = (props: {
                             O.fold(
                                 () => null,
                                 (grunnlag) => (
-                                    <Vilkårvisning grunnlagsblokker={getBosituasjongrunnlagsblokker(grunnlag, intl)} />
+                                    <Vilkårvisning grunnlagsblokker={getBosituasjongrunnlagsblokker(grunnlag, i18n)} />
                                 )
                             )
                         ),
@@ -149,7 +149,7 @@ const Formueblokk = (props: {
     revurdering: Revurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return pipe(
         O.fromNullable(props.revurdering.grunnlagsdataOgVilkårsvurderinger.formue),
@@ -179,7 +179,7 @@ const Vedtaksinformasjon = (props: {
     revurdering: Revurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const skalViseEndringerIOppsummering = Object.entries(props.revurdering.informasjonSomRevurderes)
         .filter(([informasjon]) => informasjon !== InformasjonSomRevurderes.Inntekt)

--- a/src/features/revurdering/revurderingoppsummering/vedtaksinformasjon/grunnlagsblokker.ts
+++ b/src/features/revurdering/revurderingoppsummering/vedtaksinformasjon/grunnlagsblokker.ts
@@ -1,7 +1,6 @@
-import { IntlShape } from 'react-intl';
-
 import { formatPeriode } from '~lib/dateUtils';
 import { formatCurrency } from '~lib/formatUtils';
+import { UseI18N } from '~lib/hooks';
 import {
     erBosituasjonFullstendig,
     BosituasjonTyper,
@@ -9,58 +8,66 @@ import {
 } from '~types/grunnlagsdataOgVilkårsvurderinger/bosituasjon/Bosituasjongrunnlag';
 import { UføreResultat, UføreVilkår } from '~types/grunnlagsdataOgVilkårsvurderinger/uføre/Uførevilkår';
 
+import messages from './vedtaksinformasjon-nb';
+
+type Messages = typeof messages;
+
 export type Grunnlagsblokk = Array<{
     label: string;
     verdi: string;
 }>;
 
-export function getUførevilkårgrunnlagsblokker(vilkår: UføreVilkår, intl: IntlShape): Grunnlagsblokk[] {
+export function getUførevilkårgrunnlagsblokker(
+    vilkår: UføreVilkår,
+    { intl, formatMessage }: UseI18N<Messages>
+): Grunnlagsblokk[] {
     return vilkår.vurderinger.map((v) =>
         v.grunnlag && v.resultat === UføreResultat.VilkårOppfylt
             ? [
                   {
-                      label: intl.formatMessage({ id: 'uførhet.label.uføregrad' }),
+                      label: formatMessage('uførhet.label.uføregrad'),
                       verdi: `${v.grunnlag.uføregrad.toString()}%`,
                   },
                   {
-                      label: intl.formatMessage({ id: 'generell.label.periode' }),
+                      label: formatMessage('generell.label.periode'),
                       verdi: formatPeriode(v.grunnlag.periode, intl),
                   },
                   {
-                      label: intl.formatMessage({ id: 'uførhet.label.ieu' }),
+                      label: formatMessage('uførhet.label.ieu'),
                       verdi: formatCurrency(intl, v.grunnlag.forventetInntekt),
                   },
               ]
             : [
                   {
-                      label: intl.formatMessage({ id: 'uførhet.label.harUførevedtak' }),
-                      verdi: intl.formatMessage({ id: 'generell.nei' }),
+                      label: formatMessage('uførhet.label.harUførevedtak'),
+                      verdi: formatMessage('generell.nei'),
                   },
                   {
-                      label: intl.formatMessage({ id: 'generell.label.periode' }),
+                      label: formatMessage('generell.label.periode'),
                       verdi: formatPeriode(v.periode, intl),
                   },
               ]
     );
 }
 
-export function getBosituasjongrunnlagsblokker(b: Bosituasjon, intl: IntlShape): Grunnlagsblokk[] {
+export function getBosituasjongrunnlagsblokker(
+    b: Bosituasjon,
+    { intl, formatMessage }: UseI18N<Messages>
+): Grunnlagsblokk[] {
     if (!erBosituasjonFullstendig(b)) {
         return [];
     }
     const basics = [
         {
-            label: intl.formatMessage({ id: 'generell.label.periode' }),
+            label: formatMessage('generell.label.periode'),
             verdi: formatPeriode(b.periode, intl),
         },
         {
-            label: intl.formatMessage({ id: 'bosituasjon.label.sats' }),
-            verdi: intl.formatMessage({
-                id: b.sats === 'ORDINÆR' ? 'bosituasjon.sats.ordinær' : 'bosituasjon.sats.høy',
-            }),
+            label: formatMessage('bosituasjon.label.sats'),
+            verdi: formatMessage(b.sats === 'ORDINÆR' ? 'bosituasjon.sats.ordinær' : 'bosituasjon.sats.høy'),
         },
         {
-            label: intl.formatMessage({ id: 'generell.label.begrunnelse' }),
+            label: formatMessage('generell.label.begrunnelse'),
             verdi: b.begrunnelse ?? '',
         },
     ];
@@ -70,12 +77,12 @@ export function getBosituasjongrunnlagsblokker(b: Bosituasjon, intl: IntlShape):
                 [
                     ...basics,
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.harEps' }),
-                        verdi: intl.formatMessage({ id: 'generell.nei' }),
+                        label: formatMessage('bosituasjon.label.harEps'),
+                        verdi: formatMessage('generell.nei'),
                     },
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.delerBolig' }),
-                        verdi: intl.formatMessage({ id: 'generell.ja' }),
+                        label: formatMessage('bosituasjon.label.delerBolig'),
+                        verdi: formatMessage('generell.ja'),
                     },
                 ],
             ];
@@ -84,12 +91,12 @@ export function getBosituasjongrunnlagsblokker(b: Bosituasjon, intl: IntlShape):
                 [
                     ...basics,
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.harEps' }),
-                        verdi: intl.formatMessage({ id: 'generell.ja' }),
+                        label: formatMessage('bosituasjon.label.harEps'),
+                        verdi: formatMessage('generell.ja'),
                     },
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.epsUførFlyktning' }),
-                        verdi: intl.formatMessage({ id: 'generell.nei' }),
+                        label: formatMessage('bosituasjon.label.epsUførFlyktning'),
+                        verdi: formatMessage('generell.nei'),
                     },
                 ],
             ];
@@ -98,12 +105,12 @@ export function getBosituasjongrunnlagsblokker(b: Bosituasjon, intl: IntlShape):
                 [
                     ...basics,
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.harEps' }),
-                        verdi: intl.formatMessage({ id: 'generell.ja' }),
+                        label: formatMessage('bosituasjon.label.harEps'),
+                        verdi: formatMessage('generell.ja'),
                     },
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.epsUførFlyktning' }),
-                        verdi: intl.formatMessage({ id: 'generell.nei' }),
+                        label: formatMessage('bosituasjon.label.epsUførFlyktning'),
+                        verdi: formatMessage('generell.nei'),
                     },
                 ],
             ];
@@ -112,12 +119,12 @@ export function getBosituasjongrunnlagsblokker(b: Bosituasjon, intl: IntlShape):
                 [
                     ...basics,
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.harEps' }),
-                        verdi: intl.formatMessage({ id: 'generell.ja' }),
+                        label: formatMessage('bosituasjon.label.harEps'),
+                        verdi: formatMessage('generell.ja'),
                     },
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.epsUførFlyktning' }),
-                        verdi: intl.formatMessage({ id: 'generell.ja' }),
+                        label: formatMessage('bosituasjon.label.epsUførFlyktning'),
+                        verdi: formatMessage('generell.ja'),
                     },
                 ],
             ];
@@ -126,12 +133,12 @@ export function getBosituasjongrunnlagsblokker(b: Bosituasjon, intl: IntlShape):
                 [
                     ...basics,
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.harEps' }),
-                        verdi: intl.formatMessage({ id: 'generell.nei' }),
+                        label: formatMessage('bosituasjon.label.harEps'),
+                        verdi: formatMessage('generell.nei'),
                     },
                     {
-                        label: intl.formatMessage({ id: 'bosituasjon.label.delerBolig' }),
-                        verdi: intl.formatMessage({ id: 'generell.nei' }),
+                        label: formatMessage('bosituasjon.label.delerBolig'),
+                        verdi: formatMessage('generell.nei'),
                     },
                 ],
             ];

--- a/src/features/revurdering/revurderingskallFeilet/RevurderingskallFeilet.tsx
+++ b/src/features/revurdering/revurderingskallFeilet/RevurderingskallFeilet.tsx
@@ -95,7 +95,7 @@ export const feilkodeTilFeilmelding = (intl: IntlShape, feil?: Nullable<ErrorMes
 };
 
 const RevurderingskallFeilet = (props: { error?: ApiError }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <AlertStripeFeil className={styles.alertstripe}>

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,7 +1,7 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { AsyncThunk } from '@reduxjs/toolkit';
 import React, { useState } from 'react';
-import { createIntlCache, createIntl } from 'react-intl';
+import { createIntlCache, createIntl, IntlShape } from 'react-intl';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ApiClientResult, ApiError } from '~api/apiClient';
@@ -9,13 +9,24 @@ import { useAppDispatch } from '~redux/Store';
 
 import { SuccessNotificationState } from './routes';
 
-export const useI18n = (args: { messages: Record<string, string> }) => {
+export type MessageFormatter<T extends Record<string, string>> = (id: keyof T) => string;
+export interface UseI18N<T extends Record<string, string>> {
+    intl: IntlShape;
+    formatMessage: MessageFormatter<T>;
+}
+
+export const useI18n = <T extends Record<string, string>>(args: { messages: T }): UseI18N<T> => {
     const intl = React.useMemo(() => {
         const cache = createIntlCache();
         return createIntl({ locale: 'nb-NO', messages: args.messages }, cache);
     }, [args.messages]);
 
-    return intl;
+    const formatMessage: MessageFormatter<T> = React.useCallback(
+        (id: keyof T) => intl.formatMessage({ id: id as string }),
+        [intl]
+    );
+
+    return { intl, formatMessage };
 };
 
 export const useDocTitle = (title: string) => {

--- a/src/pages/attestering/Attestering.tsx
+++ b/src/pages/attestering/Attestering.tsx
@@ -18,7 +18,7 @@ import AttesterRevurdering from './attesterRevurdering/AttesterRevurdering';
 const Attestering = () => {
     const dispatch = useAppDispatch();
     const urlParams = Routes.useRouteParams<typeof Routes.attestering>();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const { sak, søker } = useAppSelector((s) => ({ sak: s.sak.sak, søker: s.søker.søker }));
 
     useEffect(() => {

--- a/src/pages/attestering/attesterBehandlingPage/AttesterBehandlingPage.tsx
+++ b/src/pages/attestering/attesterBehandlingPage/AttesterBehandlingPage.tsx
@@ -243,7 +243,7 @@ const Attesteringsinnhold = ({
 
 const AttesterBehandling = (props: { sak: Sak; søker: Person }) => {
     const urlParams = Routes.useRouteParams<typeof Routes.attesterBehandling>();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const behandling = props.sak.behandlinger.find((x) => x.id === urlParams.behandlingId);
 

--- a/src/pages/attestering/attesterRevurdering/AttesterRevurdering.tsx
+++ b/src/pages/attestering/attesterRevurdering/AttesterRevurdering.tsx
@@ -71,7 +71,7 @@ const schema = yup.object<FormData>({
 
 const AttesterRevurdering = (props: { sak: Sak; søker: Person }) => {
     const urlParams = Routes.useRouteParams<typeof Routes.attesterRevurdering>();
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
     const revurdering = props.sak.revurderinger.find((r) => r.id === urlParams.revurderingId);
     const dispatch = useAppDispatch();
     const history = useHistory();

--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -37,7 +37,7 @@ const Saksoversikt = () => {
     const urlParams = Routes.useRouteParams<typeof Routes.saksoversiktValgtSak>();
     const history = useHistory();
 
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const { søker, sak } = useAppSelector((s) => ({ søker: s.søker.søker, sak: s.sak.sak }));
     const dispatch = useAppDispatch();

--- a/src/pages/saksbehandling/behandlingsoppsummeringPage/BehandlingsoppsummeringPage.tsx
+++ b/src/pages/saksbehandling/behandlingsoppsummeringPage/BehandlingsoppsummeringPage.tsx
@@ -18,7 +18,7 @@ const BehandlingsoppsummeringPage = (props: Props) => {
     const urlParams = Routes.useRouteParams<typeof Routes.saksoversiktValgtBehandling>();
     const behandling = props.sak.behandlinger.find((behandling) => behandling.id === urlParams.behandlingId);
     const vedtakForBehandling = props.sak.vedtak.find((v) => v.behandlingId === behandling?.id);
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     if (!behandling) {
         return <></>;

--- a/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
@@ -36,7 +36,7 @@ interface AvvistProps {
 const Avvist = (props: AvvistProps) => {
     const dispatch = useAppDispatch();
     const urlParams = Routes.useRouteParams<typeof Routes.avsluttSøknadsbehandling>();
-    const intl = useI18n({ messages: nb });
+    const { intl } = useI18n({ messages: nb });
 
     const onSeBrevClick = useCallback(() => {
         if (

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -33,7 +33,7 @@ const LukkSøknad = (props: { sak: Sak }) => {
     const urlParams = Routes.useRouteParams<typeof Routes.avsluttSøknadsbehandling>();
     const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
     const søknad = props.sak.søknader.find((s) => s.id === urlParams.soknadId);
-    const intl = useI18n({ messages: nb });
+    const { intl } = useI18n({ messages: nb });
     const history = useHistory();
 
     const formik = useFormik<LukkSøknadFormData>({

--- a/src/pages/saksbehandling/lukkSøknad/Trukket.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Trukket.tsx
@@ -28,7 +28,7 @@ interface TrukketProps {
 const Trukket = (props: TrukketProps) => {
     const dispatch = useAppDispatch();
     const [clickedViewLetter, setClickedViewLetter] = useState<boolean>(false);
-    const intl = useI18n({ messages: nb });
+    const { intl } = useI18n({ messages: nb });
 
     const onSeBrevClick = useCallback(() => {
         if (RemoteData.isPending(props.lukketSøknadBrevutkastStatus)) {

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
@@ -52,7 +52,7 @@ const OppsummeringshandlingForm = (props: {
     feilmeldinger: ErrorMessage[];
 }) => {
     const history = useHistory();
-    const intl = useI18n({ messages: { ...messages, ...revurderingsfeilMessages } });
+    const { intl } = useI18n({ messages: { ...messages, ...revurderingsfeilMessages } });
     const feilRef = React.useRef<HTMLDivElement>(null);
 
     const [sendTilAttesteringState, sendTilAttestering] = useAsyncActionCreatorWithArgsTransformer(
@@ -249,7 +249,7 @@ const RevurderingOppsummeringPage = (props: {
     grunnlagsdataOgVilkårsvurderinger: RemoteData.RemoteData<ApiError, GrunnlagsdataOgVilkårsvurderinger>;
 }) => {
     const dispatch = useAppDispatch();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     React.useEffect(() => {
         if (RemoteData.isInitial(props.grunnlagsdataOgVilkårsvurderinger)) {

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
@@ -21,7 +21,7 @@ import styles from './oppsummeringPageForms.module.less';
 const VedtaksbrevInput = (
     props: { sakId: string; revurderingId: string } & Omit<BrevInputProps, 'tittel' | 'placeholder' | 'onVisBrevClick'>
 ) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <BrevInput
@@ -44,7 +44,7 @@ const VedtaksbrevInput = (
 const ForhåndsvarselbrevInput = (
     props: { sakId: string; revurderingId: string } & Omit<BrevInputProps, 'tittel' | 'placeholder' | 'onVisBrevClick'>
 ) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <BrevInput
@@ -64,7 +64,7 @@ const BeslutningEtterForhåndsvarselRadios = (props: {
     feil?: string;
     onChange(beslutning: BeslutningEtterForhåndsvarsling): void;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const name = 'beslutningEtterForhåndsvarsel';
     return (
         <RadioGruppe
@@ -109,7 +109,7 @@ export const ResultatEtterForhåndsvarselform = (props: {
         begrunnelse: string;
     }): void;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     interface FormData {
         resultatEtterForhåndsvarsel: Nullable<BeslutningEtterForhåndsvarsling>;
@@ -214,7 +214,7 @@ export const VelgForhåndsvarselForm = (props: {
         fritekstTilBrev: Nullable<string>;
     }
 
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const form = useForm<FormData>({
         defaultValues: {
@@ -315,7 +315,7 @@ export const SendTilAttesteringForm = (props: {
     brevsending: 'aldriSende' | 'alltidSende' | 'kanVelge';
     onSubmit(args: { fritekstTilBrev: string; skalFøreTilBrevutsending: boolean }): void;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     interface FormData {
         tekstTilVedtaksbrev: string;
         skalFøreTilBrevutsending: boolean;

--- a/src/pages/saksbehandling/revurdering/Revurdering.tsx
+++ b/src/pages/saksbehandling/revurdering/Revurdering.tsx
@@ -55,7 +55,7 @@ const stegTilTekstId = (steg: RevurderingSteg) => {
 };
 
 const RevurderingPage = (props: { sak: Sak }) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
 
     const urlParams = Routes.useRouteParams<typeof Routes.revurderValgtRevurdering>();
 

--- a/src/pages/saksbehandling/revurdering/bosituasjon/BosituasjonForm.tsx
+++ b/src/pages/saksbehandling/revurdering/bosituasjon/BosituasjonForm.tsx
@@ -39,7 +39,7 @@ interface BosituasjonFormData {
 }
 
 const GjeldendeBosituasjon = (props: { bosituasjon?: Bosituasjon[] }) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
 
     return (
         <div>
@@ -219,7 +219,7 @@ const BosituasjonForm = (props: {
     forrigeUrl: string;
     nesteUrl: (revurdering: Revurdering) => string;
 }) => {
-    const intl = useI18n({ messages: { ...messages, ...sharedMessages } });
+    const { intl } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const [epsAlder, setEpsAlder] = useState<Nullable<number>>(null);
     const [status, setStatus] = React.useState<RemoteData.RemoteData<ApiError, null>>(RemoteData.initial);
     const dispatch = useAppDispatch();

--- a/src/pages/saksbehandling/revurdering/bunnknapper/RevurderingBunnknapper.tsx
+++ b/src/pages/saksbehandling/revurdering/bunnknapper/RevurderingBunnknapper.tsx
@@ -16,7 +16,7 @@ export const RevurderingBunnknapper = (props: {
     onLagreOgFortsettSenereClickSpinner?: boolean;
     nesteKnappTekst?: string;
 }) => {
-    const intl = useI18n({ messages: { ...sharedI18n } });
+    const { intl } = useI18n({ messages: { ...sharedI18n } });
 
     return (
         <div>

--- a/src/pages/saksbehandling/revurdering/endringAvFradrag/EndringAvFradrag.tsx
+++ b/src/pages/saksbehandling/revurdering/endringAvFradrag/EndringAvFradrag.tsx
@@ -51,7 +51,7 @@ interface EndringAvFradragFormData {
 }
 
 const GjeldendeFradrag = (props: { fradrag: Fradrag[] }) => {
-    const intl = useI18n({ messages: { ...messages, ...fradragstypeMessages } });
+    const { intl } = useI18n({ messages: { ...messages, ...fradragstypeMessages } });
     return (
         <div>
             <Systemtittel className={styles.grunnlagsdataHeading}>
@@ -138,7 +138,7 @@ const EndringAvFradrag = (props: {
     forrigeUrl: string;
     nesteUrl: string;
 }) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: { ...sharedMessages, ...fradragMessages, ...uføreMessages, ...fradragstypeMessages },
     });
     const dispatch = useAppDispatch();

--- a/src/pages/saksbehandling/revurdering/formue/Formue.tsx
+++ b/src/pages/saksbehandling/revurdering/formue/Formue.tsx
@@ -54,7 +54,7 @@ import styles from './formue.module.less';
 const Formue = (props: RevurderingProps) => {
     const formuegrenser = props.gjeldendeGrunnlagsdataOgVilkårsvurderinger.formue.formuegrenser;
     const history = useHistory();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const [epsStatus, hentEPS] = useApiCall(personApi.fetchPerson);
     const epsFnr = hentBosituasjongrunnlag(props.revurdering.grunnlagsdataOgVilkårsvurderinger).fnr;
     const [lagreFormuegrunnlagStatus, lagreFormuegrunnlagAction] = useAsyncActionCreator(lagreFormuegrunnlag);
@@ -155,7 +155,7 @@ const FormueBlokk = (props: {
     triggerValidation: UseFormTrigger<FormueFormData>;
     onSlettClick: (index: number) => void;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const blokkName = `formue.${props.blokkIndex}` as const;
     const [søkersBekreftetFormue, setSøkersBekreftetFormue] = useState<number>(
         regnUtFormDataVerdier(props.blokkField.søkersFormue)
@@ -319,7 +319,7 @@ const FormuePanel = (props: {
     formController: Control<FormueFormData>;
     triggerValidation: UseFormTrigger<FormueFormData>;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const [åpen, setÅpen] = useState<boolean>(false);
     const formueTilhører = props.tilhører === 'Søkers' ? 'søkersFormue' : 'epsFormue';
     const panelName = `formue.${props.blokkIndex}.${formueTilhører}` as const;

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroForm.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroForm.tsx
@@ -88,7 +88,7 @@ const informasjonSomRevurderesMessageId = (i: InformasjonSomRevurderes) => {
 };
 
 const RevurderingIntroForm = (props: RevurderingIntroFormProps) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
     const [submittedStatus, setSubmittedStatus] = useState<SubmittedStatus>(SubmittedStatus.NOT_SUBMITTED);
 
     const hasSubmitted = () => submittedStatus === SubmittedStatus.NESTE || submittedStatus === SubmittedStatus.LAGRE;

--- a/src/pages/saksbehandling/revurdering/revurderingsperiodeheader/RevurderingsperiodeHeader.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingsperiodeheader/RevurderingsperiodeHeader.tsx
@@ -9,7 +9,7 @@ import messages from './revurderingsperiodeheader-nb';
 import styles from './revurderingsperiodeheader.module.less';
 
 const RevurderingsperiodeHeader = (props: { periode: Periode<string> }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     return (
         <div className={styles.container}>
             <Systemtittel className={styles.tittel}>{intl.formatMessage({ id: 'heading' })}</Systemtittel>

--- a/src/pages/saksbehandling/revurdering/uførhet/Uførhet.tsx
+++ b/src/pages/saksbehandling/revurdering/uførhet/Uførhet.tsx
@@ -110,7 +110,7 @@ const Uføreperiodevurdering = (props: {
     maxDate: Date;
     onRemoveClick(): void;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const value = useWatch({ control: props.control, name: `grunnlag.${props.index}` as `grunnlag.0` });
 
     React.useEffect(() => {
@@ -229,7 +229,7 @@ const Uføreperiodevurdering = (props: {
 };
 
 const UførhetForm = (props: { sakId: string; revurdering: Revurdering; forrigeUrl: string; nesteUrl: string }) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
     const dispatch = useAppDispatch();
     const history = useHistory();
 
@@ -385,7 +385,7 @@ const UførhetForm = (props: { sakId: string; revurdering: Revurdering; forrigeU
 };
 
 const GjeldendeGrunnlagsdata = (props: { vilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger }) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
     return (
         <div>
             <Systemtittel className={styles.grunnlagsdataHeading}>

--- a/src/pages/saksbehandling/sakintro/Sakintro.tsx
+++ b/src/pages/saksbehandling/sakintro/Sakintro.tsx
@@ -72,7 +72,7 @@ const lukketBegrunnelseResourceId = (type?: LukkSøknadBegrunnelse) => {
 
 const Sakintro = (props: { sak: Sak; søker: Person }) => {
     const locationState = useNotificationFromLocation();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const åpneSøknader = props.sak.søknader
         .filter((søknad) => {

--- a/src/pages/saksbehandling/sakintro/Utbetalinger.tsx
+++ b/src/pages/saksbehandling/sakintro/Utbetalinger.tsx
@@ -27,7 +27,7 @@ export const Utbetalinger = (props: {
     utbetalingsperioder: Utbetalingsperiode[];
     kanStansesEllerGjenopptas: KanStansesEllerGjenopptas;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const dispatch = useAppDispatch();
     const { utbetalingsperioder, kanStansesEllerGjenopptas, søker } = props;
     const { stansUtbetalingerStatus, gjenopptaUtbetalingerStatus } = useAppSelector((s) => s.sak);

--- a/src/pages/saksbehandling/sendTilAttesteringPage/SendTilAttesteringPage.tsx
+++ b/src/pages/saksbehandling/sendTilAttesteringPage/SendTilAttesteringPage.tsx
@@ -32,7 +32,7 @@ type Props = {
 
 const SendTilAttesteringPage = (props: Props) => {
     const { sak } = props;
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const dispatch = useAppDispatch();
     const { sendtTilAttesteringStatus } = useAppSelector((s) => s.sak);

--- a/src/pages/saksbehandling/steg/Vurdering.tsx
+++ b/src/pages/saksbehandling/steg/Vurdering.tsx
@@ -12,7 +12,7 @@ export const Vurderingknapper = (props: {
     onLagreOgFortsettSenereClick(): void;
     nesteKnappTekst?: string;
 }) => {
-    const intl = useI18n({ messages: { ...sharedI18n } });
+    const { intl } = useI18n({ messages: { ...sharedI18n } });
 
     return (
         <div className={styles.buttonContainer}>

--- a/src/pages/saksbehandling/steg/fast-opphold-i-norge/FastOppholdINorge.tsx
+++ b/src/pages/saksbehandling/steg/fast-opphold-i-norge/FastOppholdINorge.tsx
@@ -49,7 +49,7 @@ const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const formik = useFormik<FormData>({
         initialValues: {

--- a/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/steg/flyktning/Flyktning.tsx
@@ -46,7 +46,7 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const vilGiTidligAvslag = (): boolean => {
         return (

--- a/src/pages/saksbehandling/steg/formue/Formue.tsx
+++ b/src/pages/saksbehandling/steg/formue/Formue.tsx
@@ -80,7 +80,7 @@ const schema = yup.object<FormData>({
 const Formue = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const [eps, setEps] = useState<RemoteData.RemoteData<ApiError, personApi.Person>>(RemoteData.initial);
     const [kanEndreAnnenPersonsFormue, setKanEndreAnnenPersonsFormue] = useState<boolean>(true);
     const [åpnerNyFormueBlokkMenViserEnBlokk, setÅpnerNyFormueBlokkMenViserEnBlokk] = useState<boolean>(false);

--- a/src/pages/saksbehandling/steg/framdriftsindikator/SaksbehandlingFramdriftsindikator.tsx
+++ b/src/pages/saksbehandling/steg/framdriftsindikator/SaksbehandlingFramdriftsindikator.tsx
@@ -30,7 +30,7 @@ const SaksbehandlingFramdriftsindikator = (props: { sakId: string; behandling: B
     const { behandlingsinformasjon } = props.behandling;
     const vilkårrekkefølge = mapToVilkårsinformasjon(behandlingsinformasjon);
     const beregningsrekkefølge = vilkårsinformasjonForBeregningssteg(props.behandling);
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const vilkårUrl = (vt: Vilkårtype) =>
         Routes.saksbehandlingVilkårsvurdering.createURL({

--- a/src/pages/saksbehandling/steg/institusjonsopphold/Institusjonsopphold.tsx
+++ b/src/pages/saksbehandling/steg/institusjonsopphold/Institusjonsopphold.tsx
@@ -53,7 +53,7 @@ const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
     const history = useHistory();
     const [hasSubmitted, setHasSubmitted] = useState(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const formik = useFormik<InstitusjonsoppholdFormData>({
         initialValues: {

--- a/src/pages/saksbehandling/steg/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
+++ b/src/pages/saksbehandling/steg/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
@@ -45,7 +45,7 @@ const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const handleSave = async (values: FormData, nesteUrl: string) => {
         if (!values.status) return;

--- a/src/pages/saksbehandling/steg/opphold-i-utlandet/OppholdIUtlandet.tsx
+++ b/src/pages/saksbehandling/steg/opphold-i-utlandet/OppholdIUtlandet.tsx
@@ -39,7 +39,7 @@ const OppholdIUtlandet = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const handleSave = async (values: FormData, nesteUrl: string) => {
         if (!values.status) return;

--- a/src/pages/saksbehandling/steg/personlig-oppmøte/PersonligOppmøte.tsx
+++ b/src/pages/saksbehandling/steg/personlig-oppmøte/PersonligOppmøte.tsx
@@ -199,7 +199,7 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const handleLagreOgFortsettSenere = async (values: FormData) => {
         const personligOppmøteStatus = toPersonligOppmøteStatus(values);

--- a/src/pages/saksbehandling/steg/sats/Sats.tsx
+++ b/src/pages/saksbehandling/steg/sats/Sats.tsx
@@ -140,7 +140,7 @@ const getValidationSchema = (eps: Nullable<Person>) => {
 
 const Sats = (props: VilkårsvurderingBaseProps) => {
     const [epsStatus, fetchEps] = useApiCall(fetchPerson);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const history = useHistory();
     const epsFnr = hentBosituasjongrunnlag(props.behandling.grunnlagsdataOgVilkårsvurderinger).fnr;
 

--- a/src/pages/saksbehandling/steg/uførhet/Uførhet.tsx
+++ b/src/pages/saksbehandling/steg/uførhet/Uførhet.tsx
@@ -68,7 +68,7 @@ const Uførhet = (props: VilkårsvurderingBaseProps) => {
     const dispatch = useAppDispatch();
     const [hasSubmitted, setHasSubmitted] = useState(false);
     const lagreBehandlingsinformasjonStatus = useAppSelector((s) => s.sak.lagreBehandlingsinformasjonStatus);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const handleSave = async (values: FormData, nesteUrl: string) => {
         if (!values.status) return;

--- a/src/pages/saksbehandling/steg/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/src/pages/saksbehandling/steg/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -71,7 +71,7 @@ const schema = yup.object<FormData>({
 });
 
 const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
-    const intl = useI18n({ messages: { ...sharedMessages, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedMessages, ...messages } });
     const history = useHistory();
     const [savingState, setSavingState] = React.useState<RemoteData.RemoteData<ApiError, null>>(RemoteData.initial);
     const dispatch = useAppDispatch();

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -194,7 +194,7 @@ const StartUtfylling = () => {
     const { søker: søkerFraStore } = useAppSelector((s) => s.søker);
     const søknad = useAppSelector((s) => s.soknad);
     const { step } = useParams<{ step: Søknadsteg }>();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const user = useUserContext();
     const history = useHistory();
 

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/Bo-og-opphold-i-norge.tsx
@@ -207,7 +207,7 @@ const BoOgOppholdINorge = (props: { forrigeUrl: string; nesteUrl: string; avbryt
     });
 
     const feiloppsummeringref = React.useRef<HTMLDivElement>(null);
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     let adresser: Array<{ label: string; radioValue: Adresse }> = [];
 
     if (RemoteData.isSuccess(søker) && søker.value.adresse) {

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
@@ -19,7 +19,7 @@ interface Props {
 const EktefellePartnerSamboer = (props: Props) => {
     const epsFormData: EPSFormData = props.value ?? { fnr: null, alder: null, erUførFlyktning: null };
 
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     const erEpsUnder67 = useMemo(() => {
         return epsFormData.alder && epsFormData.alder < 67;

--- a/src/pages/søknad/steg/ektefelle/EktefellesFormue.tsx
+++ b/src/pages/søknad/steg/ektefelle/EktefellesFormue.tsx
@@ -268,7 +268,7 @@ const EktefellesFormue = (props: { forrigeUrl: string; nesteUrl: string; avbrytU
         validateOnChange: hasSubmitted,
     });
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const feiloppsummeringref = React.useRef<HTMLDivElement>(null);
 

--- a/src/pages/søknad/steg/ektefelle/EktefellesInntekt.tsx
+++ b/src/pages/søknad/steg/ektefelle/EktefellesInntekt.tsx
@@ -323,7 +323,7 @@ const EktefellesInntekt = (props: { forrigeUrl: string; nesteUrl: string; avbryt
         );
     };
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     return (
         <RawIntlProvider value={intl}>
             <div className={sharedStyles.container}>

--- a/src/pages/søknad/steg/flyktningstatus-oppholdstillatelse/Flyktningstatus-oppholdstillatelse.tsx
+++ b/src/pages/søknad/steg/flyktningstatus-oppholdstillatelse/Flyktningstatus-oppholdstillatelse.tsx
@@ -88,7 +88,7 @@ const FlyktningstatusOppholdstillatelse = (props: { forrigeUrl: string; nesteUrl
     });
     const feiloppsummeringref = React.useRef<HTMLDivElement>(null);
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     return (
         <RawIntlProvider value={intl}>

--- a/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
+++ b/src/pages/søknad/steg/for-veileder/ForVeileder.tsx
@@ -69,7 +69,7 @@ const ForVeileder = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: s
         validateOnChange: hasSubmitted,
     });
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     return (
         <TextProvider messages={{ [Languages.nb]: messages }}>
             <div>

--- a/src/pages/søknad/steg/formue/DinFormue.tsx
+++ b/src/pages/søknad/steg/formue/DinFormue.tsx
@@ -313,7 +313,7 @@ const DinFormue = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: str
         validateOnChange: hasSubmitted,
     });
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const feiloppsummeringref = React.useRef<HTMLDivElement>(null);
 

--- a/src/pages/søknad/steg/informasjon-om-papirsøknad/InformasjonOmPapirsøknad.tsx
+++ b/src/pages/søknad/steg/informasjon-om-papirsøknad/InformasjonOmPapirsøknad.tsx
@@ -64,7 +64,7 @@ const InformasjonOmPapirsøknad = (props: { forrigeUrl: string; nesteUrl: string
         validateOnChange: hasSubmitted,
     });
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     return (
         <TextProvider messages={{ [Languages.nb]: messages }}>
             <form

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -25,7 +25,7 @@ const index = (props: { nesteUrl: string }) => {
     const [hasSubmitted, setHasSubmitted] = React.useState<boolean>(false);
     const [erBekreftet, setErBekreftet] = React.useState<boolean>(false);
 
-    const intl = useI18n({ messages: nb });
+    const { intl } = useI18n({ messages: nb });
 
     React.useEffect(() => {
         dispatch(søknadSlice.actions.resetSøknad());

--- a/src/pages/søknad/steg/inntekt/Inntekt.tsx
+++ b/src/pages/søknad/steg/inntekt/Inntekt.tsx
@@ -365,7 +365,7 @@ const DinInntekt = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: st
         );
     };
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
     return (
         <RawIntlProvider value={intl}>
             <div className={sharedStyles.container}>

--- a/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
@@ -22,7 +22,7 @@ import Søknadoppsummering from './Søknadoppsummering/Søknadoppsummering';
 const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: string; søker: Person }) => {
     const history = useHistory();
     const [søknadFraStore, innsending] = useAppSelector((s) => [s.soknad, s.innsending.søknad]);
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const dispatch = useAppDispatch();
 
     const handleSubmit = async () => {

--- a/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
@@ -29,7 +29,7 @@ import oppsummeringMessages from './søknadsoppsummering-nb';
 import styles from './søknadsoppsummering.module.less';
 
 const Søknadoppsummering = ({ søknad, søker }: { søknad: SøknadState; søker: Person }) => {
-    const intl = useI18n({
+    const { intl } = useI18n({
         messages: {
             ...stegMessages,
             ...uførevedtakMessages,

--- a/src/pages/søknad/steg/oppsummering/components/EndreSvar.tsx
+++ b/src/pages/søknad/steg/oppsummering/components/EndreSvar.tsx
@@ -13,7 +13,7 @@ import messages from '../Søknadoppsummering/søknadsoppsummering-nb';
 import styles from '../Søknadoppsummering/søknadsoppsummering.module.less';
 
 export const EndreSvar = (props: { path: Søknadsteg; søker: Person }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     return (
         <Link
             className={styles.endreSvarContainer}

--- a/src/pages/søknad/steg/oppsummering/components/FormueOppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/components/FormueOppsummering.tsx
@@ -13,7 +13,7 @@ export const FormueOppsummering = ({
     formue: SøknadState['formue'];
     messages: Record<string, string>;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
 
     return (
         <>

--- a/src/pages/søknad/steg/oppsummering/components/InntektsOppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/components/InntektsOppsummering.tsx
@@ -15,7 +15,7 @@ const InntektsOppsummering = ({
     inntekt: SøknadState['inntekt'];
     messages: Record<string, string>;
 }) => {
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     return (
         <>
             <Oppsummeringsfelt

--- a/src/pages/søknad/steg/uførevedtak/Uførevedtak.tsx
+++ b/src/pages/søknad/steg/uførevedtak/Uførevedtak.tsx
@@ -39,7 +39,7 @@ const Uførevedtak = (props: { nesteUrl: string; forrigeUrl: string; avbrytUrl: 
         },
         validationSchema: schema,
     });
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const feiloppsummeringref = React.useRef<HTMLDivElement>(null);
 

--- a/src/pages/søknad/steg/utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/pages/søknad/steg/utenlandsopphold/Utenlandsopphold.tsx
@@ -266,7 +266,7 @@ const Utenlandsopphold = (props: { forrigeUrl: string; nesteUrl: string; avbrytU
         validateOnChange: hasSubmitted,
     });
 
-    const intl = useI18n({ messages: { ...sharedI18n, ...messages } });
+    const { intl } = useI18n({ messages: { ...sharedI18n, ...messages } });
 
     const feiloppsummeringref = React.useRef<HTMLDivElement>(null);
 

--- a/src/pages/vedtak/Vedtaksoppsummering.tsx
+++ b/src/pages/vedtak/Vedtaksoppsummering.tsx
@@ -45,7 +45,7 @@ const vedtaksresultatToTekst = (type: VedtakType, intl: IntlShape): string => {
 /* TODO ai 16.03.2021: Denna støtter pt innvilgede revurderingsvedtak. Må sørge for att søknadsbehandling og andre resultat støttes i framtiden. */
 const Vedtaksoppsummering = (props: Props) => {
     const urlParams = Routes.useRouteParams<typeof Routes.vedtaksoppsummering>();
-    const intl = useI18n({ messages });
+    const { intl } = useI18n({ messages });
     const [fetchVedtaksbrev, setFetchVedtaksbrev] = useState<RemoteData.RemoteData<ApiError, null>>(RemoteData.initial);
     const vedtak = props.sak.vedtak.find((v) => v.id === urlParams.vedtakId);
     if (!vedtak) return <div>{intl.formatMessage({ id: 'feilmelding.fantIkkeVedtak' })}</div>;


### PR DESCRIPTION
Vi kan med dette få en 'type-safe' `formatMessage`-funksjon i tillegg til selve i18n-instansen.
Den nye funksjonaliteten har blitt testet ut i `Vedtaksinformasjon`.