### PR TITLE
Håndter lagring av EPS med kode 6 når saksbehandler ikke har nok rettigheter

### DIFF
--- a/src/pages/saksbehandling/søknadsbehandling/formue/formue-nb.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/formue/formue-nb.ts
@@ -14,7 +14,7 @@ export default {
     'modal.skjerming.ariaBeskrivelse': 'Advarsel om at søkers ektefelle har en type skjerming',
     'modal.skjerming.heading': 'Ektefelle/samboer har en type skjerming',
     'modal.skjerming.innhold': `
-    Ektellen/samboeren til {navn} ({fnr}) har en type <b>skjerming</b> (fortrolig adresse, strengt fortrolig adresse eller skjerming).
+    Ektefellen/samboeren til {navn} ({fnr}) har en type <b>skjerming</b> (fortrolig adresse, strengt fortrolig adresse eller skjerming).
     {br}
     {br}
     Derfor mister du tilgang til saken og den må behandles av noen med riktig tilgang.

--- a/src/pages/saksbehandling/søknadsbehandling/formue/utils.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/formue/utils.ts
@@ -35,7 +35,7 @@ export function getFormueInitialValues(
         status: behandlingsFormue?.status ?? FormueStatus.VilkårOppfylt,
         begrunnelse: behandlingsFormue?.begrunnelse ?? null,
         borSøkerMedEPS:
-            behandlingsFormue?.borSøkerMedEPS ??
+            !!hentBosituasjongrunnlag(grunnlagsdata)?.fnr ??
             søknadsInnhold.boforhold.delerBoligMed === DelerBoligMed.EKTEMAKE_SAMBOER,
         epsFnr:
             hentBosituasjongrunnlag(grunnlagsdata)?.fnr ??


### PR DESCRIPTION
Endre slik at vi da *kun* lagrer EPS, i stedet for å lagre hele formue-skjemaet.