### PR TITLE
Hent alltid oppdatert sak når man går til saksoversikten

### DIFF
--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -42,10 +42,10 @@ const Saksoversikt = () => {
     const dispatch = useAppDispatch();
 
     useEffect(() => {
-        if (urlParams.sakId && RemoteData.isInitial(sak)) {
+        if (urlParams.sakId) {
             dispatch(sakSlice.fetchSak({ sakId: urlParams.sakId }));
         }
-    }, [sak._tag]);
+    }, []);
 
     useEffect(() => {
         if (RemoteData.isSuccess(sak)) {


### PR DESCRIPTION
Dette fikser f.eks. bug-en vi har med at når man trykker "Avslutt" etter å ha registrert papirsøknad så vises ikke den søknaden i saksoversikten.