### PR TITLE
Fix lagre og fortsett senere

### DIFF
--- a/src/pages/saksbehandling/søknadsbehandling/fast-opphold-i-norge/FastOppholdINorge.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/fast-opphold-i-norge/FastOppholdINorge.tsx
@@ -165,12 +165,10 @@ const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() => {
-                                form.handleSubmit(
-                                    handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                    focusAfterTimeout(feiloppsummeringRef)
-                                );
-                            }}
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/søknadsbehandling/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/flyktning/Flyktning.tsx
@@ -231,9 +231,10 @@ const Flyktning = (props: VilkårsvurderingBaseProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() =>
-                                form.handleSubmit(handleLagreOgFortsettSenere, focusAfterTimeout(feiloppsummeringRef))
-                            }
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleLagreOgFortsettSenere,
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                             nesteKnappTekst={vilGiTidligAvslag ? formatMessage('knapp.tilVedtaket') : undefined}
                         />
                     </form>

--- a/src/pages/saksbehandling/søknadsbehandling/formue/Formue.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/formue/Formue.tsx
@@ -578,12 +578,10 @@ const Formue = (props: {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() => {
-                                form.handleSubmit(
-                                    handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                    focusAfterTimeout(feiloppsummeringRef)
-                                );
-                            }}
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/søknadsbehandling/institusjonsopphold/Institusjonsopphold.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/institusjonsopphold/Institusjonsopphold.tsx
@@ -175,12 +175,10 @@ const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() => {
-                                form.handleSubmit(
-                                    handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                    focusAfterTimeout(feiloppsummeringRef)
-                                );
-                            }}
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/søknadsbehandling/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
@@ -167,12 +167,10 @@ const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() =>
-                                form.handleSubmit(
-                                    handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                    focusAfterTimeout(feiloppsummeringRef)
-                                )
-                            }
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/søknadsbehandling/opphold-i-utlandet/OppholdIUtlandet.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/opphold-i-utlandet/OppholdIUtlandet.tsx
@@ -174,12 +174,10 @@ const OppholdIUtlandet = (props: VilkårsvurderingBaseProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() => {
-                                form.handleSubmit(
-                                    handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                    focusAfterTimeout(feiloppsummeringRef)
-                                );
-                            }}
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                         />
                     </form>
                 ),

--- a/src/pages/saksbehandling/søknadsbehandling/personlig-oppmøte/PersonligOppmøte.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/personlig-oppmøte/PersonligOppmøte.tsx
@@ -497,9 +497,10 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() => {
-                                form.handleSubmit(handleLagreOgFortsettSenere, focusAfterTimeout(feiloppsummeringRef));
-                            }}
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleLagreOgFortsettSenere,
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                             nesteKnappTekst={
                                 oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
                                 erFerdigbehandletMedAvslag(oppdatertVilkårsinformasjon)

--- a/src/pages/saksbehandling/søknadsbehandling/sats/Sats.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/sats/Sats.tsx
@@ -397,12 +397,10 @@ const SatsForm = (props: SatsProps) => {
                             onTilbakeClick={() => {
                                 history.push(props.forrigeUrl);
                             }}
-                            onLagreOgFortsettSenereClick={() => {
-                                form.handleSubmit(
-                                    handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                    focusAfterTimeout(feiloppsummeringRef)
-                                );
-                            }}
+                            onLagreOgFortsettSenereClick={form.handleSubmit(
+                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
+                                focusAfterTimeout(feiloppsummeringRef)
+                            )}
                         />
                     </form>
                 ),


### PR DESCRIPTION
Var en bug på en del av stegene våre, hvor lagre og fortsett senere aldri kalte på handleren sin.

Vi ønsker
```javascript
clickHandler={clickHandlerFunction()}
```
Ikke
```javascript
clickHandler={() => clickHandlerFunction()}
```