### PR TITLE
Fiks håndtering av det å legge til EPS med kode 6 for en saksbehandler som ikke har tilgang

### DIFF
--- a/src/pages/saksbehandling/søknadsbehandling/formue/Formue.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/formue/Formue.tsx
@@ -189,18 +189,18 @@ const Formue = (props: {
             return;
         }
 
-        await lagreEpsGrunnlag(
+        await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,
                 behandlingId: props.behandling.id,
-                epsFnr: values.epsFnr,
+                behandlingsinformasjon: { formue: formueValues },
             },
             () => {
-                return lagreBehandlingsinformasjon(
+                return lagreEpsGrunnlag(
                     {
                         sakId: props.sakId,
                         behandlingId: props.behandling.id,
-                        behandlingsinformasjon: { formue: formueValues },
+                        epsFnr: values.epsFnr,
                     },
                     () => {
                         clearDraft();
@@ -273,7 +273,7 @@ const Formue = (props: {
         form.handleSubmit(handleSave(Routes.home.createURL()), () => {
             dispatch(sakSliceActions.actions.resetSak());
             dispatch(personSlice.actions.resetSøker());
-        });
+        })();
     };
 
     const erVilkårOppfylt = totalFormue <= senesteHalvG;


### PR DESCRIPTION
Nå lagres EPS, og så kaster vi saksbehandleren ut til forsiden igjen, siden de mister tilgang til saken.