### PR TITLE
fjern tidlig return på beregning dersom formet er likt

### DIFF
--- a/src/components/beregningOgSimulering/beregning/Beregning.tsx
+++ b/src/components/beregningOgSimulering/beregning/Beregning.tsx
@@ -131,7 +131,6 @@ const Beregning = (props: VilkårsvurderingBaseProps) => {
 
         if (eqBeregningFormData.equals(values, initialFormData)) {
             clearDraft();
-            return;
         }
 
         return new Promise<Behandling | null>((resolve) =>


### PR DESCRIPTION
Siden vi ikke gjør et side-skift, blir man sittende fast på siden hvis man ikke fyller ut noe data