### PR TITLE
Fiks bug med oppdatering av grunnlag for uførhet

### DIFF
--- a/src/api/revurderingApi.ts
+++ b/src/api/revurderingApi.ts
@@ -15,7 +15,6 @@ import {
     OpprettetRevurderingGrunn,
     RevurderingErrorCodes,
     BeslutningEtterForhåndsvarsling,
-    LeggTilUføreResponse,
     InformasjonSomRevurderes,
     Revurdering,
     BosituasjonRequest,
@@ -171,7 +170,7 @@ export async function lagreUføregrunnlag(arg: {
         begrunnelse: Nullable<string>;
     }>;
 }) {
-    return apiClient<LeggTilUføreResponse>({
+    return apiClient<OpprettetRevurdering>({
         url: `/saker/${arg.sakId}/revurderinger/${arg.revurderingId}/uføregrunnlag`,
         method: 'POST',
         body: { vurderinger: arg.vurderinger },

--- a/src/features/revurdering/revurderingActions.ts
+++ b/src/features/revurdering/revurderingActions.ts
@@ -17,7 +17,6 @@ import {
     OpprettetRevurderingGrunn,
     RevurderingErrorCodes,
     BeslutningEtterForhåndsvarsling,
-    LeggTilUføreResponse,
     InformasjonSomRevurderes,
     Revurdering,
     BosituasjonRequest,
@@ -189,7 +188,7 @@ export const fortsettEtterForhåndsvarsel = createAsyncThunk<
 );
 
 export const lagreUføregrunnlag = createAsyncThunk<
-    LeggTilUføreResponse,
+    OpprettetRevurdering,
     {
         sakId: string;
         revurderingId: string;
@@ -204,6 +203,7 @@ export const lagreUføregrunnlag = createAsyncThunk<
     { rejectValue: ApiError }
 >('revurdering/grunnlag/uføre/lagre', async (arg, thunkApi) => {
     const res = await revurderingApi.lagreUføregrunnlag(arg);
+
     if (res.status === 'ok') {
         return res.data;
     }

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -683,7 +683,7 @@ export default createSlice({
         });
 
         builder.addCase(lagreUføregrunnlagForRevurdering.fulfilled, (state, action) => {
-            state.sak = oppdaterRevurderingISak(state.sak, action.payload.revurdering);
+            state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
 
         builder.addCase(lagreFradragsgrunnlag.fulfilled, (state, action) => {

--- a/src/types/Revurdering.ts
+++ b/src/types/Revurdering.ts
@@ -191,10 +191,6 @@ export enum RevurderingErrorCodes {
     //feilutbetaling
     FEILUTBETALING_STØTTES_IKKE = 'feilutbetalinger_støttes_ikke',
 }
-export interface LeggTilUføreResponse {
-    revurdering: Revurdering;
-    gjeldendeVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
-}
 
 export enum InformasjonSomRevurderes {
     Uførhet = 'Uførhet',


### PR DESCRIPTION
Bakover har oppdatert retur-typen for api-kallet som gjøres når man oppdaterer grunnlag for uførhet.
PR:en tar i bruk den nya typen.