### PR TITLE
Fiks bakgrunn- og borderfarger i vedtaksoppsummering

### DIFF
--- a/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/faktablokker-nb.ts
+++ b/src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/faktablokker-nb.ts
@@ -28,7 +28,7 @@ export default {
 
     'formue.tittel': 'Formue',
     'formue.heading.søker': 'Søker',
-    'formue.heading.eps': 'Ektefelle/samboer',
+    'formue.heading.eps': 'Ektefelle/\u200Bsamboer',
     'formue.delerBoligMed': 'Hvem deler du bolig med?',
     'formue.delerBoligMed.ingen': 'Ingen',
     'formue.ektefelleTitle': 'Ektefelle',

--- a/src/components/oppsummering/vilkårsOppsummering/vilkårsOppsummering.module.less
+++ b/src/components/oppsummering/vilkårsOppsummering/vilkårsOppsummering.module.less
@@ -34,7 +34,8 @@
 
     .pairBlokkContainer {
         display: flex;
-        border: 1px solid lightgrey;
+        border: 1px solid @navBorder;
+        background-color: @navBakgrunn;
 
         .blokk {
             width: 50%;
@@ -42,7 +43,7 @@
             padding: @spacing-xs;
 
             &:not(:last-child) {
-                border-right: 1px solid lightgrey;
+                border-right: 1px solid @navBorder;
             }
         }
 
@@ -54,7 +55,7 @@
 
                 &:not(:last-child) {
                     border-right: none;
-                    border-bottom: 1px solid lightgrey;
+                    border-bottom: 1px solid @navBorder;
                 }
             }
         }

--- a/src/components/søknadsbehandlingoppsummering/Søknadsbehandlingoppsummering.tsx
+++ b/src/components/søknadsbehandlingoppsummering/Søknadsbehandlingoppsummering.tsx
@@ -1,3 +1,4 @@
+import Panel from 'nav-frontend-paneler';
 import { Innholdstittel, Systemtittel, Undertittel } from 'nav-frontend-typografi';
 import * as React from 'react';
 
@@ -58,7 +59,9 @@ const Søknadsbehandlingoppsummering = (props: Props) => {
                 behandlingsinformasjon={props.behandling.behandlingsinformasjon}
             />
             {props.behandling.beregning ? (
-                <VisBeregningOgSimulering behandling={props.behandling} />
+                <Panel border>
+                    <VisBeregningOgSimulering behandling={props.behandling} />
+                </Panel>
             ) : (
                 formatMessage('feilmelding.ikkeGjortEnBeregning')
             )}


### PR DESCRIPTION
Fikser også sånn at overskriften "Ektefelle/samboer" brekker fint når den ikke har plass i bredden.