### PR TITLE
fjern disabled prop til select for underkjenning

### DIFF
--- a/src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling.tsx
+++ b/src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling.tsx
@@ -171,7 +171,7 @@ const Attesteringsinnhold = ({
                                             value={formik.values.grunn}
                                             error={errors.grunn}
                                         >
-                                            <option value="" disabled>
+                                            <option value="">
                                                 {intl.formatMessage({ id: 'input.grunn.value.default' })}
                                             </option>
                                             {Object.values(UnderkjennelseGrunn).map((grunn, index) => (


### PR DESCRIPTION
Dersom den er disabled, hopper den til den nest gyldige-verdien i selecten, men denne blir ikke satt i state. 
Det kan bli forvirrende fordi i selecten ser det ut som at en verdi er valgt, men er tom i state.