### PR TITLE
Mulighet for å avslutte revurdering

### DIFF
--- a/src/api/pdfApi.ts
+++ b/src/api/pdfApi.ts
@@ -1,3 +1,5 @@
+import { Nullable } from '~lib/types';
+
 import apiClient, { ApiClientResult } from './apiClient';
 
 export async function fetchBrevutkastForSøknadsbehandling(args: {
@@ -35,22 +37,10 @@ export async function fetchSøknadutskrift(søknadId: string): Promise<ApiClient
     });
 }
 
-export async function fetchBrevutkastForRevurdering(args: {
+export async function fetchBrevutkastForRevurderingMedPotensieltFritekst(args: {
     sakId: string;
     revurderingId: string;
-}): Promise<ApiClientResult<Blob>> {
-    return apiClient({
-        url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/brevutkast`,
-        method: 'GET',
-        request: { headers: new Headers({ Accept: 'application/pdf' }) },
-        bodyTransformer: (res) => res.blob(),
-    });
-}
-
-export async function fetchBrevutkastForRevurderingWithFritekst(args: {
-    sakId: string;
-    revurderingId: string;
-    fritekst: string;
+    fritekst: Nullable<string>;
 }): Promise<ApiClientResult<Blob>> {
     return apiClient({
         url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/brevutkast`,
@@ -74,6 +64,22 @@ export async function fetchBrevutkastForForhåndsvarsel(
         request: { headers: new Headers({ Accept: 'application/pdf' }) },
         body: {
             fritekst,
+        },
+        bodyTransformer: (res) => res.blob(),
+    });
+}
+
+export async function fetchBrevutkastForAvslutningAvRevurdering(args: {
+    sakId: string;
+    revurderingId: string;
+    fritekst: Nullable<string>;
+}): Promise<ApiClientResult<Blob>> {
+    return apiClient({
+        url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/brevutkastForAvslutning`,
+        method: 'POST',
+        request: { headers: new Headers({ Accept: 'application/pdf' }) },
+        body: {
+            fritekst: args.fritekst,
         },
         bodyTransformer: (res) => res.blob(),
     });

--- a/src/api/pdfApi.ts
+++ b/src/api/pdfApi.ts
@@ -75,7 +75,7 @@ export async function fetchBrevutkastForAvslutningAvRevurdering(args: {
     fritekst: Nullable<string>;
 }): Promise<ApiClientResult<Blob>> {
     return apiClient({
-        url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/brevutkastForAvslutning`,
+        url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/brevutkastForAvslutting`,
         method: 'POST',
         request: { headers: new Headers({ Accept: 'application/pdf' }) },
         body: {

--- a/src/api/revurderingApi.ts
+++ b/src/api/revurderingApi.ts
@@ -322,3 +322,19 @@ export async function hentTidligereGrunnlagsdataForVedtak(args: {
         method: 'GET',
     });
 }
+
+export async function avsluttRevurdering(args: {
+    sakId: string;
+    revurderingId: string;
+    begrunnelse: string;
+    fritekst: Nullable<string>;
+}): Promise<ApiClientResult<Revurdering>> {
+    return apiClient<Revurdering>({
+        url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/avslutt`,
+        method: 'POST',
+        body: {
+            begrunnelse: args.begrunnelse,
+            fritekst: args.fritekst,
+        },
+    });
+}

--- a/src/api/revurderingApi.ts
+++ b/src/api/revurderingApi.ts
@@ -16,10 +16,10 @@ import {
     OpprettetRevurderingGrunn,
     BeslutningEtterForhåndsvarsling,
     InformasjonSomRevurderes,
-    Revurdering,
     BosituasjonRequest,
     FormuegrunnlagRequest,
-    AbstraktRevurdering,
+    Revurdering,
+    InformasjonsRevurdering,
 } from '~types/Revurdering';
 import { Gjenopptak, StansAvYtelse } from '~types/Stans';
 
@@ -269,7 +269,7 @@ export async function lagreFradragsgrunnlag(
     sakId: string,
     revurderingId: string,
     fradrag: Fradrag[]
-): Promise<ApiClientResult<{ revurdering: Revurdering; feilmeldinger: ErrorMessage[] }>> {
+): Promise<ApiClientResult<{ revurdering: InformasjonsRevurdering; feilmeldinger: ErrorMessage[] }>> {
     return apiClient({
         url: `/saker/${sakId}/revurderinger/${revurderingId}/fradrag`,
         method: 'POST',
@@ -281,7 +281,7 @@ export async function lagreFradragsgrunnlag(
 
 export async function lagreBosituasjonsgrunnlag(
     data: BosituasjonRequest
-): Promise<ApiClientResult<{ revurdering: Revurdering; feilmeldinger: ErrorMessage[] }>> {
+): Promise<ApiClientResult<{ revurdering: InformasjonsRevurdering; feilmeldinger: ErrorMessage[] }>> {
     return apiClient({
         url: `/saker/${data.sakId}/revurderinger/${data.revurderingId}/bosituasjongrunnlag`,
         method: 'POST',
@@ -296,7 +296,7 @@ export async function lagreBosituasjonsgrunnlag(
 
 export async function lagreFormuegrunnlag(
     data: FormuegrunnlagRequest
-): Promise<ApiClientResult<{ revurdering: Revurdering; feilmeldinger: ErrorMessage[] }>> {
+): Promise<ApiClientResult<{ revurdering: InformasjonsRevurdering; feilmeldinger: ErrorMessage[] }>> {
     return apiClient({
         url: `/saker/${data.sakId}/revurderinger/${data.revurderingId}/formuegrunnlag`,
         method: 'POST',
@@ -329,7 +329,7 @@ export async function avsluttRevurdering(args: {
     revurderingId: string;
     begrunnelse: string;
     fritekst: Nullable<string>;
-}): Promise<ApiClientResult<AbstraktRevurdering>> {
+}): Promise<ApiClientResult<Revurdering>> {
     return apiClient<Revurdering>({
         url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/avslutt`,
         method: 'POST',

--- a/src/api/revurderingApi.ts
+++ b/src/api/revurderingApi.ts
@@ -19,6 +19,7 @@ import {
     Revurdering,
     BosituasjonRequest,
     FormuegrunnlagRequest,
+    AbstraktRevurdering,
 } from '~types/Revurdering';
 import { Gjenopptak, StansAvYtelse } from '~types/Stans';
 
@@ -328,7 +329,7 @@ export async function avsluttRevurdering(args: {
     revurderingId: string;
     begrunnelse: string;
     fritekst: Nullable<string>;
-}): Promise<ApiClientResult<Revurdering>> {
+}): Promise<ApiClientResult<AbstraktRevurdering>> {
     return apiClient<Revurdering>({
         url: `/saker/${args.sakId}/revurderinger/${args.revurderingId}/avslutt`,
         method: 'POST',

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
@@ -104,4 +104,7 @@ export default {
     'avsluttet.revurderingen.er.iverksatt': 'Revurderingen er Iverksatt',
     'avsluttet.revurderingen.er.ikke.forhåndsvarslet.for.å.vise.brev':
         'Revurderingen er ikke forhåndsvarslet for å vise brev',
+    'avsluttet.fritekst.fyllt.ut.uten.forhåndsvarsel':
+        'Fritekst har blitt fyllt ut, men revurderingen er ikke forhåndsvarslet',
+    'avsluttet.fant.ikke.person.eller.saksbehandler.navn': 'Fant ikke person, eller saksbehandler navn',
 };

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
@@ -99,9 +99,9 @@ export default {
     'gjenopptak.åpen.revurdering.eksisterer': 'Åpen revurdering for gjenopptak av ytelse eksisterer fra før',
     'gjenopptak.iverksetting.feilutbetaling': 'Iverksetting av gjenopptak som fører til feilutbetaling støttes ikke',
 
-    'avsluttet.revurderingen.er.allerede.avsluttet': 'Revurderingen er allerede blitt avsluttet',
+    'avsluttet.revurderingen.er.allerede.avsluttet': 'Revurderingen er allerede avsluttet',
     'avsluttet.revurderingen.er.til.attestering': 'Revurderingen er til attestering',
-    'avsluttet.revurderingen.er.iverksatt': 'Revurderingen er Iverksatt',
+    'avsluttet.revurderingen.er.iverksatt': 'Revurderingen er iverksatt',
     'avsluttet.revurderingen.er.ikke.forhåndsvarslet.for.å.vise.brev':
         'Revurderingen er ikke forhåndsvarslet for å vise brev',
     'avsluttet.fritekst.fyllt.ut.uten.forhåndsvarsel':

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
@@ -7,7 +7,6 @@ export default {
     'generell.ugyldig.periode': 'Ugyldig periode',
     'generell.ugyldig.årsak': 'Ugyldig årsak',
     'generell.kunne.ikke.slå.opp.eps': 'Kunne ikke slå opp ektefelle eller samboer i PDL',
-    'generell.revurderingen.er.allerede.avsluttet': 'Revurderingen er allerede blitt avsluttet',
 
     'periode.ingenting.å.revurdere': 'Fant ingen vedtak som kan revurderes for angitt periode',
 
@@ -99,4 +98,10 @@ export default {
         'Kan ikke opprette revurdering for gjenopptak av ytelse, siste vedtak er ikke en stans',
     'gjenopptak.åpen.revurdering.eksisterer': 'Åpen revurdering for gjenopptak av ytelse eksisterer fra før',
     'gjenopptak.iverksetting.feilutbetaling': 'Iverksetting av gjenopptak som fører til feilutbetaling støttes ikke',
+
+    'avsluttet.revurderingen.er.allerede.avsluttet': 'Revurderingen er allerede blitt avsluttet',
+    'avsluttet.revurderingen.er.til.attestering': 'Revurderingen er til attestering',
+    'avsluttet.revurderingen.er.iverksatt': 'Revurderingen er Iverksatt',
+    'avsluttet.revurderingen.er.ikke.forhåndsvarslet.for.å.vise.brev':
+        'Revurderingen er ikke forhåndsvarslet for å vise brev',
 };

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError-nb.ts
@@ -7,6 +7,7 @@ export default {
     'generell.ugyldig.periode': 'Ugyldig periode',
     'generell.ugyldig.årsak': 'Ugyldig årsak',
     'generell.kunne.ikke.slå.opp.eps': 'Kunne ikke slå opp ektefelle eller samboer i PDL',
+    'generell.revurderingen.er.allerede.avsluttet': 'Revurderingen er allerede blitt avsluttet',
 
     'periode.ingenting.å.revurdere': 'Fant ingen vedtak som kan revurderes for angitt periode',
 

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
@@ -150,7 +150,7 @@ enum Gjenopptak {
 
 enum Avsluttet {
     REVURDERINGEN_ER_ALLEREDE_AVSLUTTET = 'revurderingen_er_allerede_avsluttet',
-    REVURDERINGER_ER_TIL_ATTESTERING = ' ',
+    REVURDERINGER_ER_TIL_ATTESTERING = 'revurdering_er_til_attestering',
     REVURDERINGEN_ER_IVERKSATT = 'revurderingen_er_iverksatt',
     REVURDERING_ER_IKKE_FORHÅNDSVARSLET_FOR_Å_VISE_BREV = 'revurdering_er_ikke_forhåndsvarslet_for_å_vise_brev',
     FRITEKST_ER_FYLLT_UT_UTEN_FORHÅNDSVARSEL = 'fritekst_er_fyllt_ut_uten_forhåndsvarsel',

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
@@ -29,7 +29,8 @@ export type RevurderingErrorCodes =
     | UtfallSomIkkeStøttes
     | Brev
     | Stans
-    | Gjenopptak;
+    | Gjenopptak
+    | Avsluttet;
 
 type VilkårErrorCodes = OpprettelseOgOppdatering | Uføre | Bosituasjon | Formue | Fradrag;
 
@@ -45,8 +46,6 @@ enum Generell {
     UGYLDIG_ÅRSAK = 'ugyldig_årsak',
 
     KUNNE_IKKE_SLÅ_OPP_EPS = 'kunne_ikke_slå_opp_eps',
-
-    REVURDERINGEN_ER_ALLEREDE_AVSLUTTET = 'revurderingen_er_allerede_avsluttet',
 }
 
 enum Vurderingsperiode {
@@ -149,6 +148,13 @@ enum Gjenopptak {
     IVERKSETTING_FØRER_TIL_FEILUTBETALING = 'kunne_ikke_iverksette_gjenopptak_fører_til_feilutbetaling',
 }
 
+enum Avsluttet {
+    REVURDERINGEN_ER_ALLEREDE_AVSLUTTET = 'revurderingen_er_allerede_avsluttet',
+    REVURDERINGER_ER_TIL_ATTESTERING = ' ',
+    REVURDERINGEN_ER_IVERKSATT = 'revurderingen_er_iverksatt',
+    REVURDERING_ER_IKKE_FORHÅNDSVARSLET_FOR_Å_VISE_BREV = 'revurdering_er_ikke_forhåndsvarslet_for_å_vise_brev',
+}
+
 const revurderingErrorCodeMessageIdMap: { [key in RevurderingErrorCodes]: keyof typeof messages | undefined } = {
     [Generell.G_REGULERING_KAN_IKKE_FØRE_TIL_OPPHØR]: 'generell.gregulering.kan.ikke.føre.til.opphør',
     [Generell.ATTESTANT_OG_SAKSBEHANDLER_KAN_IKKE_VÆRE_SAMME_PERSON]:
@@ -159,7 +165,6 @@ const revurderingErrorCodeMessageIdMap: { [key in RevurderingErrorCodes]: keyof 
     [Generell.UGYLDIG_PERIODE]: 'generell.ugyldig.periode',
     [Generell.UGYLDIG_ÅRSAK]: 'generell.ugyldig.årsak',
     [Generell.KUNNE_IKKE_SLÅ_OPP_EPS]: 'generell.kunne.ikke.slå.opp.eps',
-    [Generell.REVURDERINGEN_ER_ALLEREDE_AVSLUTTET]: 'generell.revurderingen.er.allerede.avsluttet',
 
     [Vurderingsperiode.INGENTING_Å_REVURDERE_I_PERIODEN]: 'periode.ingenting.å.revurdere',
 
@@ -243,4 +248,10 @@ const revurderingErrorCodeMessageIdMap: { [key in RevurderingErrorCodes]: keyof 
     [Gjenopptak.KAN_IKKE_GJENOPPTA_OPPHØRTE_UTBETALINGER]: 'gjenopptak.kan.ikke.gjenoppta.opphørte.utbetalinger',
     [Gjenopptak.ÅPEN_REVURDERING_EKSISTERER]: 'gjenopptak.åpen.revurdering.eksisterer',
     [Gjenopptak.IVERKSETTING_FØRER_TIL_FEILUTBETALING]: 'gjenopptak.iverksetting.feilutbetaling',
+
+    [Avsluttet.REVURDERINGEN_ER_ALLEREDE_AVSLUTTET]: 'avsluttet.revurderingen.er.allerede.avsluttet',
+    [Avsluttet.REVURDERINGER_ER_TIL_ATTESTERING]: 'avsluttet.revurderingen.er.til.attestering',
+    [Avsluttet.REVURDERINGEN_ER_IVERKSATT]: 'avsluttet.revurderingen.er.iverksatt',
+    [Avsluttet.REVURDERING_ER_IKKE_FORHÅNDSVARSLET_FOR_Å_VISE_BREV]:
+        'avsluttet.revurderingen.er.ikke.forhåndsvarslet.for.å.vise.brev',
 };

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
@@ -153,6 +153,8 @@ enum Avsluttet {
     REVURDERINGER_ER_TIL_ATTESTERING = ' ',
     REVURDERINGEN_ER_IVERKSATT = 'revurderingen_er_iverksatt',
     REVURDERING_ER_IKKE_FORHÅNDSVARSLET_FOR_Å_VISE_BREV = 'revurdering_er_ikke_forhåndsvarslet_for_å_vise_brev',
+    FRITEKST_ER_FYLLT_UT_UTEN_FORHÅNDSVARSEL = 'fritekst_er_fyllt_ut_uten_forhåndsvarsel',
+    FANT_IKKE_PERSON_ELLER_SAKSBEHANDLER_NAVN = 'fant_ikke_person_eller_saksbehandler_navn',
 }
 
 const revurderingErrorCodeMessageIdMap: { [key in RevurderingErrorCodes]: keyof typeof messages | undefined } = {
@@ -254,4 +256,6 @@ const revurderingErrorCodeMessageIdMap: { [key in RevurderingErrorCodes]: keyof 
     [Avsluttet.REVURDERINGEN_ER_IVERKSATT]: 'avsluttet.revurderingen.er.iverksatt',
     [Avsluttet.REVURDERING_ER_IKKE_FORHÅNDSVARSLET_FOR_Å_VISE_BREV]:
         'avsluttet.revurderingen.er.ikke.forhåndsvarslet.for.å.vise.brev',
+    [Avsluttet.FRITEKST_ER_FYLLT_UT_UTEN_FORHÅNDSVARSEL]: 'avsluttet.fritekst.fyllt.ut.uten.forhåndsvarsel',
+    [Avsluttet.FANT_IKKE_PERSON_ELLER_SAKSBEHANDLER_NAVN]: 'avsluttet.fant.ikke.person.eller.saksbehandler.navn',
 };

--- a/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
+++ b/src/components/apiErrorAlert/revurderingApiError/RevurderingApiError.ts
@@ -45,6 +45,8 @@ enum Generell {
     UGYLDIG_ÅRSAK = 'ugyldig_årsak',
 
     KUNNE_IKKE_SLÅ_OPP_EPS = 'kunne_ikke_slå_opp_eps',
+
+    REVURDERINGEN_ER_ALLEREDE_AVSLUTTET = 'revurderingen_er_allerede_avsluttet',
 }
 
 enum Vurderingsperiode {
@@ -157,6 +159,7 @@ const revurderingErrorCodeMessageIdMap: { [key in RevurderingErrorCodes]: keyof 
     [Generell.UGYLDIG_PERIODE]: 'generell.ugyldig.periode',
     [Generell.UGYLDIG_ÅRSAK]: 'generell.ugyldig.årsak',
     [Generell.KUNNE_IKKE_SLÅ_OPP_EPS]: 'generell.kunne.ikke.slå.opp.eps',
+    [Generell.REVURDERINGEN_ER_ALLEREDE_AVSLUTTET]: 'generell.revurderingen.er.allerede.avsluttet',
 
     [Vurderingsperiode.INGENTING_Å_REVURDERE_I_PERIODEN]: 'periode.ingenting.å.revurdere',
 

--- a/src/components/revurdering/oppsummering/Revurderingoppsummering.tsx
+++ b/src/components/revurdering/oppsummering/Revurderingoppsummering.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 
 import Beregningblokk from '~components/revurdering/oppsummering/beregningblokk/Beregningblokk';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
-import { Revurdering } from '~types/Revurdering';
+import { InformasjonsRevurdering } from '~types/Revurdering';
 
 import Oppsummeringsblokk from './oppsummeringsblokk/Oppsummeringsblokk';
 import styles from './revurderingoppsummering.module.less';
 
 const Revurderingoppsummering = (props: {
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     forrigeGrunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
     return (

--- a/src/components/revurdering/oppsummering/beregningblokk/Beregningblokk.tsx
+++ b/src/components/revurdering/oppsummering/beregningblokk/Beregningblokk.tsx
@@ -4,19 +4,19 @@ import * as React from 'react';
 import VisBeregning from '~components/beregningOgSimulering/beregning/VisBeregning';
 import { Utbetalingssimulering } from '~components/beregningOgSimulering/simulering/simulering';
 import { useI18n } from '~lib/i18n';
-import { harBeregninger, harSimulering, Revurdering, RevurderingsStatus } from '~types/Revurdering';
-import { erGregulering, erRevurderingIngenEndring } from '~utils/revurdering/revurderingUtils';
+import { AbstraktRevurdering, harBeregninger, harSimulering, RevurderingsStatus } from '~types/Revurdering';
+import { erGregulering, erRevurdering, erRevurderingIngenEndring } from '~utils/revurdering/revurderingUtils';
 
 import Oppsummeringspanel, { Oppsummeringsfarge, Oppsummeringsikon } from '../oppsummeringspanel/Oppsummeringspanel';
 
 import messages from './beregningblokk-nb';
 import styles from './beregningblokk.module.less';
 
-const Beregningblokk = (props: { revurdering: Revurdering }) => {
+const Beregningblokk = (props: { revurdering: AbstraktRevurdering }) => {
     const { intl } = useI18n({ messages });
 
     const alert = React.useMemo(() => {
-        if (erRevurderingIngenEndring(props.revurdering)) {
+        if (erRevurdering(props.revurdering) && erRevurderingIngenEndring(props.revurdering)) {
             return erGregulering(props.revurdering.årsak)
                 ? {
                       tittel: intl.formatMessage({ id: 'revurdering.ingenEndring.gregulering.tittel' }),
@@ -56,8 +56,8 @@ const Beregningblokk = (props: { revurdering: Revurdering }) => {
                         {intl.formatMessage({ id: 'heading.beregning' })}
                     </Heading>
                     <Panel border>
-                        {harBeregninger(props.revurdering) ? (
-                            <VisBeregning beregning={props.revurdering.beregninger.revurdert} utenTittel />
+                        {erRevurdering(props.revurdering) && harBeregninger(props.revurdering) ? (
+                            <VisBeregning beregning={props.revurdering.beregninger} utenTittel />
                         ) : (
                             intl.formatMessage({ id: 'error.ingenBeregning' })
                         )}

--- a/src/components/revurdering/oppsummering/beregningblokk/Beregningblokk.tsx
+++ b/src/components/revurdering/oppsummering/beregningblokk/Beregningblokk.tsx
@@ -4,19 +4,23 @@ import * as React from 'react';
 import VisBeregning from '~components/beregningOgSimulering/beregning/VisBeregning';
 import { Utbetalingssimulering } from '~components/beregningOgSimulering/simulering/simulering';
 import { useI18n } from '~lib/i18n';
-import { AbstraktRevurdering, harBeregninger, harSimulering, RevurderingsStatus } from '~types/Revurdering';
-import { erGregulering, erRevurdering, erRevurderingIngenEndring } from '~utils/revurdering/revurderingUtils';
+import { Revurdering, harBeregninger, harSimulering, RevurderingsStatus } from '~types/Revurdering';
+import {
+    erGregulering,
+    erInformasjonsRevurdering,
+    erRevurderingIngenEndring,
+} from '~utils/revurdering/revurderingUtils';
 
 import Oppsummeringspanel, { Oppsummeringsfarge, Oppsummeringsikon } from '../oppsummeringspanel/Oppsummeringspanel';
 
 import messages from './beregningblokk-nb';
 import styles from './beregningblokk.module.less';
 
-const Beregningblokk = (props: { revurdering: AbstraktRevurdering }) => {
+const Beregningblokk = (props: { revurdering: Revurdering }) => {
     const { intl } = useI18n({ messages });
 
     const alert = React.useMemo(() => {
-        if (erRevurdering(props.revurdering) && erRevurderingIngenEndring(props.revurdering)) {
+        if (erInformasjonsRevurdering(props.revurdering) && erRevurderingIngenEndring(props.revurdering)) {
             return erGregulering(props.revurdering.årsak)
                 ? {
                       tittel: intl.formatMessage({ id: 'revurdering.ingenEndring.gregulering.tittel' }),
@@ -56,7 +60,7 @@ const Beregningblokk = (props: { revurdering: AbstraktRevurdering }) => {
                         {intl.formatMessage({ id: 'heading.beregning' })}
                     </Heading>
                     <Panel border>
-                        {erRevurdering(props.revurdering) && harBeregninger(props.revurdering) ? (
+                        {erInformasjonsRevurdering(props.revurdering) && harBeregninger(props.revurdering) ? (
                             <VisBeregning beregning={props.revurdering.beregning} utenTittel />
                         ) : (
                             intl.formatMessage({ id: 'error.ingenBeregning' })

--- a/src/components/revurdering/oppsummering/beregningblokk/Beregningblokk.tsx
+++ b/src/components/revurdering/oppsummering/beregningblokk/Beregningblokk.tsx
@@ -57,7 +57,7 @@ const Beregningblokk = (props: { revurdering: AbstraktRevurdering }) => {
                     </Heading>
                     <Panel border>
                         {erRevurdering(props.revurdering) && harBeregninger(props.revurdering) ? (
-                            <VisBeregning beregning={props.revurdering.beregninger} utenTittel />
+                            <VisBeregning beregning={props.revurdering.beregning} utenTittel />
                         ) : (
                             intl.formatMessage({ id: 'error.ingenBeregning' })
                         )}

--- a/src/components/revurdering/oppsummering/oppsummeringsblokk/Oppsummeringsblokk.tsx
+++ b/src/components/revurdering/oppsummering/oppsummeringsblokk/Oppsummeringsblokk.tsx
@@ -5,7 +5,7 @@ import UnderkjenteAttesteringer from '~components/underkjenteAttesteringer/Under
 import sharedMessages from '~features/revurdering/sharedMessages-nb';
 import { useI18n } from '~lib/i18n';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
-import { Revurdering } from '~types/Revurdering';
+import { InformasjonsRevurdering, Revurdering } from '~types/Revurdering';
 import * as DateUtils from '~utils/date/dateUtils';
 import { getRevurderingsårsakMessageId } from '~utils/revurdering/revurderingUtils';
 
@@ -56,7 +56,7 @@ const Intro = (props: { revurdering: Revurdering }) => {
 };
 
 const Oppsummeringsblokk = (props: {
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
     const { intl } = useI18n({ messages });

--- a/src/components/revurdering/oppsummering/vedtaksinformasjon/Vedtaksinformasjon.tsx
+++ b/src/components/revurdering/oppsummering/vedtaksinformasjon/Vedtaksinformasjon.tsx
@@ -9,7 +9,7 @@ import Formuestatus from '~components/revurdering/formuestatus/Formuestatus';
 import { useI18n } from '~lib/i18n';
 import { FormueResultat, FormueVilkår } from '~types/grunnlagsdataOgVilkårsvurderinger/formue/Formuevilkår';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
-import { Revurdering, Vurderingstatus, InformasjonSomRevurderes } from '~types/Revurdering';
+import { Vurderingstatus, InformasjonSomRevurderes, InformasjonsRevurdering } from '~types/Revurdering';
 import { regnUtFormuegrunnlag } from '~utils/revurdering/formue/RevurderFormueUtils';
 import { hentBosituasjongrunnlag } from '~utils/søknadsbehandlingOgRevurdering/bosituasjon/bosituasjonUtils';
 
@@ -198,7 +198,7 @@ const Fradragblokk = (props: {
 };
 
 const Vedtaksinformasjon = (props: {
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
 }) => {
     const { intl } = useI18n({ messages });

--- a/src/features/revurdering/revurderingActions.ts
+++ b/src/features/revurdering/revurderingActions.ts
@@ -18,10 +18,10 @@ import {
     OpprettetRevurderingGrunn,
     BeslutningEtterForhåndsvarsling,
     InformasjonSomRevurderes,
-    Revurdering,
     BosituasjonRequest,
     FormuegrunnlagRequest,
-    AbstraktRevurdering,
+    Revurdering,
+    InformasjonsRevurdering,
 } from '~types/Revurdering';
 import { Gjenopptak, StansAvYtelse } from '~types/Stans';
 
@@ -283,7 +283,7 @@ export const lagreUføregrunnlag = createAsyncThunk<
 });
 
 export const lagreFradragsgrunnlag = createAsyncThunk<
-    { revurdering: Revurdering; feilmeldinger: ErrorMessage[] },
+    { revurdering: InformasjonsRevurdering; feilmeldinger: ErrorMessage[] },
     {
         sakId: string;
         revurderingId: string;
@@ -299,7 +299,7 @@ export const lagreFradragsgrunnlag = createAsyncThunk<
 });
 
 export const lagreBosituasjonsgrunnlag = createAsyncThunk<
-    { revurdering: Revurdering; feilmeldinger: ErrorMessage[] },
+    { revurdering: InformasjonsRevurdering; feilmeldinger: ErrorMessage[] },
     BosituasjonRequest,
     { rejectValue: ApiError }
 >('revurdering/grunnlag/bosituasjon/lagre', async (arg, thunkApi) => {
@@ -318,7 +318,7 @@ export const lagreBosituasjonsgrunnlag = createAsyncThunk<
 });
 
 export const lagreFormuegrunnlag = createAsyncThunk<
-    { revurdering: Revurdering; feilmeldinger: ErrorMessage[] },
+    { revurdering: InformasjonsRevurdering; feilmeldinger: ErrorMessage[] },
     FormuegrunnlagRequest,
     { rejectValue: ApiError }
 >('revurdering/grunnlag/formue/lagre', async (arg, thunkApi) => {
@@ -349,7 +349,7 @@ export const hentGjeldendeGrunnlagsdataOgVilkårsvurderinger = createAsyncThunk<
 });
 
 export const avsluttRevurdering = createAsyncThunk<
-    AbstraktRevurdering,
+    Revurdering,
     { sakId: string; revurderingId: string; begrunnelse: string; fritekst: Nullable<string> },
     { rejectValue: ApiError }
 >('revurdering/avsluttRevurdering', async (arg, thunkApi) => {

--- a/src/features/revurdering/revurderingActions.ts
+++ b/src/features/revurdering/revurderingActions.ts
@@ -346,3 +346,21 @@ export const hentGjeldendeGrunnlagsdataOgVilkårsvurderinger = createAsyncThunk<
     }
     return thunkApi.rejectWithValue(res.error);
 });
+
+export const avsluttRevurdering = createAsyncThunk<
+    Revurdering,
+    { sakId: string; revurderingId: string; begrunnelse: string; fritekst: Nullable<string> },
+    { rejectValue: ApiError }
+>('revurdering/avsluttRevurdering', async (arg, thunkApi) => {
+    const res = await revurderingApi.avsluttRevurdering({
+        sakId: arg.sakId,
+        revurderingId: arg.revurderingId,
+        begrunnelse: arg.begrunnelse,
+        fritekst: arg.fritekst,
+    });
+
+    if (res.status === 'ok') {
+        return res.data;
+    }
+    return thunkApi.rejectWithValue(res.error);
+});

--- a/src/features/revurdering/revurderingActions.ts
+++ b/src/features/revurdering/revurderingActions.ts
@@ -21,6 +21,7 @@ import {
     Revurdering,
     BosituasjonRequest,
     FormuegrunnlagRequest,
+    AbstraktRevurdering,
 } from '~types/Revurdering';
 import { Gjenopptak, StansAvYtelse } from '~types/Stans';
 
@@ -348,7 +349,7 @@ export const hentGjeldendeGrunnlagsdataOgVilkårsvurderinger = createAsyncThunk<
 });
 
 export const avsluttRevurdering = createAsyncThunk<
-    Revurdering,
+    AbstraktRevurdering,
     { sakId: string; revurderingId: string; begrunnelse: string; fritekst: Nullable<string> },
     { rejectValue: ApiError }
 >('revurdering/avsluttRevurdering', async (arg, thunkApi) => {

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -7,25 +7,7 @@ import * as dokumentApi from '~api/dokumentApi';
 import * as sakApi from '~api/sakApi';
 import * as søknadApi from '~api/søknadApi';
 import { AvslagManglendeDokType, LukkSøknadBodyTypes } from '~api/søknadApi';
-import {
-    beregnOgSimuler,
-    iverksettRevurdering,
-    oppdaterRevurderingsPeriode,
-    lagreUføregrunnlag as lagreUføregrunnlagForRevurdering,
-    hentGjeldendeGrunnlagsdataOgVilkårsvurderinger,
-    opprettRevurdering,
-    sendRevurderingTilAttestering,
-    underkjennRevurdering,
-    forhåndsvarsleEllerSendTilAttestering,
-    fortsettEtterForhåndsvarsel,
-    lagreFradragsgrunnlag,
-    lagreBosituasjonsgrunnlag,
-    lagreFormuegrunnlag,
-    opprettStans,
-    oppdaterStans,
-    gjenoppta,
-    oppdaterGjenopptak,
-} from '~features/revurdering/revurderingActions';
+import * as revurderingActions from '~features/revurdering/revurderingActions';
 import { pipe } from '~lib/fp';
 import { Nullable } from '~lib/types';
 import { createApiCallAsyncThunk, handleAsyncThunk, simpleRejectedActionToRemoteData } from '~redux/utils';
@@ -37,7 +19,7 @@ import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkå
 import { UføreResultat } from '~types/grunnlagsdataOgVilkårsvurderinger/uføre/Uførevilkår';
 import { Periode } from '~types/Periode';
 import { Restans } from '~types/Restans';
-import { Revurdering } from '~types/Revurdering';
+import { AbstraktRevurdering } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Vilkårtype, VilkårVurderingStatus } from '~types/Vilkårsvurdering';
 
@@ -599,7 +581,7 @@ export default createSlice({
             },
         });
 
-        handleAsyncThunk(builder, opprettRevurdering, {
+        handleAsyncThunk(builder, revurderingActions.opprettRevurdering, {
             pending: (state) => {
                 state.opprettRevurderingStatus = RemoteData.pending;
             },
@@ -619,7 +601,7 @@ export default createSlice({
             },
         });
 
-        handleAsyncThunk(builder, oppdaterRevurderingsPeriode, {
+        handleAsyncThunk(builder, revurderingActions.oppdaterRevurderingsPeriode, {
             pending: (state) => {
                 state.oppdaterRevurderingStatus = RemoteData.pending;
             },
@@ -634,7 +616,7 @@ export default createSlice({
             },
         });
 
-        handleAsyncThunk(builder, hentGjeldendeGrunnlagsdataOgVilkårsvurderinger, {
+        handleAsyncThunk(builder, revurderingActions.hentGjeldendeGrunnlagsdataOgVilkårsvurderinger, {
             pending: (state, action) => {
                 state.revurderingGrunnlagSimulering[action.meta.arg.revurderingId] = RemoteData.pending;
             },
@@ -681,7 +663,7 @@ export default createSlice({
             );
         });
 
-        builder.addCase(opprettStans.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.opprettStans.fulfilled, (state, action) => {
             state.sak = pipe(
                 state.sak,
                 RemoteData.map((sak) => ({
@@ -691,7 +673,7 @@ export default createSlice({
             );
         });
 
-        builder.addCase(gjenoppta.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.gjenoppta.fulfilled, (state, action) => {
             state.sak = pipe(
                 state.sak,
                 RemoteData.map((sak) => ({
@@ -701,56 +683,60 @@ export default createSlice({
             );
         });
 
-        builder.addCase(lagreUføregrunnlagForRevurdering.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.lagreUføregrunnlag.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload.revurdering);
         });
 
-        builder.addCase(lagreFradragsgrunnlag.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.lagreFradragsgrunnlag.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload.revurdering);
         });
 
-        builder.addCase(lagreBosituasjonsgrunnlag.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.lagreBosituasjonsgrunnlag.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload.revurdering);
         });
 
-        builder.addCase(lagreFormuegrunnlag.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.lagreFormuegrunnlag.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload.revurdering);
         });
 
-        builder.addCase(beregnOgSimuler.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.beregnOgSimuler.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload.revurdering);
         });
 
-        builder.addCase(sendRevurderingTilAttestering.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.sendRevurderingTilAttestering.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
 
-        builder.addCase(iverksettRevurdering.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.iverksettRevurdering.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
-        builder.addCase(underkjennRevurdering.fulfilled, (state, action) => {
-            state.sak = oppdaterRevurderingISak(state.sak, action.payload);
-        });
-
-        builder.addCase(forhåndsvarsleEllerSendTilAttestering.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.underkjennRevurdering.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
 
-        builder.addCase(fortsettEtterForhåndsvarsel.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.forhåndsvarsleEllerSendTilAttestering.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
 
-        builder.addCase(oppdaterStans.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.fortsettEtterForhåndsvarsel.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
 
-        builder.addCase(oppdaterGjenopptak.fulfilled, (state, action) => {
+        builder.addCase(revurderingActions.oppdaterStans.fulfilled, (state, action) => {
+            state.sak = oppdaterRevurderingISak(state.sak, action.payload);
+        });
+
+        builder.addCase(revurderingActions.oppdaterGjenopptak.fulfilled, (state, action) => {
+            state.sak = oppdaterRevurderingISak(state.sak, action.payload);
+        });
+
+        builder.addCase(revurderingActions.avsluttRevurdering.fulfilled, (state, action) => {
             state.sak = oppdaterRevurderingISak(state.sak, action.payload);
         });
     },
 });
 
-function oppdaterRevurderingISak(sak: RemoteData.RemoteData<ApiError, Sak>, revurdering: Revurdering) {
+function oppdaterRevurderingISak(sak: RemoteData.RemoteData<ApiError, Sak>, revurdering: AbstraktRevurdering) {
     return pipe(
         sak,
         RemoteData.map((s) => ({

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -19,7 +19,7 @@ import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkå
 import { UføreResultat } from '~types/grunnlagsdataOgVilkårsvurderinger/uføre/Uførevilkår';
 import { Periode } from '~types/Periode';
 import { Restans } from '~types/Restans';
-import { AbstraktRevurdering } from '~types/Revurdering';
+import { Revurdering } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Vilkårtype, VilkårVurderingStatus } from '~types/Vilkårsvurdering';
 
@@ -630,17 +630,11 @@ export default createSlice({
         });
 
         builder.addCase(lukkSøknad.fulfilled, (state, action) => {
-            state.sak = pipe(
-                state.sak,
-                RemoteData.map((sak) => ({ ...sak, ...action.payload }))
-            );
+            state.sak = RemoteData.success(action.payload);
         });
 
         builder.addCase(avslagManglendeDokSøknad.fulfilled, (state, action) => {
-            state.sak = pipe(
-                state.sak,
-                RemoteData.map((sak) => ({ ...sak, ...action.payload }))
-            );
+            state.sak = RemoteData.success(action.payload);
         });
 
         builder.addCase(lagreBosituasjonGrunnlag.fulfilled, (state, action) => {
@@ -736,7 +730,7 @@ export default createSlice({
     },
 });
 
-function oppdaterRevurderingISak(sak: RemoteData.RemoteData<ApiError, Sak>, revurdering: AbstraktRevurdering) {
+function oppdaterRevurderingISak(sak: RemoteData.RemoteData<ApiError, Sak>, revurdering: Revurdering) {
     return pipe(
         sak,
         RemoteData.map((s) => ({

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -343,8 +343,6 @@ interface SakState {
     simuleringStatus: RemoteData.RemoteData<ApiError, null>;
     sendtTilAttesteringStatus: RemoteData.RemoteData<ApiError, null>;
     attesteringStatus: RemoteData.RemoteData<ApiError, null>;
-    søknadLukketStatus: RemoteData.RemoteData<ApiError, null>;
-    lukketSøknadBrevutkastStatus: RemoteData.RemoteData<ApiError, null>;
     opprettRevurderingStatus: RemoteData.RemoteData<ApiError, null>;
     oppdaterRevurderingStatus: RemoteData.RemoteData<ApiError, null>;
 }
@@ -359,8 +357,6 @@ const initialState: SakState = {
     simuleringStatus: RemoteData.initial,
     sendtTilAttesteringStatus: RemoteData.initial,
     attesteringStatus: RemoteData.initial,
-    søknadLukketStatus: RemoteData.initial,
-    lukketSøknadBrevutkastStatus: RemoteData.initial,
     opprettRevurderingStatus: RemoteData.initial,
     oppdaterRevurderingStatus: RemoteData.initial,
 };
@@ -603,34 +599,6 @@ export default createSlice({
             },
         });
 
-        handleAsyncThunk(builder, lukkSøknad, {
-            pending: (state) => {
-                state.søknadLukketStatus = RemoteData.pending;
-                state.lukketSøknadBrevutkastStatus = RemoteData.initial;
-            },
-            fulfilled: (state, action) => {
-                state.søknadLukketStatus = RemoteData.success(null);
-
-                state.sak = RemoteData.success(action.payload);
-            },
-            rejected: (state, action) => {
-                state.søknadLukketStatus = simpleRejectedActionToRemoteData(action);
-            },
-        });
-
-        handleAsyncThunk(builder, hentLukketSøknadBrevutkast, {
-            pending: (state) => {
-                state.lukketSøknadBrevutkastStatus = RemoteData.pending;
-                state.søknadLukketStatus = RemoteData.initial;
-            },
-            fulfilled: (state) => {
-                state.lukketSøknadBrevutkastStatus = RemoteData.success(null);
-            },
-            rejected: (state, action) => {
-                state.lukketSøknadBrevutkastStatus = simpleRejectedActionToRemoteData(action);
-            },
-        });
-
         handleAsyncThunk(builder, opprettRevurdering, {
             pending: (state) => {
                 state.opprettRevurderingStatus = RemoteData.pending;
@@ -677,6 +645,13 @@ export default createSlice({
                 state.revurderingGrunnlagSimulering[action.meta.arg.revurderingId] =
                     simpleRejectedActionToRemoteData(action);
             },
+        });
+
+        builder.addCase(lukkSøknad.fulfilled, (state, action) => {
+            state.sak = pipe(
+                state.sak,
+                RemoteData.map((sak) => ({ ...sak, ...action.payload }))
+            );
         });
 
         builder.addCase(avslagManglendeDokSøknad.fulfilled, (state, action) => {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -73,20 +73,12 @@ export const vedtaksoppsummering: Route<{ sakId: string; vedtakId: string }> = {
 };
 
 //---------------Søknadsbehandling & revurdering------
-export const avsluttSøknadsbehandling: Route<{
+export const avsluttBehandling: Route<{
     sakId: string;
-    soknadId: string;
+    id: string;
 }> = {
-    path: '/saksoversikt/:sakId/:soknadId/avsluttSoknadsbehandling/',
-    createURL: (args) => `/saksoversikt/${args.sakId}/${args.soknadId}/avsluttSoknadsbehandling`,
-};
-
-export const avslagManglendeDokSøknadsbehandling: Route<{
-    sakId: string;
-    soknadId: string;
-}> = {
-    path: '/saksoversikt/:sakId/:soknadId/avslagManglendeDokSoknadsbehandling/',
-    createURL: (args) => `/saksoversikt/${args.sakId}/${args.soknadId}/avslagManglendeDokSoknadsbehandling`,
+    path: '/saksoversikt/:sakId/:id/avsluttBehandling/',
+    createURL: (args) => `/saksoversikt/${args.sakId}/${args.id}/avsluttBehandling`,
 };
 
 export const saksoversiktValgtBehandling: Route<{

--- a/src/pages/nøkkeltall/index.tsx
+++ b/src/pages/nøkkeltall/index.tsx
@@ -85,7 +85,6 @@ const NøkkelTall = () => {
                                 />
                             </ul>
                         </Panel>
-
                         <Heading level="2" size="medium">
                             {formatMessage('personer.tittel')}
                         </Heading>

--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -24,9 +24,8 @@ const Vilkår = React.lazy(() => import('./søknadsbehandling/vilkår/Vilkår'))
 const SendTilAttesteringPage = React.lazy(
     () => import('./søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage')
 );
-const AvslåttSøknad = React.lazy(() => import('~pages/saksbehandling/avslag/AvslåttSøknad'));
 const Vedtaksoppsummering = React.lazy(() => import('~pages/saksbehandling/vedtak/Vedtaksoppsummering'));
-const LukkSøknad = React.lazy(() => import('./lukkSøknad/LukkSøknad'));
+const AvsluttBehandling = React.lazy(() => import('./avsluttBehandling/AvsluttBehandling'));
 const Revurdering = React.lazy(() => import('./revurdering/Revurdering'));
 const Sakintro = React.lazy(() => import('./sakintro/Sakintro'));
 const DokumenterPage = React.lazy(() => import('~pages/saksbehandling/dokumenter/DokumenterPage'));
@@ -116,14 +115,9 @@ const Saksoversikt = () => {
                                                     <Gjenoppta sak={sak} />
                                                 </div>
                                             </Route>
-                                            <Route path={Routes.avsluttSøknadsbehandling.path}>
+                                            <Route path={Routes.avsluttBehandling.path}>
                                                 <div className={styles.mainContent}>
-                                                    <LukkSøknad sak={sak} />
-                                                </div>
-                                            </Route>
-                                            <Route path={Routes.avslagManglendeDokSøknadsbehandling.path}>
-                                                <div className={styles.mainContent}>
-                                                    <AvslåttSøknad sak={sak} />
+                                                    <AvsluttBehandling sak={sak} />
                                                 </div>
                                             </Route>
                                             <Route path={Routes.revurderValgtSak.path}>

--- a/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
+++ b/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
@@ -22,7 +22,7 @@ import yup from '~lib/validering';
 import { useAppDispatch } from '~redux/Store';
 import { IverksattRevurdering, RevurderingsStatus, UnderkjentRevurdering } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
-import { erRevurderingTilAttestering, erGregulering, erRevurdering } from '~utils/revurdering/revurderingUtils';
+import { erRevurderingTilAttestering, erGregulering } from '~utils/revurdering/revurderingUtils';
 
 import SharedStyles from '../sharedStyles.module.less';
 
@@ -150,7 +150,7 @@ const AttesterRevurdering = (props: { sak: Sak; søker: Person }) => {
         );
     }
 
-    if (!erRevurdering(revurdering) || !erRevurderingTilAttestering(revurdering)) {
+    if (!erRevurderingTilAttestering(revurdering)) {
         return (
             <div className={styles.advarselContainer}>
                 <Alert variant="error">{intl.formatMessage({ id: 'feil.ikkeTilAttestering' })}</Alert>

--- a/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
+++ b/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
@@ -22,7 +22,7 @@ import yup from '~lib/validering';
 import { useAppDispatch } from '~redux/Store';
 import { IverksattRevurdering, RevurderingsStatus, UnderkjentRevurdering } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
-import { erRevurderingTilAttestering, erGregulering } from '~utils/revurdering/revurderingUtils';
+import { erRevurderingTilAttestering, erGregulering, erRevurdering } from '~utils/revurdering/revurderingUtils';
 
 import SharedStyles from '../sharedStyles.module.less';
 
@@ -74,7 +74,7 @@ const AttesterRevurdering = (props: { sak: Sak; søker: Person }) => {
     const dispatch = useAppDispatch();
     const history = useHistory();
     const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
-    const [hentPdfStatus, hentPdf] = useApiCall(PdfApi.fetchBrevutkastForRevurdering);
+    const [hentPdfStatus, hentPdf] = useApiCall(PdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst);
     const [sendtBeslutning, setSendtBeslutning] = useState<
         RemoteData.RemoteData<ApiError, IverksattRevurdering | UnderkjentRevurdering>
     >(RemoteData.initial);
@@ -150,7 +150,7 @@ const AttesterRevurdering = (props: { sak: Sak; søker: Person }) => {
         );
     }
 
-    if (!erRevurderingTilAttestering(revurdering)) {
+    if (!erRevurdering(revurdering) || !erRevurderingTilAttestering(revurdering)) {
         return (
             <div className={styles.advarselContainer}>
                 <Alert variant="error">{intl.formatMessage({ id: 'feil.ikkeTilAttestering' })}</Alert>
@@ -159,7 +159,7 @@ const AttesterRevurdering = (props: { sak: Sak; søker: Person }) => {
     }
 
     const handleShowBrevClick = async () => {
-        hentPdf({ sakId: props.sak.id, revurderingId: revurdering.id }, (data) => {
+        hentPdf({ sakId: props.sak.id, revurderingId: revurdering.id, fritekst: null }, (data) => {
             window.open(URL.createObjectURL(data));
         });
     };

--- a/src/pages/saksbehandling/avslag/AvslåttSøknad.tsx
+++ b/src/pages/saksbehandling/avslag/AvslåttSøknad.tsx
@@ -1,86 +1,42 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert, Button, Link, Loader, Textarea } from '@navikt/ds-react';
+import { Button, Loader, Textarea } from '@navikt/ds-react';
 import React from 'react';
-import { Controller, useForm } from 'react-hook-form';
-import { useHistory } from 'react-router-dom';
 
-import { AvslagManglendeDokType } from '~api/søknadApi';
-import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
-import { avslagManglendeDokSøknad } from '~features/saksoversikt/sak.slice';
-import { useAsyncActionCreator } from '~lib/hooks';
+import { ApiResult } from '~lib/hooks';
 import { useI18n } from '~lib/i18n';
-import * as Routes from '~lib/routes';
+import { Nullable } from '~lib/types';
 import { Sak } from '~types/Sak';
 
 import nb from './avslåttSøknad-nb';
 import styles from './avslåttSøknad.module.less';
 
 interface Props {
-    sak: Sak;
+    søknadsbehandlingAvsluttetStatus: ApiResult<Sak, string>;
+    fritekstValue: Nullable<string>;
+    fritekstError?: string;
+    onFritekstChange: (value: string) => void;
 }
 
 const AvslåttSøknad = (props: Props) => {
-    const { control, handleSubmit } = useForm<AvslagManglendeDokType>();
-    const urlParams = Routes.useRouteParams<typeof Routes.avsluttSøknadsbehandling>();
-    const [apiStatus, setApiStatus] = useAsyncActionCreator(avslagManglendeDokSøknad);
-    const søknad = props.sak.søknader.find((s) => s.id === urlParams.soknadId);
     const { formatMessage } = useI18n({ messages: nb });
-    const history = useHistory();
-
-    if (!søknad) {
-        return (
-            <div>
-                <Alert variant="error">
-                    {formatMessage('display.søknad.fantIkkeSøknad')} {urlParams.soknadId}
-                </Alert>
-            </div>
-        );
-    }
-
-    const onSubmit = (data: AvslagManglendeDokType) => {
-        setApiStatus(
-            {
-                søknadId: urlParams.soknadId,
-                body: { fritekst: data.fritekst },
-            },
-            () => {
-                const message = formatMessage('display.søknad.harBlittAvslått');
-                return history.push(Routes.createSakIntroLocation(message, props.sak.id));
-            }
-        );
-    };
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)} className={styles.formContainer}>
-            <div>
-                <p>
-                    {formatMessage('display.saksnummer')} {props.sak.saksnummer}
-                </p>
-                <p>
-                    {formatMessage('display.søknadId')} {urlParams.soknadId}
-                </p>
-            </div>
+        <div className={styles.formContainer}>
             <div className={styles.avvistContainer}>
                 <div className={styles.textAreaContainer}>
-                    <Controller
-                        name="fritekst"
-                        control={control}
-                        render={({ field }) => <Textarea {...field} label={formatMessage('display.avvist.fritekst')} />}
+                    <Textarea
+                        label={formatMessage('display.avvist.fritekst')}
+                        value={props.fritekstValue ?? ''}
+                        error={props.fritekstError}
+                        onChange={(e) => props.onFritekstChange(e.target.value)}
                     />
                 </div>
                 <Button variant="danger" className={styles.avvisButton} type="submit">
                     {formatMessage('knapp.avvis')}
-                    {RemoteData.isPending(apiStatus) && <Loader />}
+                    {RemoteData.isPending(props.søknadsbehandlingAvsluttetStatus) && <Loader />}
                 </Button>
             </div>
-            <div className={styles.tilbakeKnappContainer}>
-                <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: urlParams.sakId })}>
-                    {formatMessage('knapp.tilbake')}
-                </Link>
-            </div>
-
-            <div>{RemoteData.isFailure(apiStatus) && <ApiErrorAlert error={apiStatus.error} />}</div>
-        </form>
+        </div>
     );
 };
 

--- a/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling.tsx
@@ -1,0 +1,47 @@
+import { Alert, Link } from '@navikt/ds-react';
+import React from 'react';
+
+import { useI18n } from '~lib/i18n';
+import * as Routes from '~lib/routes';
+import { Sak } from '~types/Sak';
+
+import LukkSøknadOgAvsluttBehandling from '../lukkSøknad/LukkSøknad';
+
+import messages from './avsluttBehandling-nb';
+import AvsluttRevurdering from './avsluttRevurdering/AvsluttRevurdering';
+
+const AvsluttBehandling = (props: { sak: Sak }) => {
+    const { formatMessage } = useI18n({ messages });
+    const urlParams = Routes.useRouteParams<typeof Routes.avsluttBehandling>();
+
+    const søknad = props.sak.søknader.find((s) => s.id === urlParams.id);
+    const revurdering = props.sak.revurderinger.find((r) => r.id === urlParams.id);
+
+    if (!søknad && !revurdering) {
+        return (
+            <div>
+                <Alert variant="error">
+                    {formatMessage('feil.fantIkkeBehandling')} {urlParams.id}
+                </Alert>
+                <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}>
+                    {formatMessage('link.tilbake')}
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <p>
+                {formatMessage('display.saksnummer')} {props.sak.saksnummer}
+            </p>
+            <p>
+                {formatMessage(søknad ? 'behandling.søknadsId' : 'behandling.revurderingsId')} {urlParams.id}
+            </p>
+            {søknad && <LukkSøknadOgAvsluttBehandling sakId={props.sak.id} søknad={søknad} />}
+            {revurdering && <AvsluttRevurdering />}
+        </div>
+    );
+};
+
+export default AvsluttBehandling;

--- a/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling.tsx
@@ -1,4 +1,4 @@
-import { Alert, Link } from '@navikt/ds-react';
+import { Alert, Heading, Link, Panel } from '@navikt/ds-react';
 import React from 'react';
 
 import { useI18n } from '~lib/i18n';
@@ -8,6 +8,7 @@ import { Sak } from '~types/Sak';
 import LukkSøknadOgAvsluttBehandling from '../lukkSøknad/LukkSøknad';
 
 import messages from './avsluttBehandling-nb';
+import styles from './avsluttBehandling.module.less';
 import AvsluttRevurdering from './avsluttRevurdering/AvsluttRevurdering';
 
 const AvsluttBehandling = (props: { sak: Sak }) => {
@@ -31,16 +32,22 @@ const AvsluttBehandling = (props: { sak: Sak }) => {
     }
 
     return (
-        <div>
-            <p>
+        <Panel className={styles.pageContainer}>
+            <Heading level="2" size="medium">
                 {formatMessage('display.saksnummer')} {props.sak.saksnummer}
-            </p>
-            <p>
+            </Heading>
+            <Heading level="2" size="medium" spacing>
                 {formatMessage(søknad ? 'behandling.søknadsId' : 'behandling.revurderingsId')} {urlParams.id}
-            </p>
-            {søknad && <LukkSøknadOgAvsluttBehandling sakId={props.sak.id} søknad={søknad} />}
-            {revurdering && <AvsluttRevurdering />}
-        </div>
+            </Heading>
+
+            <div className={styles.mainContent}>
+                {søknad && <LukkSøknadOgAvsluttBehandling sakId={props.sak.id} søknad={søknad} />}
+                {revurdering && <AvsluttRevurdering sakId={props.sak.id} revurdering={revurdering} />}
+            </div>
+            <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}>
+                {formatMessage('link.tilbake')}
+            </Link>
+        </Panel>
     );
 };
 

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttBehandling-nb.ts
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttBehandling-nb.ts
@@ -1,0 +1,10 @@
+export default {
+    'behandling.søknadsId': 'Søknads-id: ',
+    'behandling.revurderingsId': 'Revurderings-id: ',
+
+    'display.saksnummer': 'Saksnummer: ',
+
+    'feil.fantIkkeBehandling': 'Fant ikke behandling med gitt id: ',
+
+    'link.tilbake': 'Tilbake',
+};

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttBehandling.module.less
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttBehandling.module.less
@@ -1,0 +1,9 @@
+@import '~/styles/variables.less';
+
+.pageContainer {
+    margin-top: @spacing;
+}
+
+.mainContent {
+    margin-bottom: @spacing;
+}

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
@@ -81,7 +81,7 @@ const AvsluttRevurdering = (props: { sakId: string; revurdering: AbstraktRevurde
                     )}
                 />
             </div>
-            <Button variant="danger">
+            <Button variant="danger" className={styles.avsluttRevurderingButton}>
                 {formatMessage('knapp.avsluttRevurdering')}{' '}
                 {RemoteData.isPending(avsluttRevurderingStatus) && <Loader />}
             </Button>

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
@@ -13,8 +13,8 @@ import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
-import { AbstraktRevurdering } from '~types/Revurdering';
-import { erForhåndsvarselSendtEllerBesluttet, erRevurdering } from '~utils/revurdering/revurderingUtils';
+import { Revurdering } from '~types/Revurdering';
+import { erForhåndsvarselSendtEllerBesluttet, erInformasjonsRevurdering } from '~utils/revurdering/revurderingUtils';
 
 import messages from './avsluttRevurdering-nb';
 import styles from './avsluttRevurdering.module.less';
@@ -29,7 +29,7 @@ const schema = yup.object<AvsluttRevurderingFormData>({
     begrunnelse: yup.string().required(),
 });
 
-const AvsluttRevurdering = (props: { sakId: string; revurdering: AbstraktRevurdering }) => {
+const AvsluttRevurdering = (props: { sakId: string; revurdering: Revurdering }) => {
     const history = useHistory();
     const { formatMessage } = useI18n({ messages });
 
@@ -59,7 +59,7 @@ const AvsluttRevurdering = (props: { sakId: string; revurdering: AbstraktRevurde
 
     return (
         <form onSubmit={handleSubmit(avsluttRevurderingSubmitHandler)}>
-            {erRevurdering(props.revurdering) && erForhåndsvarselSendtEllerBesluttet(props.revurdering) && (
+            {erInformasjonsRevurdering(props.revurdering) && erForhåndsvarselSendtEllerBesluttet(props.revurdering) && (
                 <ForhåndsvarsletRevurderingForm
                     sakId={props.sakId}
                     revurderingId={props.revurdering.id}
@@ -109,9 +109,9 @@ const ForhåndsvarsletRevurderingForm = (props: {
                     name={'fritekst'}
                     render={({ field, fieldState }) => (
                         <Textarea
+                            {...field}
                             label={formatMessage('form.fritekst.label')}
                             value={field.value ?? ''}
-                            onChange={field.onChange}
                             error={fieldState.error?.message}
                         />
                     )}
@@ -129,6 +129,7 @@ const ForhåndsvarsletRevurderingForm = (props: {
                 }
             >
                 {formatMessage('knapp.seBrev')}
+                {RemoteData.isPending(brevStatus) && <Loader />}
             </Button>
             {RemoteData.isFailure(brevStatus) && <ApiErrorAlert error={brevStatus.error} />}
         </div>

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AvsluttRevurdering = () => {
+    return <div>hei hei</div>;
+};
+
+export default AvsluttRevurdering;

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
@@ -1,7 +1,138 @@
+import * as RemoteData from '@devexperts/remote-data-ts';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Alert, Button, Loader, Textarea } from '@navikt/ds-react';
 import React from 'react';
+import { Control, Controller, useForm, UseFormWatch } from 'react-hook-form';
+import { useHistory } from 'react-router';
 
-const AvsluttRevurdering = () => {
-    return <div>hei hei</div>;
+import * as pdfApi from '~api/pdfApi';
+import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
+import { avsluttRevurdering } from '~features/revurdering/revurderingActions';
+import { useAsyncActionCreator, useBrevForhåndsvisning } from '~lib/hooks';
+import { useI18n } from '~lib/i18n';
+import * as Routes from '~lib/routes';
+import { Nullable } from '~lib/types';
+import yup from '~lib/validering';
+import { AbstraktRevurdering } from '~types/Revurdering';
+import { erRevurdering, erRevurderingForhåndsvarslet } from '~utils/revurdering/revurderingUtils';
+
+import messages from './avsluttRevurdering-nb';
+import styles from './avsluttRevurdering.module.less';
+
+interface AvsluttRevurderingFormData {
+    fritekst: Nullable<string>;
+    begrunnelse: Nullable<string>;
+}
+
+const schema = yup.object<AvsluttRevurderingFormData>({
+    fritekst: yup.string().nullable().defined(),
+    begrunnelse: yup.string().required(),
+});
+
+const AvsluttRevurdering = (props: { sakId: string; revurdering: AbstraktRevurdering }) => {
+    const history = useHistory();
+    const { formatMessage } = useI18n({ messages });
+
+    const [avsluttRevurderingStatus, avsluttRevurderingAction] = useAsyncActionCreator(avsluttRevurdering);
+
+    const { control, watch, handleSubmit } = useForm<AvsluttRevurderingFormData>({
+        defaultValues: { fritekst: null },
+        resolver: yupResolver(schema),
+    });
+
+    const avsluttRevurderingSubmitHandler = (data: AvsluttRevurderingFormData) => {
+        avsluttRevurderingAction(
+            {
+                sakId: props.sakId,
+                revurderingId: props.revurdering.id,
+                //validering fanger denne
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                begrunnelse: data.begrunnelse!,
+                fritekst: data.fritekst,
+            },
+            () => {
+                const message = formatMessage('avslutt.revurderingHarBlittAvsluttet');
+                return history.push(Routes.createSakIntroLocation(message, props.sakId));
+            }
+        );
+    };
+
+    return (
+        <form onSubmit={handleSubmit(avsluttRevurderingSubmitHandler)}>
+            {erRevurdering(props.revurdering) && erRevurderingForhåndsvarslet(props.revurdering) && (
+                <ForhåndsvarsletRevurderingForm
+                    sakId={props.sakId}
+                    revurderingId={props.revurdering.id}
+                    formController={control}
+                    watch={watch}
+                />
+            )}
+            <div className={styles.begrunnelseContainer}>
+                <Controller
+                    control={control}
+                    name={'begrunnelse'}
+                    render={({ field, fieldState }) => (
+                        <Textarea
+                            label={formatMessage('form.begrunnelse.label')}
+                            value={field.value ?? ''}
+                            onChange={field.onChange}
+                            error={fieldState.error?.message}
+                        />
+                    )}
+                />
+            </div>
+            <Button variant="danger">
+                {formatMessage('knapp.avsluttRevurdering')}{' '}
+                {RemoteData.isPending(avsluttRevurderingStatus) && <Loader />}
+            </Button>
+            {RemoteData.isFailure(avsluttRevurderingStatus) && <ApiErrorAlert error={avsluttRevurderingStatus.error} />}
+        </form>
+    );
+};
+
+const ForhåndsvarsletRevurderingForm = (props: {
+    sakId: string;
+    revurderingId: string;
+    formController: Control<AvsluttRevurderingFormData>;
+    watch: UseFormWatch<AvsluttRevurderingFormData>;
+}) => {
+    const { formatMessage } = useI18n({ messages });
+
+    const [brevStatus, hentBrev] = useBrevForhåndsvisning(pdfApi.fetchBrevutkastForAvslutningAvRevurdering);
+
+    return (
+        <div className={styles.revurderingForhåndsvarsletContainer}>
+            <Alert variant="info">{formatMessage('alert.revurderingErForhåndsvarslet')}</Alert>
+            <div>
+                <Controller
+                    control={props.formController}
+                    name={'fritekst'}
+                    render={({ field, fieldState }) => (
+                        <Textarea
+                            label={formatMessage('form.fritekst.label')}
+                            value={field.value ?? ''}
+                            onChange={field.onChange}
+                            error={fieldState.error?.message}
+                        />
+                    )}
+                />
+            </div>
+            <Button
+                type="button"
+                variant="secondary"
+                onClick={() =>
+                    hentBrev({
+                        sakId: props.sakId,
+                        revurderingId: props.revurderingId,
+                        fritekst: props.watch('fritekst'),
+                    })
+                }
+            >
+                {formatMessage('knapp.seBrev')}
+            </Button>
+            {RemoteData.isFailure(brevStatus) && <ApiErrorAlert error={brevStatus.error} />}
+        </div>
+    );
 };
 
 export default AvsluttRevurdering;

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/AvsluttRevurdering.tsx
@@ -14,7 +14,7 @@ import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
 import { AbstraktRevurdering } from '~types/Revurdering';
-import { erRevurdering, erRevurderingForhåndsvarslet } from '~utils/revurdering/revurderingUtils';
+import { erForhåndsvarselSendtEllerBesluttet, erRevurdering } from '~utils/revurdering/revurderingUtils';
 
 import messages from './avsluttRevurdering-nb';
 import styles from './avsluttRevurdering.module.less';
@@ -59,7 +59,7 @@ const AvsluttRevurdering = (props: { sakId: string; revurdering: AbstraktRevurde
 
     return (
         <form onSubmit={handleSubmit(avsluttRevurderingSubmitHandler)}>
-            {erRevurdering(props.revurdering) && erRevurderingForhåndsvarslet(props.revurdering) && (
+            {erRevurdering(props.revurdering) && erForhåndsvarselSendtEllerBesluttet(props.revurdering) && (
                 <ForhåndsvarsletRevurderingForm
                     sakId={props.sakId}
                     revurderingId={props.revurdering.id}

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/avsluttRevurdering-nb.ts
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/avsluttRevurdering-nb.ts
@@ -1,0 +1,11 @@
+export default {
+    'alert.revurderingErForhåndsvarslet': 'Revurderingen er forhåndsvarslet',
+
+    'form.begrunnelse.label': 'Begrunnelse for avslutning',
+    'form.fritekst.label': 'Fritekst',
+
+    'knapp.avsluttRevurdering': 'Avslutt revurdering',
+    'knapp.seBrev': 'Se brev',
+
+    'avslutt.revurderingHarBlittAvsluttet': 'Behandling av revurdering har blitt avsluttet',
+};

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/avsluttRevurdering.module.less
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/avsluttRevurdering.module.less
@@ -1,0 +1,13 @@
+@import '~/styles/variables.less';
+
+.begrunnelseContainer {
+    margin-bottom: @spacing;
+}
+
+.revurderingForhåndsvarsletContainer {
+    margin-bottom: @spacing;
+
+    > :not(:last-child) {
+        margin-bottom: @spacing-s;
+    }
+}

--- a/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/avsluttRevurdering.module.less
+++ b/src/pages/saksbehandling/avsluttBehandling/avsluttRevurdering/avsluttRevurdering.module.less
@@ -11,3 +11,7 @@
         margin-bottom: @spacing-s;
     }
 }
+
+.avsluttRevurderingButton {
+    margin-bottom: @spacing-xs;
+}

--- a/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
@@ -14,7 +14,7 @@ import { LukkSøknadBegrunnelse } from '~types/Søknad';
 
 import nb from './lukkSøknad-nb';
 import styles from './lukkSøknad.module.less';
-import { AvvistBrevtyper, LukkSøknadFormData } from './lukkSøknadUtils';
+import { AvvistBrevtyper, LukkSøknadOgAvsluttSøknadsbehandlingFormData } from './lukkSøknadUtils';
 
 interface AvvistFormData {
     skalSendesBrev: Nullable<boolean>;
@@ -24,7 +24,7 @@ interface AvvistFormData {
 
 interface AvvistProps {
     søknadId: string;
-    validateForm: () => Promise<FormikErrors<LukkSøknadFormData>>;
+    validateForm: () => Promise<FormikErrors<LukkSøknadOgAvsluttSøknadsbehandlingFormData>>;
     avvistFormData: AvvistFormData;
     søknadLukketStatus: ApiResult<Sak, string>;
     feilmeldinger: FormikErrors<AvvistFormData>;
@@ -82,42 +82,44 @@ const Avvist = (props: AvvistProps) => {
                     />
                 </div>
             )}
-            <div className={styles.buttonsContainer}>
-                {props.avvistFormData.skalSendesBrev && (
-                    <Button
-                        variant="secondary"
-                        className={styles.seBrevKnapp}
-                        type="button"
-                        onClick={() => {
-                            props.validateForm().then((res) => {
-                                if (Object.keys(res).length === 0) {
-                                    hentBrev({
-                                        søknadId: props.søknadId,
-                                        body: {
-                                            type: LukkSøknadBegrunnelse.Avvist,
-                                            //Vi har en use-state som sjekker at verdi ikke er null
-                                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                                            brevConfig: props.avvistFormData.typeBrev
-                                                ? {
-                                                      brevtype: props.avvistFormData.typeBrev,
-                                                      fritekst: props.avvistFormData.fritekst,
-                                                  }
-                                                : null,
-                                        },
-                                    });
-                                }
-                            });
-                        }}
-                    >
-                        {formatMessage('knapp.seBrev')}
-                        {RemoteData.isPending(brevStatus) && <Loader />}
+            {props.avvistFormData.skalSendesBrev !== null && (
+                <div className={styles.buttonsContainer}>
+                    {props.avvistFormData.skalSendesBrev && (
+                        <Button
+                            variant="secondary"
+                            className={styles.seBrevKnapp}
+                            type="button"
+                            onClick={() => {
+                                props.validateForm().then((res) => {
+                                    if (Object.keys(res).length === 0) {
+                                        hentBrev({
+                                            søknadId: props.søknadId,
+                                            body: {
+                                                type: LukkSøknadBegrunnelse.Avvist,
+                                                //Vi har en use-state som sjekker at verdi ikke er null
+                                                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                                                brevConfig: props.avvistFormData.typeBrev
+                                                    ? {
+                                                          brevtype: props.avvistFormData.typeBrev,
+                                                          fritekst: props.avvistFormData.fritekst,
+                                                      }
+                                                    : null,
+                                            },
+                                        });
+                                    }
+                                });
+                            }}
+                        >
+                            {formatMessage('knapp.seBrev')}
+                            {RemoteData.isPending(brevStatus) && <Loader />}
+                        </Button>
+                    )}
+                    <Button variant="danger" type="submit">
+                        {formatMessage('knapp.lukkSøknad')}
+                        {RemoteData.isPending(props.søknadLukketStatus) && <Loader />}
                     </Button>
-                )}
-                <Button variant="danger">
-                    {formatMessage('knapp.lukkSøknad')}
-                    {RemoteData.isPending(props.søknadLukketStatus) && <Loader />}
-                </Button>
-            </div>
+                </div>
+            )}
             <div>{RemoteData.isFailure(brevStatus) && <ApiErrorAlert error={brevStatus.error} />}</div>
         </div>
     );

--- a/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Avvist.tsx
@@ -27,7 +27,7 @@ interface AvvistProps {
     validateForm: () => Promise<FormikErrors<LukkSøknadOgAvsluttSøknadsbehandlingFormData>>;
     avvistFormData: AvvistFormData;
     søknadLukketStatus: ApiResult<Sak, string>;
-    feilmeldinger: FormikErrors<AvvistFormData>;
+    feilmeldinger?: FormikErrors<AvvistFormData>;
     onValueChange: (value: AvvistFormData) => void;
 }
 
@@ -36,13 +36,28 @@ const Avvist = (props: AvvistProps) => {
 
     const [brevStatus, hentBrev] = useBrevForhåndsvisning(søknadApi.hentLukketSøknadsBrevutkast);
 
+    const handleHentBrevClick = () => {
+        hentBrev({
+            søknadId: props.søknadId,
+            body: {
+                type: LukkSøknadBegrunnelse.Avvist,
+                brevConfig: props.avvistFormData.typeBrev
+                    ? {
+                          brevtype: props.avvistFormData.typeBrev,
+                          fritekst: props.avvistFormData.fritekst,
+                      }
+                    : null,
+            },
+        });
+    };
+
     return (
         <div className={styles.avvistContainer}>
             <div className={styles.radioContainer}>
                 <BooleanRadioGroup
                     name="skalSendesBrev"
                     legend={formatMessage('avvist.skalSendesBrevTilSøker')}
-                    error={props.feilmeldinger.skalSendesBrev}
+                    error={props.feilmeldinger?.skalSendesBrev}
                     value={props.avvistFormData.skalSendesBrev}
                     onChange={(val) => {
                         props.onValueChange({ skalSendesBrev: val, typeBrev: null, fritekst: null });
@@ -77,7 +92,7 @@ const Avvist = (props: AvvistProps) => {
                         label={formatMessage('avvist.fritekst')}
                         name="fritekst"
                         value={props.avvistFormData.fritekst ?? ''}
-                        error={props.feilmeldinger.fritekst}
+                        error={props.feilmeldinger?.fritekst}
                         onChange={(e) => props.onValueChange({ ...props.avvistFormData, fritekst: e.target.value })}
                     />
                 </div>
@@ -92,20 +107,7 @@ const Avvist = (props: AvvistProps) => {
                             onClick={() => {
                                 props.validateForm().then((res) => {
                                     if (Object.keys(res).length === 0) {
-                                        hentBrev({
-                                            søknadId: props.søknadId,
-                                            body: {
-                                                type: LukkSøknadBegrunnelse.Avvist,
-                                                //Vi har en use-state som sjekker at verdi ikke er null
-                                                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                                                brevConfig: props.avvistFormData.typeBrev
-                                                    ? {
-                                                          brevtype: props.avvistFormData.typeBrev,
-                                                          fritekst: props.avvistFormData.fritekst,
-                                                      }
-                                                    : null,
-                                            },
-                                        });
+                                        handleHentBrevClick();
                                     }
                                 });
                             }}

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -1,5 +1,5 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert, BodyShort, Button, Link, Loader, Select } from '@navikt/ds-react';
+import { Button, Link, Loader, Select } from '@navikt/ds-react';
 import classNames from 'classnames';
 import { useFormik } from 'formik';
 import React, { useState } from 'react';
@@ -7,12 +7,13 @@ import { useHistory } from 'react-router-dom';
 
 import { LukkSøknadBodyTypes } from '~api/søknadApi';
 import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
-import { lukkSøknad } from '~features/saksoversikt/sak.slice';
+import * as sakSlice from '~features/saksoversikt/sak.slice';
+import { useAsyncActionCreator } from '~lib/hooks';
 import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
-import { useAppDispatch, useAppSelector } from '~redux/Store';
-import { Sak } from '~types/Sak';
 import { LukkSøknadBegrunnelse, Søknad, Søknadstype } from '~types/Søknad';
+
+import AvslåttSøknad from '../avslag/AvslåttSøknad';
 
 import Avvist from './Avvist';
 import nb from './lukkSøknad-nb';
@@ -21,53 +22,52 @@ import {
     lukkSøknadInitialValues,
     LukkSøknadValidationSchema,
     LukkSøknadFormData,
-    lukkSøknadBegrunnelseI18nId,
+    AvsluttSøknadsbehandlingBegrunnelse,
+    LukkSøknadOgAvsluttSøknadsbehandlingType,
 } from './lukkSøknadUtils';
 import Trukket from './Trukket';
 
-const LukkSøknad = (props: { sak: Sak }) => {
-    const dispatch = useAppDispatch();
-    const { søknadLukketStatus, lukketSøknadBrevutkastStatus } = useAppSelector((s) => s.sak);
-    const urlParams = Routes.useRouteParams<typeof Routes.avsluttSøknadsbehandling>();
-    const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
-    const søknad = props.sak.søknader.find((s) => s.id === urlParams.soknadId);
-    const { intl } = useI18n({ messages: nb });
+const LukkSøknadOgAvsluttBehandling = (props: { sakId: string; søknad: Søknad }) => {
     const history = useHistory();
-
-    const status = RemoteData.combine(søknadLukketStatus, lukketSøknadBrevutkastStatus);
-    const error = RemoteData.isFailure(status) ? status.error : undefined;
+    const { formatMessage } = useI18n({ messages: nb });
+    const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
+    const [søknadLukketStatus, lukkSøknad] = useAsyncActionCreator(sakSlice.lukkSøknad);
+    const [avslagManglendeDokStatus, avslåPgaManglendeDok] = useAsyncActionCreator(sakSlice.avslagManglendeDokSøknad);
 
     const formik = useFormik<LukkSøknadFormData>({
         initialValues: lukkSøknadInitialValues,
         async onSubmit(values) {
-            if (!values.lukkSøknadBegrunnelse) {
+            if (!values.lukkSøknadOgAvsluttSøknadsbehandling) {
                 return;
             }
-            const response = await dispatch(
-                lukkSøknad({
-                    søknadId: urlParams.soknadId,
-                    body: lagBody(values),
-                })
-            );
 
-            if (lukkSøknad.fulfilled.match(response)) {
-                const message = intl.formatMessage({ id: 'display.søknad.harBlittLukket' });
-                history.push(Routes.createSakIntroLocation(message, props.sak.id));
+            if (values.lukkSøknadOgAvsluttSøknadsbehandling === AvsluttSøknadsbehandlingBegrunnelse.ManglendeDok) {
+                avslåPgaManglendeDok(
+                    {
+                        søknadId: props.søknad.id,
+                        body: { fritekst: '' /*data.fritekst*()*/ },
+                    },
+                    () => {
+                        const message = formatMessage('avslutt.behandlingHarBlittAvsluttet');
+                        return history.push(Routes.createSakIntroLocation(message, props.sakId));
+                    }
+                );
             }
+
+            lukkSøknad(
+                {
+                    søknadId: props.søknad.id,
+                    body: lagBody(values),
+                },
+                () => {
+                    const message = formatMessage('avslutt.behandlingHarBlittAvsluttet');
+                    history.push(Routes.createSakIntroLocation(message, props.sakId));
+                }
+            );
         },
         validationSchema: LukkSøknadValidationSchema,
         validateOnChange: hasSubmitted,
     });
-
-    if (!søknad) {
-        return (
-            <div>
-                <Alert variant="error">
-                    {intl.formatMessage({ id: 'display.søknad.fantIkkeSøknad' })} {urlParams.soknadId}
-                </Alert>
-            </div>
-        );
-    }
 
     return (
         <form
@@ -77,123 +77,127 @@ const LukkSøknad = (props: { sak: Sak }) => {
             }}
             className={styles.formContainer}
         >
-            <div>
-                <BodyShort>
-                    {intl.formatMessage({ id: 'display.saksnummer' })} {props.sak.saksnummer}
-                </BodyShort>
-                <BodyShort spacing>
-                    {intl.formatMessage({ id: 'display.søknadId' })} {urlParams.soknadId}
-                </BodyShort>
-            </div>
             <div className={styles.selectContainer}>
                 <Select
-                    label={intl.formatMessage({ id: 'display.begrunnelseForLukking' })}
-                    name={'lukkSøknadBegrunnelse'}
+                    label={formatMessage('lukkSøknadOgAvsluttSøknadsbehandling.begrunnelseForAvsluttelse')}
+                    name={'lukkSøknadOgAvsluttSøknadsbehandling'}
                     onChange={(e) => {
-                        formik.setValues({
-                            ...formik.values,
-                            datoSøkerTrakkSøknad: null,
-                            sendBrevForAvvist: null,
-                            typeBrev: null,
-                            fritekst: null,
-                        });
                         formik.handleChange(e);
                     }}
-                    error={formik.errors.lukkSøknadBegrunnelse}
+                    error={formik.errors.lukkSøknadOgAvsluttSøknadsbehandling}
                 >
-                    <option value="velgBegrunnelse">
-                        {intl.formatMessage({ id: 'display.selector.velgBegrunnelse' })}
-                    </option>
+                    <option value="velgBegrunnelse">{formatMessage('selector.velgBegrunnelse')}</option>
                     {Object.values(LukkSøknadBegrunnelse).map((begrunnelse) => (
                         <option value={begrunnelse} key={begrunnelse}>
-                            {intl.formatMessage({ id: lukkSøknadBegrunnelseI18nId(begrunnelse) })}
+                            {formatMessage(lukkSøknadBegrunnelseI18nId(begrunnelse))}
+                        </option>
+                    ))}
+                    {Object.values(AvsluttSøknadsbehandlingBegrunnelse).map((begrunnelse) => (
+                        <option value={begrunnelse} key={begrunnelse}>
+                            {formatMessage(lukkSøknadBegrunnelseI18nId(begrunnelse))}
                         </option>
                     ))}
                 </Select>
             </div>
 
-            {formik.values.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Trukket && (
+            {formik.values.lukkSøknadOgAvsluttSøknadsbehandling === LukkSøknadBegrunnelse.Trukket && (
                 <Trukket
-                    datoSøkerTrakkSøknad={formik.values.datoSøkerTrakkSøknad}
-                    søknadId={søknad.id}
-                    søknadOpprettet={hentOpprettetDatoFraSøknad(søknad)}
-                    feilmelding={formik.errors.datoSøkerTrakkSøknad}
-                    lukkSøknadBegrunnelse={formik.values.lukkSøknadBegrunnelse}
-                    lukketSøknadBrevutkastStatus={lukketSøknadBrevutkastStatus}
+                    datoSøkerTrakkSøknad={formik.values.trukket.datoSøkerTrakkSøknad}
+                    søknadId={props.søknad.id}
+                    søknadOpprettet={hentOpprettetDatoFraSøknad(props.søknad)}
+                    feilmelding={formik.errors.trukket?.datoSøkerTrakkSøknad}
                     onDatoSøkerTrakkSøknadChange={(val) =>
-                        formik.setValues((values) => ({ ...values, datoSøkerTrakkSøknad: val }))
+                        formik.setValues((values) => ({ ...values, trukket: { datoSøkerTrakkSøknad: val } }))
                     }
                     søknadLukketStatus={søknadLukketStatus}
                 />
             )}
 
-            {formik.values.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Bortfalt && (
+            {formik.values.lukkSøknadOgAvsluttSøknadsbehandling === LukkSøknadBegrunnelse.Bortfalt && (
                 <div className={classNames(styles.bortfaltContainer, styles.buttonsContainer)}>
                     <Button variant="danger">
-                        {intl.formatMessage({ id: 'knapp.lukkSøknad' })}
+                        {formatMessage('knapp.lukkSøknad')}
                         {RemoteData.isPending(søknadLukketStatus) && <Loader />}
                     </Button>
                 </div>
             )}
 
-            {formik.values.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Avvist && (
+            {formik.values.lukkSøknadOgAvsluttSøknadsbehandling === LukkSøknadBegrunnelse.Avvist && (
                 <Avvist
+                    søknadId={props.søknad.id}
+                    søknadLukketStatus={søknadLukketStatus}
                     validateForm={() => formik.validateForm()}
-                    lukkSøknadBegrunnelse={formik.values.lukkSøknadBegrunnelse}
                     avvistFormData={{
-                        sendBrevForAvvist: formik.values.sendBrevForAvvist,
-                        typeBrev: formik.values.typeBrev,
-                        fritekst: formik.values.fritekst,
+                        skalSendesBrev: formik.values.avvist.skalSendesBrev,
+                        typeBrev: formik.values.avvist.typeBrev,
+                        fritekst: formik.values.avvist.fritekst,
                     }}
                     feilmeldinger={{
-                        sendBrevForAvvist: formik.errors.sendBrevForAvvist,
-                        typeBrev: formik.errors.typeBrev,
-                        fritekst: formik.errors.fritekst,
+                        skalSendesBrev: formik.errors.avvist?.skalSendesBrev,
+                        typeBrev: formik.errors.avvist?.typeBrev,
+                        fritekst: formik.errors.avvist?.fritekst,
                     }}
                     onValueChange={(val) =>
                         formik.setValues((values) => ({
                             ...values,
-                            sendBrevForAvvist: val.sendBrevForAvvist,
-                            typeBrev: val.typeBrev,
-                            fritekst: val.fritekst,
+                            avvist: {
+                                skalSendesBrev: val.skalSendesBrev,
+                                typeBrev: val.typeBrev,
+                                fritekst: val.fritekst,
+                            },
                         }))
                     }
-                    søknadLukketStatus={søknadLukketStatus}
-                    lukketSøknadBrevutkastStatus={lukketSøknadBrevutkastStatus}
+                />
+            )}
+
+            {formik.values.lukkSøknadOgAvsluttSøknadsbehandling ===
+                AvsluttSøknadsbehandlingBegrunnelse.ManglendeDok && (
+                <AvslåttSøknad
+                    søknadsbehandlingAvsluttetStatus={avslagManglendeDokStatus}
+                    fritekstValue={formik.values.manglendeDok.fritekst}
+                    fritekstError={formik.errors.manglendeDok?.fritekst}
+                    onFritekstChange={(e: string) =>
+                        formik.setValues((values) => ({
+                            ...values,
+                            manglendeDok: {
+                                fritekst: e,
+                            },
+                        }))
+                    }
                 />
             )}
             <div className={styles.tilbakeKnappContainer}>
-                <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: urlParams.sakId })} className="knapp">
-                    {intl.formatMessage({ id: 'knapp.tilbake' })}
+                <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })}>
+                    {formatMessage('link.tilbake')}
                 </Link>
             </div>
 
-            <div>{error && <ApiErrorAlert error={error} />}</div>
+            <div>{RemoteData.isFailure(søknadLukketStatus) && <ApiErrorAlert error={søknadLukketStatus.error} />}</div>
         </form>
     );
 };
 
 function lagBody(values: LukkSøknadFormData): LukkSøknadBodyTypes {
-    switch (values.lukkSøknadBegrunnelse) {
+    switch (values.lukkSøknadOgAvsluttSøknadsbehandling) {
         case LukkSøknadBegrunnelse.Trukket:
             return {
-                type: values.lukkSøknadBegrunnelse,
-                //Denne har validering
+                type: values.lukkSøknadOgAvsluttSøknadsbehandling,
+                // Denne har validering i trukket komponenten
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                datoSøkerTrakkSøknad: values.datoSøkerTrakkSøknad!,
+                datoSøkerTrakkSøknad: values.trukket.datoSøkerTrakkSøknad!,
             };
 
         case LukkSøknadBegrunnelse.Bortfalt:
             return {
-                type: values.lukkSøknadBegrunnelse,
+                type: values.lukkSøknadOgAvsluttSøknadsbehandling,
             };
         case LukkSøknadBegrunnelse.Avvist:
             return {
-                type: values.lukkSøknadBegrunnelse,
-                brevConfig: values.typeBrev
+                type: values.lukkSøknadOgAvsluttSøknadsbehandling,
+                brevConfig: values.avvist.typeBrev
                     ? {
-                          brevtype: values.typeBrev,
-                          fritekst: values.fritekst,
+                          brevtype: values.avvist.typeBrev,
+                          fritekst: values.avvist.fritekst,
                       }
                     : null,
             };
@@ -209,4 +213,17 @@ function hentOpprettetDatoFraSøknad(søknad: Søknad) {
     return søknad.opprettet;
 }
 
-export default LukkSøknad;
+const lukkSøknadBegrunnelseI18nId = (type: LukkSøknadOgAvsluttSøknadsbehandlingType): keyof typeof nb => {
+    switch (type) {
+        case LukkSøknadBegrunnelse.Trukket:
+            return 'lukking.begrunnelse.trukket';
+        case LukkSøknadBegrunnelse.Bortfalt:
+            return 'lukking.begrunnelse.bortfalt';
+        case LukkSøknadBegrunnelse.Avvist:
+            return 'lukking.begrunnelse.avvist';
+        case AvsluttSøknadsbehandlingBegrunnelse.ManglendeDok:
+            return 'avslutt.manglendeDokumentasjon';
+    }
+};
+
+export default LukkSøknadOgAvsluttBehandling;

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -129,16 +129,8 @@ const LukkSøknadOgAvsluttBehandling = (props: { sakId: string; søknad: Søknad
                     søknadId={props.søknad.id}
                     søknadLukketStatus={søknadLukketStatus}
                     validateForm={() => formik.validateForm()}
-                    avvistFormData={{
-                        skalSendesBrev: formik.values.avvist.skalSendesBrev,
-                        typeBrev: formik.values.avvist.typeBrev,
-                        fritekst: formik.values.avvist.fritekst,
-                    }}
-                    feilmeldinger={{
-                        skalSendesBrev: formik.errors.avvist?.skalSendesBrev,
-                        typeBrev: formik.errors.avvist?.typeBrev,
-                        fritekst: formik.errors.avvist?.fritekst,
-                    }}
+                    avvistFormData={formik.values.avvist}
+                    feilmeldinger={formik.errors.avvist}
                     onValueChange={(val) =>
                         formik.setValues((values) => ({
                             ...values,

--- a/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/LukkSøknad.tsx
@@ -91,12 +91,12 @@ const LukkSøknadOgAvsluttBehandling = (props: { sakId: string; søknad: Søknad
                     <option value="velgBegrunnelse">{formatMessage('selector.velgBegrunnelse')}</option>
                     {Object.values(LukkSøknadBegrunnelse).map((begrunnelse) => (
                         <option value={begrunnelse} key={begrunnelse}>
-                            {formatMessage(lukkSøknadBegrunnelseI18nId(begrunnelse))}
+                            {formatMessage(lukkSøknadBegrunnelseI18nId[begrunnelse])}
                         </option>
                     ))}
                     {Object.values(AvsluttSøknadsbehandlingBegrunnelse).map((begrunnelse) => (
                         <option value={begrunnelse} key={begrunnelse}>
-                            {formatMessage(lukkSøknadBegrunnelseI18nId(begrunnelse))}
+                            {formatMessage(lukkSøknadBegrunnelseI18nId[begrunnelse])}
                         </option>
                     ))}
                 </Select>
@@ -201,17 +201,11 @@ function hentOpprettetDatoFraSøknad(søknad: Søknad) {
     return søknad.opprettet;
 }
 
-const lukkSøknadBegrunnelseI18nId = (type: LukkSøknadOgAvsluttSøknadsbehandlingType): keyof typeof nb => {
-    switch (type) {
-        case LukkSøknadBegrunnelse.Trukket:
-            return 'lukking.begrunnelse.trukket';
-        case LukkSøknadBegrunnelse.Bortfalt:
-            return 'lukking.begrunnelse.bortfalt';
-        case LukkSøknadBegrunnelse.Avvist:
-            return 'lukking.begrunnelse.avvist';
-        case AvsluttSøknadsbehandlingBegrunnelse.ManglendeDok:
-            return 'avslutt.manglendeDokumentasjon';
-    }
+const lukkSøknadBegrunnelseI18nId: { [key in LukkSøknadOgAvsluttSøknadsbehandlingType]: keyof typeof nb } = {
+    TRUKKET: 'lukking.begrunnelse.trukket',
+    BORTFALT: 'lukking.begrunnelse.bortfalt',
+    AVVIST: 'lukking.begrunnelse.avvist',
+    MANGLENDE_DOK: 'avslutt.manglendeDokumentasjon',
 };
 
 export default LukkSøknadOgAvsluttBehandling;

--- a/src/pages/saksbehandling/lukkSøknad/Trukket.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Trukket.tsx
@@ -78,7 +78,7 @@ const Trukket = (props: TrukketProps) => {
                     {formatMessage('knapp.seBrev')}
                     {RemoteData.isPending(brevStatus) && <Loader />}
                 </Button>
-                <Button variant="danger">
+                <Button variant="danger" type="submit">
                     {formatMessage('knapp.lukkSøknad')}
                     {RemoteData.isPending(props.søknadLukketStatus) && <Loader />}
                 </Button>

--- a/src/pages/saksbehandling/lukkSøknad/Trukket.tsx
+++ b/src/pages/saksbehandling/lukkSøknad/Trukket.tsx
@@ -1,60 +1,38 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { Datepicker } from '@navikt/ds-datepicker';
 import { Button, Label, Loader, Tag } from '@navikt/ds-react';
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 
-import { ApiError } from '~api/apiClient';
-import { hentLukketSøknadBrevutkast } from '~features/saksoversikt/sak.slice';
+import * as søknadApi from '~api/søknadApi';
+import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
+import { ApiResult, useBrevForhåndsvisning } from '~lib/hooks';
 import { useI18n } from '~lib/i18n';
-import { useAppDispatch } from '~redux/Store';
+import { Sak } from '~types/Sak';
 import { LukkSøknadBegrunnelse } from '~types/Søknad';
 
 import nb from './lukkSøknad-nb';
 import styles from './lukkSøknad.module.less';
 
 interface TrukketProps {
-    lukkSøknadBegrunnelse: LukkSøknadBegrunnelse;
     søknadOpprettet: string;
     søknadId: string;
     datoSøkerTrakkSøknad: string | null;
     onDatoSøkerTrakkSøknadChange: (dato: string) => void;
     feilmelding: string | undefined;
-    lukketSøknadBrevutkastStatus: RemoteData.RemoteData<ApiError, null>;
-    søknadLukketStatus: RemoteData.RemoteData<ApiError, null>;
+    søknadLukketStatus: ApiResult<Sak, string>;
 }
 
 const Trukket = (props: TrukketProps) => {
-    const dispatch = useAppDispatch();
     const [clickedViewLetter, setClickedViewLetter] = useState<boolean>(false);
-    const { intl } = useI18n({ messages: nb });
+    const { formatMessage } = useI18n({ messages: nb });
 
-    const onSeBrevClick = useCallback(() => {
-        if (RemoteData.isPending(props.lukketSøknadBrevutkastStatus)) {
-            return;
-        }
-
-        if (props.lukkSøknadBegrunnelse === LukkSøknadBegrunnelse.Trukket && props.datoSøkerTrakkSøknad) {
-            dispatch(
-                hentLukketSøknadBrevutkast({
-                    søknadId: props.søknadId,
-                    body: {
-                        type: props.lukkSøknadBegrunnelse,
-                        datoSøkerTrakkSøknad: props.datoSøkerTrakkSøknad,
-                    },
-                })
-            ).then((action) => {
-                if (hentLukketSøknadBrevutkast.fulfilled.match(action)) {
-                    window.open(action.payload.objectUrl);
-                }
-            });
-        }
-    }, [props]);
+    const [brevStatus, hentBrev] = useBrevForhåndsvisning(søknadApi.hentLukketSøknadsBrevutkast);
 
     return (
         <div className={styles.trukketContainer}>
             <div className={styles.datoContainer}>
                 <Label as="label" htmlFor={'datoSøkerTrakkSøknad'}>
-                    {intl.formatMessage({ id: 'display.trekking.datoSøkerTrakkSøknad' })}
+                    {formatMessage('trekking.datoSøkerTrakkSøknad')}
                 </Label>
                 <Datepicker
                     inputProps={{
@@ -76,7 +54,7 @@ const Trukket = (props: TrukketProps) => {
                 />
                 {props.feilmelding && <Tag variant="error">{props.feilmelding}</Tag>}
                 {clickedViewLetter && props.datoSøkerTrakkSøknad === null && (
-                    <Tag variant="error">{intl.formatMessage({ id: 'display.feil.feltMåFyllesUt' })}</Tag>
+                    <Tag variant="error">{formatMessage('feil.feltMåFyllesUt')}</Tag>
                 )}
             </div>
             <div className={styles.buttonsContainer}>
@@ -86,17 +64,26 @@ const Trukket = (props: TrukketProps) => {
                     type="button"
                     onClick={() => {
                         setClickedViewLetter(true);
-                        onSeBrevClick();
+                        hentBrev({
+                            søknadId: props.søknadId,
+                            body: {
+                                type: LukkSøknadBegrunnelse.Trukket,
+                                //Vi har en use-state som sjekker at verdi ikke er null
+                                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                                datoSøkerTrakkSøknad: props.datoSøkerTrakkSøknad!,
+                            },
+                        });
                     }}
                 >
-                    {intl.formatMessage({ id: 'knapp.seBrev' })}
-                    {RemoteData.isPending(props.lukketSøknadBrevutkastStatus) && <Loader />}
+                    {formatMessage('knapp.seBrev')}
+                    {RemoteData.isPending(brevStatus) && <Loader />}
                 </Button>
                 <Button variant="danger">
-                    {intl.formatMessage({ id: 'knapp.lukkSøknad' })}
+                    {formatMessage('knapp.lukkSøknad')}
                     {RemoteData.isPending(props.søknadLukketStatus) && <Loader />}
                 </Button>
             </div>
+            <div>{RemoteData.isFailure(brevStatus) && <ApiErrorAlert error={brevStatus.error} />}</div>
         </div>
     );
 };

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad-nb.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad-nb.ts
@@ -33,5 +33,5 @@ export default {
     'lukking.søknad.harBlittLukket': 'Søknaden har blitt lukket',
     'lukking.søknad.KunneIkkeLukkeSøknad': 'Kunne ikke lukke søknad',
 
-    'lukkSøknadOgAvsluttSøknadsbehandling.begrunnelseForAvsluttelse': 'Begrunnelse for å lukke søknad',
+    'lukkSøknadOgAvsluttSøknadsbehandling.begrunnelseForAvsluttelse': 'Begrunnelse for å avslutte behandling av søknad',
 };

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad-nb.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad-nb.ts
@@ -1,35 +1,37 @@
 export default {
-    'display.begrunnelseForLukking': 'Begrunnelse for å lukke søknad',
-    'display.brev.kunneIkkeViseBrev': 'Kunne ikke vise brev',
+    'avslutt.manglendeDokumentasjon': 'Avslutt pga manglende dokumentasjon',
+    'avslutt.behandlingHarBlittAvsluttet': 'Behandling av søknad av blitt avsluttet',
 
-    'display.avvist.sendBrevTilSøker': 'Skal det sendes brev til søker?',
-    'display.avvist.typeBrev': 'Type brev',
-    'display.avvist.fritekst': 'Fritekst',
+    'avvist.skalSendesBrevTilSøker': 'Skal det sendes brev til søker?',
+    'avvist.typeBrev': 'Type brev',
+    'avvist.fritekst': 'Fritekst',
+    'avvist.brevType.vedtaksbrev': 'Vedtaksbrev',
+    'avvist.brevType.fritekstbrev': 'Fritekst',
 
-    'display.avvist.brevType.vedtaksbrev': 'Vedtaksbrev',
-    'display.avvist.brevType.fritekstbrev': 'Fritekst',
-
-    'display.feil.feltMåFyllesUt': 'Feltet må fylles ut',
+    'brev.kunneIkkeViseBrev': 'Kunne ikke vise brev',
 
     'display.saksnummer': 'Saksnummer:',
 
-    'display.selector.velgBegrunnelse': 'Velg begrunnelse',
+    'feil.feltMåFyllesUt': 'Feltet må fylles ut',
 
-    'display.søknadId': 'Søknad id:',
+    'selector.velgBegrunnelse': 'Velg begrunnelse',
 
-    'display.søknad.fantIkkeSøknad': 'Fant ikke søknad med søknad id: ',
-    'display.søknad.harBlittLukket': 'Søknaden har blitt lukket',
-    'display.søknad.KunneIkkeLukkeSøknad': 'Kunne ikke lukke søknad',
+    'søknad.søknadId': 'Søknad id:',
 
-    'display.trekking.datoSøkerTrakkSøknad': 'Dato søker trakk søknad',
+    'trekking.datoSøkerTrakkSøknad': 'Dato søker trakk søknad',
 
-    'display.tilSaksoversikt': 'Til saksoversikt',
-
-    'knapp.tilbake': 'Tilbake',
     'knapp.lukkSøknad': 'Lukk søknad',
     'knapp.seBrev': 'Se brev',
+
+    'link.tilbake': 'Tilbake',
 
     'lukking.begrunnelse.trukket': 'Trukket',
     'lukking.begrunnelse.bortfalt': 'Bortfalt',
     'lukking.begrunnelse.avvist': 'Avvist',
+
+    'lukking.søknad.fantIkkeSøknad': 'Fant ikke søknad med søknad id: ',
+    'lukking.søknad.harBlittLukket': 'Søknaden har blitt lukket',
+    'lukking.søknad.KunneIkkeLukkeSøknad': 'Kunne ikke lukke søknad',
+
+    'lukkSøknadOgAvsluttSøknadsbehandling.begrunnelseForAvsluttelse': 'Begrunnelse for å lukke søknad',
 };

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
@@ -26,6 +26,7 @@
 .buttonsContainer {
     display: flex;
     justify-content: center;
+    margin-bottom: @spacing-xs;
 
     .seBrevKnapp {
         margin-right: @spacing-xs;
@@ -38,6 +39,7 @@
     .radioContainer {
         margin-bottom: @spacing-s;
     }
+
     .textAreaContainer {
         margin-bottom: @spacing-s;
     }

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknad.module.less
@@ -1,7 +1,7 @@
 @import '~/styles/variables.less';
 
 .formContainer {
-    margin-bottom: @spacing-xxl;
+    margin-bottom: @spacing;
 }
 
 .selectContainer {
@@ -49,9 +49,4 @@
     display: flex;
     align-items: center;
     margin: @spacing;
-}
-
-.tilbakeKnappContainer {
-    display: flex;
-    justify-content: center;
 }

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
@@ -2,8 +2,8 @@ import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
 import { LukkSøknadBegrunnelse } from '~types/Søknad';
 
-export interface LukkSøknadFormData {
-    lukkSøknadOgAvsluttSøknadsbehandling: Nullable<LukkSøknadOgAvsluttSøknadsbehandlingType>;
+export interface LukkSøknadOgAvsluttSøknadsbehandlingFormData {
+    begrunnelse: Nullable<LukkSøknadOgAvsluttSøknadsbehandlingType>;
     trukket: {
         datoSøkerTrakkSøknad: Nullable<string>;
     };
@@ -18,7 +18,7 @@ export interface LukkSøknadFormData {
 }
 
 export const lukkSøknadInitialValues = {
-    lukkSøknadOgAvsluttSøknadsbehandling: null,
+    begrunnelse: null,
     trukket: {
         datoSøkerTrakkSøknad: null,
     },
@@ -48,8 +48,8 @@ export interface AvvistBrevConfig {
     fritekst: Nullable<string>;
 }
 
-export const LukkSøknadValidationSchema = yup.object<LukkSøknadFormData>({
-    lukkSøknadOgAvsluttSøknadsbehandling: yup
+export const LukkSøknadValidationSchema = yup.object<LukkSøknadOgAvsluttSøknadsbehandlingFormData>({
+    begrunnelse: yup
         .mixed()
         .oneOf([
             LukkSøknadBegrunnelse.Trukket,
@@ -60,7 +60,7 @@ export const LukkSøknadValidationSchema = yup.object<LukkSøknadFormData>({
         .required(),
     trukket: yup
         .object({
-            datoSøkerTrakkSøknad: yup.string().nullable().defined().when('lukkSøknadOgAvsluttSøknadsbehandling', {
+            datoSøkerTrakkSøknad: yup.string().nullable().defined().when('begrunnelse', {
                 is: LukkSøknadBegrunnelse.Trukket,
                 then: yup.string().required(),
                 otherwise: yup.string().nullable().defined(),
@@ -69,7 +69,7 @@ export const LukkSøknadValidationSchema = yup.object<LukkSøknadFormData>({
         .defined(),
     avvist: yup
         .object({
-            skalSendesBrev: yup.boolean().nullable().defined().when('lukkSøknadOgAvsluttSøknadsbehandling', {
+            skalSendesBrev: yup.boolean().nullable().defined().when('begrunnelse', {
                 is: LukkSøknadBegrunnelse.Avvist,
                 then: yup.boolean().required(),
             }),
@@ -93,16 +93,12 @@ export const LukkSøknadValidationSchema = yup.object<LukkSøknadFormData>({
         })
         .defined(),
     manglendeDok: yup
-        .object({
-            fritekst: yup
-                .string()
-                .nullable()
-                .defined()
-                .when('lukkSøknadOgAvsluttSøknadsbehandling', {
-                    is: AvsluttSøknadsbehandlingBegrunnelse.ManglendeDok,
-                    then: yup.string().required().min(1),
-                    otherwise: yup.string().nullable().defined(),
-                }),
+        .object<{ fritekst: Nullable<string> }>()
+        .when('begrunnelse', {
+            is: AvsluttSøknadsbehandlingBegrunnelse.ManglendeDok,
+            then: yup.object({
+                fritekst: yup.string().nullable().required(),
+            }),
         })
         .defined(),
 });

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
@@ -17,25 +17,6 @@ export interface LukkSøknadOgAvsluttSøknadsbehandlingFormData {
     };
 }
 
-export interface TopkekFormData {
-    begrunnelse: Nullable<LukkSøknadOgAvsluttSøknadsbehandlingType>;
-    form: TrukketFormData | AvvistFormData | ManglendeDok;
-}
-
-interface TrukketFormData {
-    datoSøkerTrakkSøknad: Nullable<string>;
-}
-
-interface AvvistFormData {
-    skalSendesBrev: Nullable<boolean>;
-    typeBrev: Nullable<AvvistBrevtyper>;
-    fritekst: Nullable<string>;
-}
-
-interface ManglendeDok {
-    fritekst: Nullable<string>;
-}
-
 export const lukkSøknadInitialValues = {
     begrunnelse: null,
     trukket: {

--- a/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
+++ b/src/pages/saksbehandling/lukkSøknad/lukkSøknadUtils.ts
@@ -17,6 +17,25 @@ export interface LukkSøknadOgAvsluttSøknadsbehandlingFormData {
     };
 }
 
+export interface TopkekFormData {
+    begrunnelse: Nullable<LukkSøknadOgAvsluttSøknadsbehandlingType>;
+    form: TrukketFormData | AvvistFormData | ManglendeDok;
+}
+
+interface TrukketFormData {
+    datoSøkerTrakkSøknad: Nullable<string>;
+}
+
+interface AvvistFormData {
+    skalSendesBrev: Nullable<boolean>;
+    typeBrev: Nullable<AvvistBrevtyper>;
+    fritekst: Nullable<string>;
+}
+
+interface ManglendeDok {
+    fritekst: Nullable<string>;
+}
+
 export const lukkSøknadInitialValues = {
     begrunnelse: null,
     trukket: {

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
@@ -133,10 +133,19 @@ const OppsummeringshandlingForm = (props: {
         (args) => {
             if (args.beslutningEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettMedAndreOpplysninger) {
                 history.push(props.førsteRevurderingstegUrl);
-            } else {
+            } else if (
+                args.beslutningEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger
+            ) {
                 history.push(
                     Routes.createSakIntroLocation(
                         intl.formatMessage({ id: 'notification.sendtTilAttestering' }),
+                        props.sakId
+                    )
+                );
+            } else {
+                history.push(
+                    Routes.createSakIntroLocation(
+                        intl.formatMessage({ id: 'notification.avsluttetRevurdering' }),
                         props.sakId
                     )
                 );
@@ -216,7 +225,7 @@ const OppsummeringshandlingForm = (props: {
                     onSubmit={(args) =>
                         fortsettEtterForhåndsvarsel({
                             beslutningEtterForhåndsvarsel: args.resultatEtterForhåndsvarsel,
-                            brevtekst: args.tekstTilVedtaksbrev,
+                            brevtekst: args.brevTekst,
                             begrunnelse: args.begrunnelse,
                         })
                     }

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
@@ -17,7 +17,7 @@ import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkå
 import {
     BeregnetIngenEndring,
     BeslutningEtterForhåndsvarsling,
-    Revurdering,
+    InformasjonsRevurdering,
     SimulertRevurdering,
     UnderkjentRevurdering,
 } from '~types/Revurdering';
@@ -131,24 +131,25 @@ const OppsummeringshandlingForm = (props: {
             };
         },
         (args) => {
-            if (args.beslutningEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettMedAndreOpplysninger) {
-                history.push(props.førsteRevurderingstegUrl);
-            } else if (
-                args.beslutningEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger
-            ) {
-                history.push(
-                    Routes.createSakIntroLocation(
-                        intl.formatMessage({ id: 'notification.sendtTilAttestering' }),
-                        props.sakId
-                    )
-                );
-            } else {
-                history.push(
-                    Routes.createSakIntroLocation(
-                        intl.formatMessage({ id: 'notification.avsluttetRevurdering' }),
-                        props.sakId
-                    )
-                );
+            switch (args.beslutningEtterForhåndsvarsel) {
+                case BeslutningEtterForhåndsvarsling.FortsettMedAndreOpplysninger:
+                    history.push(props.førsteRevurderingstegUrl);
+                    break;
+                case BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger:
+                    history.push(
+                        Routes.createSakIntroLocation(
+                            intl.formatMessage({ id: 'notification.sendtTilAttestering' }),
+                            props.sakId
+                        )
+                    );
+                    break;
+                case BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer:
+                    history.push(
+                        Routes.createSakIntroLocation(
+                            intl.formatMessage({ id: 'notification.avsluttetRevurdering' }),
+                            props.sakId
+                        )
+                    );
             }
         }
     );
@@ -239,7 +240,7 @@ const RevurderingOppsummeringPage = (props: {
     sakId: string;
     forrigeUrl: string;
     førsteRevurderingstegUrl: string;
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     grunnlagsdataOgVilkårsvurderinger: RemoteData.RemoteData<ApiError, GrunnlagsdataOgVilkårsvurderinger>;
 }) => {
     const dispatch = useAppDispatch();

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
@@ -31,7 +31,7 @@ const VedtaksbrevInput = (
                 id: 'brevInput.tekstTilVedtaksbrev.placeholder',
             })}
             onVisBrevClick={() =>
-                pdfApi.fetchBrevutkastForRevurderingWithFritekst({
+                pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
                     sakId: props.sakId,
                     revurderingId: props.revurderingId,
                     fritekst: props.tekst,

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
@@ -12,16 +12,14 @@ import { ApiResult } from '~lib/hooks';
 import { useI18n } from '~lib/i18n';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
-import { BeslutningEtterForhåndsvarsling, Revurdering } from '~types/Revurdering';
+import { BeslutningEtterForhåndsvarsling, InformasjonsRevurdering } from '~types/Revurdering';
 
 import { RevurderingBunnknapper } from '../../bunnknapper/RevurderingBunnknapper';
 
 import messages from './oppsummeringPageForms-nb';
 import styles from './oppsummeringPageForms.module.less';
 
-const OppsummeringsBrevInput = (
-    props: { sakId: string; revurderingId: string } & Omit<BrevInputProps, 'placeholder' | 'intl'>
-) => {
+const OppsummeringsBrevInput = (props: Omit<BrevInputProps, 'placeholder' | 'intl'>) => {
     const { intl } = useI18n({ messages });
     return (
         <BrevInput placeholder={intl.formatMessage({ id: 'brevInput.innhold.placeholder' })} intl={intl} {...props} />
@@ -139,8 +137,6 @@ export const ResultatEtterForhåndsvarselform = (props: {
                     name="tekstTilVedtaksbrev"
                     render={({ field, fieldState }) => (
                         <OppsummeringsBrevInput
-                            sakId={props.sakId}
-                            revurderingId={props.revurderingId}
                             tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
                             onVisBrevClick={() =>
                                 pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
@@ -162,8 +158,6 @@ export const ResultatEtterForhåndsvarselform = (props: {
                     name="tekstTilAvsluttRevurderingBrev"
                     render={({ field, fieldState }) => (
                         <OppsummeringsBrevInput
-                            sakId={props.sakId}
-                            revurderingId={props.revurderingId}
                             tittel={intl.formatMessage({ id: 'brevInput.tekstTilAvsluttRevurdering.tittel' })}
                             onVisBrevClick={() =>
                                 pdfApi.fetchBrevutkastForAvslutningAvRevurdering({
@@ -264,8 +258,6 @@ export const VelgForhåndsvarselForm = (props: {
                     render={({ field, fieldState }) =>
                         revurderingshandling === Revurderingshandling.Forhåndsvarsle ? (
                             <OppsummeringsBrevInput
-                                sakId={props.sakId}
-                                revurderingId={props.revurderingId}
                                 tittel={intl.formatMessage({ id: 'brevInput.tekstTilForhåndsvarsel.tittel' })}
                                 onVisBrevClick={() =>
                                     pdfApi.fetchBrevutkastForForhåndsvarsel(
@@ -280,8 +272,6 @@ export const VelgForhåndsvarselForm = (props: {
                             />
                         ) : (
                             <OppsummeringsBrevInput
-                                sakId={props.sakId}
-                                revurderingId={props.revurderingId}
                                 tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
                                 onVisBrevClick={() =>
                                     pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
@@ -316,7 +306,7 @@ export const VelgForhåndsvarselForm = (props: {
 };
 
 export const SendTilAttesteringForm = (props: {
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     forrigeUrl: string;
     submitStatus: ApiResult<unknown>;
     brevsending: 'aldriSende' | 'alltidSende' | 'kanVelge';
@@ -370,8 +360,6 @@ export const SendTilAttesteringForm = (props: {
                     name="tekstTilVedtaksbrev"
                     render={({ field, fieldState }) => (
                         <OppsummeringsBrevInput
-                            sakId={props.revurdering.tilRevurdering.sakId}
-                            revurderingId={props.revurdering.id}
                             tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
                             onVisBrevClick={() =>
                                 pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/OppsummeringPageForms.tsx
@@ -19,45 +19,12 @@ import { RevurderingBunnknapper } from '../../bunnknapper/RevurderingBunnknapper
 import messages from './oppsummeringPageForms-nb';
 import styles from './oppsummeringPageForms.module.less';
 
-const VedtaksbrevInput = (
-    props: { sakId: string; revurderingId: string } & Omit<BrevInputProps, 'tittel' | 'placeholder' | 'onVisBrevClick'>
+const OppsummeringsBrevInput = (
+    props: { sakId: string; revurderingId: string } & Omit<BrevInputProps, 'placeholder' | 'intl'>
 ) => {
     const { intl } = useI18n({ messages });
-
     return (
-        <BrevInput
-            tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
-            placeholder={intl.formatMessage({
-                id: 'brevInput.tekstTilVedtaksbrev.placeholder',
-            })}
-            onVisBrevClick={() =>
-                pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
-                    sakId: props.sakId,
-                    revurderingId: props.revurderingId,
-                    fritekst: props.tekst,
-                })
-            }
-            {...props}
-        />
-    );
-};
-
-const ForhåndsvarselbrevInput = (
-    props: { sakId: string; revurderingId: string } & Omit<BrevInputProps, 'tittel' | 'placeholder' | 'onVisBrevClick'>
-) => {
-    const { intl } = useI18n({ messages });
-
-    return (
-        <BrevInput
-            tittel={intl.formatMessage({ id: 'brevInput.tekstTilForhåndsvarsel.tittel' })}
-            placeholder={intl.formatMessage({
-                id: 'brevInput.tekstTilForhåndsvarsel.placeholder',
-            })}
-            onVisBrevClick={() =>
-                pdfApi.fetchBrevutkastForForhåndsvarsel(props.sakId, props.revurderingId, props.tekst)
-            }
-            {...props}
-        />
+        <BrevInput placeholder={intl.formatMessage({ id: 'brevInput.innhold.placeholder' })} intl={intl} {...props} />
     );
 };
 
@@ -68,7 +35,7 @@ export const ResultatEtterForhåndsvarselform = (props: {
     submitStatus: ApiResult<unknown>;
     onSubmit(args: {
         resultatEtterForhåndsvarsel: BeslutningEtterForhåndsvarsling;
-        tekstTilVedtaksbrev: string;
+        brevTekst: string;
         begrunnelse: string;
     }): void;
 }) => {
@@ -77,6 +44,7 @@ export const ResultatEtterForhåndsvarselform = (props: {
     interface FormData {
         resultatEtterForhåndsvarsel: Nullable<BeslutningEtterForhåndsvarsling>;
         tekstTilVedtaksbrev: string;
+        tekstTilAvsluttRevurderingBrev: string;
         begrunnelse: string;
     }
 
@@ -84,6 +52,7 @@ export const ResultatEtterForhåndsvarselform = (props: {
         defaultValues: {
             resultatEtterForhåndsvarsel: null,
             tekstTilVedtaksbrev: '',
+            tekstTilAvsluttRevurderingBrev: '',
             begrunnelse: '',
         },
         resolver: yupResolver(
@@ -94,11 +63,13 @@ export const ResultatEtterForhåndsvarselform = (props: {
                         .oneOf(Object.values(BeslutningEtterForhåndsvarsling), 'Feltet må fylles ut')
                         .required(),
                     tekstTilVedtaksbrev: yup.string(),
-                    begrunnelse: yup.string(),
+                    tekstTilAvsluttRevurderingBrev: yup.string(),
+                    begrunnelse: yup.string().required(),
                 })
                 .required()
         ),
     });
+
     const resultatEtterForhåndsvarsel = form.watch('resultatEtterForhåndsvarsel');
     return (
         <form
@@ -107,7 +78,10 @@ export const ResultatEtterForhåndsvarselform = (props: {
                     begrunnelse: values.begrunnelse,
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     resultatEtterForhåndsvarsel: values.resultatEtterForhåndsvarsel!,
-                    tekstTilVedtaksbrev: values.tekstTilVedtaksbrev,
+                    brevTekst:
+                        values.resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger
+                            ? values.tekstTilVedtaksbrev
+                            : values.tekstTilAvsluttRevurderingBrev,
                 })
             )}
             className={styles.form}
@@ -138,7 +112,7 @@ export const ResultatEtterForhåndsvarselform = (props: {
                                 id: 'etterForhåndsvarsel.radio.andreOpplysninger',
                             })}
                         </Radio>
-                        <Radio value={BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer} disabled={true}>
+                        <Radio value={BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer}>
                             {intl.formatMessage({
                                 id: 'etterForhåndsvarsel.radio.avsluttesUtenEndring',
                             })}
@@ -149,28 +123,58 @@ export const ResultatEtterForhåndsvarselform = (props: {
             <Controller
                 control={form.control}
                 name="begrunnelse"
-                render={({ field }) => (
+                render={({ field, fieldState }) => (
                     <div className={styles.etterForhåndsvarselBegrunnelseContainer}>
                         <Textarea
                             label={intl.formatMessage({ id: 'etterForhåndsvarsel.begrunnelse.label' })}
                             {...field}
+                            error={fieldState.error?.message}
                         />
                     </div>
                 )}
             />
-            {(resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger ||
-                resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer) && (
+            {resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger && (
                 <Controller
                     control={form.control}
                     name="tekstTilVedtaksbrev"
                     render={({ field, fieldState }) => (
-                        <VedtaksbrevInput
+                        <OppsummeringsBrevInput
                             sakId={props.sakId}
                             revurderingId={props.revurderingId}
+                            tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
+                            onVisBrevClick={() =>
+                                pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
+                                    sakId: props.sakId,
+                                    revurderingId: props.revurderingId,
+                                    fritekst: field.value,
+                                })
+                            }
                             tekst={field.value}
-                            feil={fieldState.error}
                             onChange={field.onChange}
-                            intl={intl}
+                            feil={fieldState.error}
+                        />
+                    )}
+                />
+            )}
+            {resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer && (
+                <Controller
+                    control={form.control}
+                    name="tekstTilAvsluttRevurderingBrev"
+                    render={({ field, fieldState }) => (
+                        <OppsummeringsBrevInput
+                            sakId={props.sakId}
+                            revurderingId={props.revurderingId}
+                            tittel={intl.formatMessage({ id: 'brevInput.tekstTilAvsluttRevurdering.tittel' })}
+                            onVisBrevClick={() =>
+                                pdfApi.fetchBrevutkastForAvslutningAvRevurdering({
+                                    sakId: props.sakId,
+                                    revurderingId: props.revurderingId,
+                                    fritekst: field.value,
+                                })
+                            }
+                            tekst={field.value}
+                            onChange={field.onChange}
+                            feil={fieldState.error}
                         />
                     )}
                 />
@@ -181,6 +185,8 @@ export const ResultatEtterForhåndsvarselform = (props: {
                 nesteKnappTekst={
                     resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.FortsettMedAndreOpplysninger
                         ? intl.formatMessage({ id: 'fortsett.button.label' })
+                        : resultatEtterForhåndsvarsel === BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer
+                        ? intl.formatMessage({ id: 'avslutt.button.label' })
                         : intl.formatMessage({ id: 'sendTilAttestering.button.label' })
                 }
                 onNesteClickSpinner={RemoteData.isPending(props.submitStatus)}
@@ -257,22 +263,36 @@ export const VelgForhåndsvarselForm = (props: {
                     name="fritekstTilBrev"
                     render={({ field, fieldState }) =>
                         revurderingshandling === Revurderingshandling.Forhåndsvarsle ? (
-                            <ForhåndsvarselbrevInput
+                            <OppsummeringsBrevInput
                                 sakId={props.sakId}
                                 revurderingId={props.revurderingId}
+                                tittel={intl.formatMessage({ id: 'brevInput.tekstTilForhåndsvarsel.tittel' })}
+                                onVisBrevClick={() =>
+                                    pdfApi.fetchBrevutkastForForhåndsvarsel(
+                                        props.sakId,
+                                        props.revurderingId,
+                                        field.value ?? ''
+                                    )
+                                }
                                 tekst={field.value ?? ''}
                                 onChange={field.onChange}
                                 feil={fieldState.error}
-                                intl={intl}
                             />
                         ) : (
-                            <VedtaksbrevInput
+                            <OppsummeringsBrevInput
                                 sakId={props.sakId}
                                 revurderingId={props.revurderingId}
+                                tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
+                                onVisBrevClick={() =>
+                                    pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
+                                        sakId: props.sakId,
+                                        revurderingId: props.revurderingId,
+                                        fritekst: field.value,
+                                    })
+                                }
                                 tekst={field.value ?? ''}
                                 onChange={field.onChange}
                                 feil={fieldState.error}
-                                intl={intl}
                             />
                         )
                     }
@@ -349,13 +369,20 @@ export const SendTilAttesteringForm = (props: {
                     control={form.control}
                     name="tekstTilVedtaksbrev"
                     render={({ field, fieldState }) => (
-                        <VedtaksbrevInput
+                        <OppsummeringsBrevInput
                             sakId={props.revurdering.tilRevurdering.sakId}
                             revurderingId={props.revurdering.id}
-                            tekst={field.value}
-                            feil={fieldState.error}
+                            tittel={intl.formatMessage({ id: 'brevInput.tekstTilVedtaksbrev.tittel' })}
+                            onVisBrevClick={() =>
+                                pdfApi.fetchBrevutkastForRevurderingMedPotensieltFritekst({
+                                    sakId: props.revurdering.tilRevurdering.sakId,
+                                    revurderingId: props.revurdering.id,
+                                    fritekst: field.value,
+                                })
+                            }
+                            tekst={field.value ?? ''}
                             onChange={field.onChange}
-                            intl={intl}
+                            feil={fieldState.error}
                         />
                     )}
                 />

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/oppsummeringPageForms-nb.ts
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/oppsummeringPageForms/oppsummeringPageForms-nb.ts
@@ -4,14 +4,16 @@ export default {
 
     'knapp.seBrev': 'Forhåndsvis brev',
 
+    'avslutt.button.label': 'Avslutt revurdering',
+
     'sendTilAttestering.button.label': 'Send til attestering',
     'sendForhåndsvarsel.button.label': 'Send forhåndsvarsel',
     'fortsett.button.label': 'Fortsett',
 
     'brevInput.tekstTilVedtaksbrev.tittel': 'Tekst til vedtaksbrev',
-    'brevInput.tekstTilVedtaksbrev.placeholder': 'Skriv teksten her',
     'brevInput.tekstTilForhåndsvarsel.tittel': 'Tekst til forhåndsvarsel',
-    'brevInput.tekstTilForhåndsvarsel.placeholder': 'Skriv teksten her',
+    'brevInput.tekstTilAvsluttRevurdering.tittel': 'Tekst til Avslutting av revurderings-brev',
+    'brevInput.innhold.placeholder': 'Skriv teksten her',
 
     'sendTilAttestering.skalFøreTilBrev': 'Send vedtaksbrev til bruker',
 

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/revurderingOppsummeringPage-nb.ts
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/revurderingOppsummeringPage-nb.ts
@@ -7,4 +7,5 @@ export default {
 
     'notification.sendtTilAttestering': 'Revurderingen er sendt til attestering',
     'notification.sendtForhåndsvarsel': 'Forhåndsvarsel er sendt',
+    'notification.avsluttetRevurdering': 'Revurderingen har blitt avsluttet',
 };

--- a/src/pages/saksbehandling/revurdering/Revurdering.tsx
+++ b/src/pages/saksbehandling/revurdering/Revurdering.tsx
@@ -19,6 +19,7 @@ import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkå
 import { Revurdering, Vurderingstatus } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import {
+    erRevurdering,
     revurderingstegrekkefølge,
     revurderingstegTilInformasjonSomRevurderes,
 } from '~utils/revurdering/revurderingUtils';
@@ -60,6 +61,16 @@ const RevurderingPage = (props: { sak: Sak }) => {
     const urlParams = Routes.useRouteParams<typeof Routes.revurderValgtRevurdering>();
 
     const påbegyntRevurdering = props.sak.revurderinger.find((r) => r.id === urlParams.revurderingId);
+
+    if (påbegyntRevurdering && !erRevurdering(påbegyntRevurdering)) {
+        //TODO: håndter at vi ikke skal ha ikke-revurderinger inn her
+        return (
+            <div>
+                Hvis du ser denne meldingen, så har noe virkelig gått galt, eller så har du brukt en feil
+                revurderings-id
+            </div>
+        );
+    }
 
     const dispatch = useAppDispatch();
     const grunnlag = useAppSelector(

--- a/src/pages/saksbehandling/revurdering/Revurdering.tsx
+++ b/src/pages/saksbehandling/revurdering/Revurdering.tsx
@@ -1,5 +1,5 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert, Heading, Loader } from '@navikt/ds-react';
+import { Alert, Heading, Link, Loader } from '@navikt/ds-react';
 import * as A from 'fp-ts/Array';
 import { pipe } from 'fp-ts/lib/function';
 import * as O from 'fp-ts/Option';
@@ -63,11 +63,15 @@ const RevurderingPage = (props: { sak: Sak }) => {
     const påbegyntRevurdering = props.sak.revurderinger.find((r) => r.id === urlParams.revurderingId);
 
     if (påbegyntRevurdering && !erRevurdering(påbegyntRevurdering)) {
-        //TODO: håndter at vi ikke skal ha ikke-revurderinger inn her
         return (
             <div>
-                Hvis du ser denne meldingen, så har noe virkelig gått galt, eller så har du brukt en feil
-                revurderings-id
+                <p>
+                    Hvis du ser denne meldingen, så har noe virkelig gått galt, eller så har du brukt en feil
+                    revurderings-id
+                </p>
+                <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}>
+                    Tilbake til saksoversikt
+                </Link>
             </div>
         );
     }

--- a/src/pages/saksbehandling/revurdering/Revurdering.tsx
+++ b/src/pages/saksbehandling/revurdering/Revurdering.tsx
@@ -1,5 +1,5 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert, Heading, Link, Loader } from '@navikt/ds-react';
+import { Alert, BodyLong, Heading, Link, Loader } from '@navikt/ds-react';
 import * as A from 'fp-ts/Array';
 import { pipe } from 'fp-ts/lib/function';
 import * as O from 'fp-ts/Option';
@@ -16,10 +16,10 @@ import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
-import { Revurdering, Vurderingstatus } from '~types/Revurdering';
+import { InformasjonsRevurdering, Vurderingstatus } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import {
-    erRevurdering,
+    erInformasjonsRevurdering,
     revurderingstegrekkefølge,
     revurderingstegTilInformasjonSomRevurderes,
 } from '~utils/revurdering/revurderingUtils';
@@ -62,15 +62,12 @@ const RevurderingPage = (props: { sak: Sak }) => {
 
     const påbegyntRevurdering = props.sak.revurderinger.find((r) => r.id === urlParams.revurderingId);
 
-    if (påbegyntRevurdering && !erRevurdering(påbegyntRevurdering)) {
+    if (påbegyntRevurdering && !erInformasjonsRevurdering(påbegyntRevurdering)) {
         return (
             <div>
-                <p>
-                    Hvis du ser denne meldingen, så har noe virkelig gått galt, eller så har du brukt en feil
-                    revurderings-id
-                </p>
+                <BodyLong>{intl.formatMessage({ id: 'feil.feilRevurderingsId' })}</BodyLong>
                 <Link href={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}>
-                    Tilbake til saksoversikt
+                    {intl.formatMessage({ id: 'link.tilbakeTilSaksoversikt' })}
                 </Link>
             </div>
         );
@@ -133,7 +130,7 @@ const RevurderingPage = (props: { sak: Sak }) => {
         url: createRevurderingsPath(steg),
     }));
 
-    const aktiveSteg = (revurdering: Revurdering) =>
+    const aktiveSteg = (revurdering: InformasjonsRevurdering) =>
         pipe(
             alleSteg,
             A.filterMap((steg) =>
@@ -186,7 +183,7 @@ const RevurderingPage = (props: { sak: Sak }) => {
                                 const forrigeUrl =
                                     aktiveSteg(påbegyntRevurdering)[idx - 1]?.url ??
                                     createRevurderingsPath(RevurderingSteg.Periode);
-                                const nesteUrl = (revurdering: Revurdering) =>
+                                const nesteUrl = (revurdering: InformasjonsRevurdering) =>
                                     aktiveSteg(revurdering)[idx + 1]?.url ??
                                     createRevurderingsPath(RevurderingSteg.Oppsummering);
                                 return (
@@ -228,9 +225,9 @@ const RevurderingPage = (props: { sak: Sak }) => {
 const RevurderingstegPage = (props: {
     steg: RevurderingSteg;
     forrigeUrl: string;
-    nesteUrl: (revurdering: Revurdering) => string;
+    nesteUrl: (revurdering: InformasjonsRevurdering) => string;
     sakId: string;
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     grunnlagsdataOgVilkårsvurderinger: RemoteData.RemoteData<ApiError, GrunnlagsdataOgVilkårsvurderinger>;
 }) => {
     return pipe(

--- a/src/pages/saksbehandling/revurdering/bosituasjon/BosituasjonForm.tsx
+++ b/src/pages/saksbehandling/revurdering/bosituasjon/BosituasjonForm.tsx
@@ -22,7 +22,7 @@ import yup, { hookFormErrorsTilFeiloppsummering } from '~lib/validering';
 import { useAppDispatch } from '~redux/Store';
 import { Bosituasjon } from '~types/grunnlagsdataOgVilkårsvurderinger/bosituasjon/Bosituasjongrunnlag';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
-import { BosituasjonRequest, Revurdering } from '~types/Revurdering';
+import { BosituasjonRequest, InformasjonsRevurdering, Revurdering } from '~types/Revurdering';
 import * as DateUtils from '~utils/date/dateUtils';
 
 import { RevurderingBunnknapper } from '../bunnknapper/RevurderingBunnknapper';
@@ -185,10 +185,10 @@ const DelerSøkerBoligForm = (props: { control: Control<BosituasjonFormData>; in
 
 const BosituasjonForm = (props: {
     sakId: string;
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     gjeldendeGrunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
     forrigeUrl: string;
-    nesteUrl: (revurdering: Revurdering) => string;
+    nesteUrl: (revurdering: InformasjonsRevurdering) => string;
 }) => {
     const { intl } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const [epsAlder, setEpsAlder] = useState<Nullable<number>>(null);

--- a/src/pages/saksbehandling/revurdering/revurdering-nb.ts
+++ b/src/pages/saksbehandling/revurdering/revurdering-nb.ts
@@ -5,4 +5,9 @@ export default {
     'steg.fradrag': 'Inntekt',
     'steg.formue': 'Formue',
     'steg.oppsummering': 'Oppsummering',
+
+    'feil.feilRevurderingsId':
+        'Hvis du ser denne meldingen, så har noe virkelig gått galt, eller så har du brukt en feil revurderings-id',
+
+    'link.tilbakeTilSaksoversikt': 'Tilbake til saksoversikt',
 };

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/EndreRevurderingPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/EndreRevurderingPage.tsx
@@ -5,14 +5,14 @@ import { useHistory } from 'react-router-dom';
 import { oppdaterRevurderingsPeriode as oppdaterRevurdering } from '~features/revurdering/revurderingActions';
 import * as Routes from '~lib/routes';
 import { useAppDispatch, useAppSelector } from '~redux/Store';
-import { InformasjonSomRevurderes, OpprettetRevurderingGrunn, Revurdering } from '~types/Revurdering';
+import { InformasjonSomRevurderes, InformasjonsRevurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { compareUtbetalingsperiode } from '~types/Utbetalingsperiode';
 import { finnNesteRevurderingsteg } from '~utils/revurdering/revurderingUtils';
 
 import RevurderingIntroForm from './RevurderingIntroForm';
 
-const EndreRevurderingPage = (props: { sak: Sak; revurdering: Revurdering }) => {
+const EndreRevurderingPage = (props: { sak: Sak; revurdering: InformasjonsRevurdering }) => {
     const oppdaterRevurderingStatus = useAppSelector((state) => state.sak.oppdaterRevurderingStatus);
     const history = useHistory();
 

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroForm.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroForm.tsx
@@ -15,7 +15,7 @@ import { customFormikSubmit } from '~lib/formUtils';
 import { useI18n } from '~lib/i18n';
 import { keyOf, Nullable } from '~lib/types';
 import yup, { formikErrorsHarFeil, formikErrorsTilFeiloppsummering } from '~lib/validering';
-import { InformasjonSomRevurderes, OpprettetRevurderingGrunn, Revurdering } from '~types/Revurdering';
+import { InformasjonSomRevurderes, InformasjonsRevurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
 import { getRevurderingsårsakMessageId } from '~utils/revurdering/revurderingUtils';
 
 import { RevurderingBunnknapper } from '../bunnknapper/RevurderingBunnknapper';
@@ -56,7 +56,7 @@ interface RevurderingIntroFormProps {
     onNesteClick: (arg: FormValues) => void;
     onLagreOgFortsettSenereClick: (arg: FormValues) => void;
     tilbakeUrl: string;
-    revurdering?: Revurdering;
+    revurdering?: InformasjonsRevurdering;
     minFraOgMed: Date;
     maxFraOgMed: Date;
     nesteClickStatus: RemoteData.RemoteData<ApiError, null>;

--- a/src/pages/saksbehandling/sakintro/RevurderingsLister.tsx
+++ b/src/pages/saksbehandling/sakintro/RevurderingsLister.tsx
@@ -1,0 +1,258 @@
+import { BodyShort, Heading, Label, Panel, Tag } from '@navikt/ds-react';
+import { last } from 'fp-ts/lib/Array';
+import { toNullable } from 'fp-ts/lib/Option';
+import Ikon from 'nav-frontend-ikoner-assets';
+import React from 'react';
+import { IntlShape } from 'react-intl';
+
+import LinkAsButton from '~components/linkAsButton/LinkAsButton';
+import UnderkjenteAttesteringer from '~components/underkjenteAttesteringer/UnderkjenteAttesteringer';
+import { useUserContext } from '~context/userContext';
+import { pipe } from '~lib/fp';
+import * as Routes from '~lib/routes';
+import { AbstraktRevurdering, RevurderingsStatus } from '~types/Revurdering';
+import { Sak } from '~types/Sak';
+import { Vedtak } from '~types/Vedtak';
+
+import {
+    erRevurderingTilAttestering,
+    erRevurderingIverksatt,
+    erRevurderingSimulert,
+    erForhåndsvarselSendt,
+    finnNesteRevurderingsteg,
+    erRevurderingStans,
+    erRevurderingGjenopptak,
+    erRevurdering,
+} from '../../../utils/revurdering/revurderingUtils';
+import { RevurderingSteg } from '../types';
+
+import { AvsluttOgStartFortsettButtons } from './Sakintro';
+import styles from './sakintro.module.less';
+
+export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: AbstraktRevurdering[]; intl: IntlShape }) => {
+    if (props.åpneRevurderinger.length === 0) return null;
+
+    return (
+        <div className={styles.søknadsContainer}>
+            <Heading level="2" size="medium" spacing>
+                {props.intl.formatMessage({ id: 'revurdering.tittel' })}
+            </Heading>
+            <ol>
+                {props.åpneRevurderinger.map((r) => {
+                    const vedtakForBehandling = props.sak.vedtak.find((v) => v.behandlingId === r.id);
+                    const underkjenteRevurderinger = r.attesteringer.filter((a) => a.underkjennelse !== null);
+                    return (
+                        <div key={r.id}>
+                            <Panel border className={styles.søknad}>
+                                <div className={styles.info}>
+                                    <div>
+                                        <div className={styles.tittel}>
+                                            <Heading level="3" size="small" spacing>
+                                                {props.intl.formatMessage({ id: 'revurdering.undertittel' })}
+                                            </Heading>
+                                            {erRevurdering(r) && erForhåndsvarselSendt(r) && (
+                                                <Tag variant="info" className={styles.etikett}>
+                                                    {props.intl.formatMessage({
+                                                        id: 'revurdering.label.forhåndsvarselSendt',
+                                                    })}
+                                                </Tag>
+                                            )}
+                                        </div>
+                                        {!erRevurdering(r) && (
+                                            <div className={styles.informasjonsTekst}>
+                                                <Label>{props.intl.formatMessage({ id: 'revurdering.type' })} </Label>
+                                                <BodyShort>
+                                                    {props.intl.formatMessage({
+                                                        id: 'revurdering.type.stansGjenoppta.label',
+                                                    })}
+                                                </BodyShort>
+                                            </div>
+                                        )}
+                                        <div className={styles.dato}>
+                                            <Label>{props.intl.formatMessage({ id: 'revurdering.opprettet' })} </Label>
+                                            <BodyShort>{props.intl.formatDate(r.opprettet)}</BodyShort>
+                                        </div>
+                                        {vedtakForBehandling?.opprettet && (
+                                            <div className={styles.dato}>
+                                                <Label>
+                                                    {props.intl.formatMessage({ id: 'revurdering.iverksattDato' })}{' '}
+                                                </Label>
+                                                <BodyShort>
+                                                    {props.intl.formatDate(vedtakForBehandling.opprettet)}
+                                                </BodyShort>
+                                            </div>
+                                        )}
+                                        {underkjenteRevurderinger.length > 0 &&
+                                            erRevurdering(r) &&
+                                            !erRevurderingIverksatt(r) && (
+                                                <div className={styles.underkjenteAttesteringerContainer}>
+                                                    <UnderkjenteAttesteringer attesteringer={r.attesteringer} />
+                                                </div>
+                                            )}
+                                    </div>
+                                    <div className={styles.knapper}>
+                                        <RevurderingStartetKnapper
+                                            sakId={props.sak.id}
+                                            vedtak={props.sak.vedtak}
+                                            revurdering={r}
+                                            intl={props.intl}
+                                        />
+                                    </div>
+                                </div>
+                            </Panel>
+                        </div>
+                    );
+                })}
+            </ol>
+        </div>
+    );
+};
+
+const RevurderingStartetKnapper = (props: {
+    sakId: string;
+    revurdering: AbstraktRevurdering;
+    vedtak: Vedtak[];
+    intl: IntlShape;
+}) => {
+    const user = useUserContext();
+    const { revurdering } = props;
+    const vedtak = props.vedtak.find((v) => v.behandlingId === revurdering.id);
+
+    return (
+        <div className={styles.behandlingContainer}>
+            {erRevurdering(revurdering) &&
+                erRevurderingTilAttestering(revurdering) &&
+                (!user.isAttestant || user.navIdent === revurdering.saksbehandler) && (
+                    <div className={styles.ikonContainer}>
+                        <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
+                        <p>
+                            {props.intl.formatMessage({
+                                id: 'attestering.tilAttestering',
+                            })}
+                        </p>
+                    </div>
+                )}
+
+            {erRevurdering(revurdering) && erRevurderingIverksatt(revurdering) && vedtak && (
+                <LinkAsButton
+                    variant="secondary"
+                    href={Routes.vedtaksoppsummering.createURL({ sakId: props.sakId, vedtakId: vedtak.id })}
+                    size="small"
+                >
+                    Se oppsummering
+                </LinkAsButton>
+            )}
+
+            <div className={styles.knapper}>
+                {erRevurdering(revurdering) &&
+                erRevurderingTilAttestering(revurdering) &&
+                user.isAttestant &&
+                user.navIdent !== revurdering.saksbehandler ? (
+                    <LinkAsButton
+                        variant="secondary"
+                        size="small"
+                        href={Routes.attesterRevurdering.createURL({
+                            sakId: props.sakId,
+                            revurderingId: revurdering.id,
+                        })}
+                    >
+                        {props.intl.formatMessage({
+                            id: 'attestering.attester',
+                        })}
+                    </LinkAsButton>
+                ) : erRevurderingStans(revurdering) ? (
+                    <AvsluttOgStartFortsettButtons
+                        sakId={props.sakId}
+                        behandlingsId={revurdering.id}
+                        primaryButtonTekst={
+                            revurdering.status === RevurderingsStatus.IVERKSATT_STANS
+                                ? props.intl.formatMessage({ id: 'revurdering.oppsummering' })
+                                : props.intl.formatMessage({ id: 'revurdering.fortsett' })
+                        }
+                        usePrimaryAsLink={{
+                            url: Routes.stansOppsummeringRoute.createURL({
+                                sakId: props.sakId,
+                                revurderingId: revurdering.id,
+                            }),
+                        }}
+                        hideSecondaryButton={revurdering.status === RevurderingsStatus.IVERKSATT_STANS}
+                        intl={props.intl}
+                    />
+                ) : erRevurderingGjenopptak(revurdering) ? (
+                    <AvsluttOgStartFortsettButtons
+                        sakId={props.sakId}
+                        behandlingsId={revurdering.id}
+                        primaryButtonTekst={
+                            revurdering.status === RevurderingsStatus.IVERKSATT_GJENOPPTAK
+                                ? props.intl.formatMessage({ id: 'revurdering.oppsummering' })
+                                : props.intl.formatMessage({ id: 'revurdering.fortsett' })
+                        }
+                        usePrimaryAsLink={{
+                            url: Routes.gjenopptaStansOppsummeringRoute.createURL({
+                                sakId: props.sakId,
+                                revurderingId: revurdering.id,
+                            }),
+                        }}
+                        hideSecondaryButton={revurdering.status === RevurderingsStatus.IVERKSATT_GJENOPPTAK}
+                        intl={props.intl}
+                    />
+                ) : (
+                    erRevurdering(revurdering) &&
+                    !erRevurderingTilAttestering(revurdering) &&
+                    !erRevurderingIverksatt(revurdering) &&
+                    user.navIdent !== pipe(revurdering.attesteringer, last, toNullable)?.attestant && (
+                        <AvsluttOgStartFortsettButtons
+                            sakId={props.sakId}
+                            behandlingsId={revurdering.id}
+                            primaryButtonTekst={props.intl.formatMessage({ id: 'revurdering.fortsett' })}
+                            usePrimaryAsLink={{
+                                url: Routes.revurderValgtRevurdering.createURL({
+                                    sakId: props.sakId,
+                                    steg: erRevurderingSimulert(revurdering)
+                                        ? RevurderingSteg.Oppsummering
+                                        : finnNesteRevurderingsteg(revurdering.informasjonSomRevurderes),
+                                    revurderingId: revurdering.id,
+                                }),
+                            }}
+                            hideSecondaryButton={false}
+                            intl={props.intl}
+                        />
+                    )
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const AvsluttedeRevurderinger = (props: { avsluttedeRevurderinger: AbstraktRevurdering[]; intl: IntlShape }) => {
+    if (props.avsluttedeRevurderinger.length === 0) return null;
+
+    return (
+        <div className={styles.søknadsContainer}>
+            <Heading level="2" size="medium" spacing>
+                {props.intl.formatMessage({
+                    id: 'revurdering.avsluttede.tittel',
+                })}
+            </Heading>
+            <ol>
+                {props.avsluttedeRevurderinger.map((revurdering) => (
+                    <li key={revurdering.id}>
+                        <Panel border className={styles.søknad}>
+                            <div className={styles.info}>
+                                <div>
+                                    <Heading level="3" size="small" spacing>
+                                        {props.intl.formatMessage({ id: 'revurdering.undertittel' })}
+                                    </Heading>
+                                    <div className={styles.dato}>
+                                        <Label>{props.intl.formatMessage({ id: 'revurdering.opprettet' })} </Label>
+                                        <BodyShort>{props.intl.formatDate(revurdering.opprettet)}</BodyShort>
+                                    </div>
+                                </div>
+                            </div>
+                        </Panel>
+                    </li>
+                ))}
+            </ol>
+        </div>
+    );
+};

--- a/src/pages/saksbehandling/sakintro/RevurderingsLister.tsx
+++ b/src/pages/saksbehandling/sakintro/RevurderingsLister.tsx
@@ -10,7 +10,7 @@ import UnderkjenteAttesteringer from '~components/underkjenteAttesteringer/Under
 import { useUserContext } from '~context/userContext';
 import { pipe } from '~lib/fp';
 import * as Routes from '~lib/routes';
-import { AbstraktRevurdering, RevurderingsStatus } from '~types/Revurdering';
+import { Revurdering, RevurderingsStatus } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Vedtak } from '~types/Vedtak';
 
@@ -22,14 +22,14 @@ import {
     finnNesteRevurderingsteg,
     erRevurderingStans,
     erRevurderingGjenopptak,
-    erRevurdering,
+    erInformasjonsRevurdering,
 } from '../../../utils/revurdering/revurderingUtils';
 import { RevurderingSteg } from '../types';
 
 import { AvsluttOgStartFortsettButtons } from './Sakintro';
 import styles from './sakintro.module.less';
 
-export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: AbstraktRevurdering[]; intl: IntlShape }) => {
+export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Revurdering[]; intl: IntlShape }) => {
     if (props.åpneRevurderinger.length === 0) return null;
 
     return (
@@ -42,7 +42,7 @@ export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Abstra
                     const vedtakForBehandling = props.sak.vedtak.find((v) => v.behandlingId === r.id);
                     const underkjenteRevurderinger = r.attesteringer.filter((a) => a.underkjennelse !== null);
                     return (
-                        <div key={r.id}>
+                        <li key={r.id}>
                             <Panel border className={styles.søknad}>
                                 <div className={styles.info}>
                                     <div>
@@ -50,7 +50,7 @@ export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Abstra
                                             <Heading level="3" size="small" spacing>
                                                 {props.intl.formatMessage({ id: 'revurdering.undertittel' })}
                                             </Heading>
-                                            {erRevurdering(r) && erForhåndsvarselSendt(r) && (
+                                            {erInformasjonsRevurdering(r) && erForhåndsvarselSendt(r) && (
                                                 <Tag variant="info" className={styles.etikett}>
                                                     {props.intl.formatMessage({
                                                         id: 'revurdering.label.forhåndsvarselSendt',
@@ -58,7 +58,7 @@ export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Abstra
                                                 </Tag>
                                             )}
                                         </div>
-                                        {!erRevurdering(r) && (
+                                        {!erInformasjonsRevurdering(r) && (
                                             <div className={styles.informasjonsTekst}>
                                                 <Label>{props.intl.formatMessage({ id: 'revurdering.type' })} </Label>
                                                 <BodyShort>
@@ -83,7 +83,7 @@ export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Abstra
                                             </div>
                                         )}
                                         {underkjenteRevurderinger.length > 0 &&
-                                            erRevurdering(r) &&
+                                            erInformasjonsRevurdering(r) &&
                                             !erRevurderingIverksatt(r) && (
                                                 <div className={styles.underkjenteAttesteringerContainer}>
                                                     <UnderkjenteAttesteringer attesteringer={r.attesteringer} />
@@ -100,7 +100,7 @@ export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Abstra
                                     </div>
                                 </div>
                             </Panel>
-                        </div>
+                        </li>
                     );
                 })}
             </ol>
@@ -110,7 +110,7 @@ export const ÅpneRevurderinger = (props: { sak: Sak; åpneRevurderinger: Abstra
 
 const RevurderingStartetKnapper = (props: {
     sakId: string;
-    revurdering: AbstraktRevurdering;
+    revurdering: Revurdering;
     vedtak: Vedtak[];
     intl: IntlShape;
 }) => {
@@ -120,31 +120,31 @@ const RevurderingStartetKnapper = (props: {
 
     return (
         <div className={styles.behandlingContainer}>
-            {erRevurdering(revurdering) &&
+            {erInformasjonsRevurdering(revurdering) &&
                 erRevurderingTilAttestering(revurdering) &&
                 (!user.isAttestant || user.navIdent === revurdering.saksbehandler) && (
                     <div className={styles.ikonContainer}>
                         <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
-                        <p>
+                        <BodyShort>
                             {props.intl.formatMessage({
                                 id: 'attestering.tilAttestering',
                             })}
-                        </p>
+                        </BodyShort>
                     </div>
                 )}
 
-            {erRevurdering(revurdering) && erRevurderingIverksatt(revurdering) && vedtak && (
+            {erInformasjonsRevurdering(revurdering) && erRevurderingIverksatt(revurdering) && vedtak && (
                 <LinkAsButton
                     variant="secondary"
                     href={Routes.vedtaksoppsummering.createURL({ sakId: props.sakId, vedtakId: vedtak.id })}
                     size="small"
                 >
-                    Se oppsummering
+                    {props.intl.formatMessage({ id: 'revurdering.seOppsummering' })}
                 </LinkAsButton>
             )}
 
             <div className={styles.knapper}>
-                {erRevurdering(revurdering) &&
+                {erInformasjonsRevurdering(revurdering) &&
                 erRevurderingTilAttestering(revurdering) &&
                 user.isAttestant &&
                 user.navIdent !== revurdering.saksbehandler ? (
@@ -197,7 +197,7 @@ const RevurderingStartetKnapper = (props: {
                         intl={props.intl}
                     />
                 ) : (
-                    erRevurdering(revurdering) &&
+                    erInformasjonsRevurdering(revurdering) &&
                     !erRevurderingTilAttestering(revurdering) &&
                     !erRevurderingIverksatt(revurdering) &&
                     user.navIdent !== pipe(revurdering.attesteringer, last, toNullable)?.attestant && (
@@ -224,7 +224,7 @@ const RevurderingStartetKnapper = (props: {
     );
 };
 
-export const AvsluttedeRevurderinger = (props: { avsluttedeRevurderinger: AbstraktRevurdering[]; intl: IntlShape }) => {
+export const AvsluttedeRevurderinger = (props: { avsluttedeRevurderinger: Revurdering[]; intl: IntlShape }) => {
     if (props.avsluttedeRevurderinger.length === 0) return null;
 
     return (

--- a/src/pages/saksbehandling/sakintro/Sakintro.tsx
+++ b/src/pages/saksbehandling/sakintro/Sakintro.tsx
@@ -1,52 +1,31 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert, BodyShort, Button, Heading, Label, LinkPanel, Loader, Panel, Tag } from '@navikt/ds-react';
-import { isEmpty, last } from 'fp-ts/lib/Array';
-import { toNullable } from 'fp-ts/lib/Option';
-import Ikon from 'nav-frontend-ikoner-assets';
+import { Alert, Button, Heading, LinkPanel, Loader } from '@navikt/ds-react';
+import { isEmpty } from 'fp-ts/lib/Array';
 import React from 'react';
 import { IntlShape } from 'react-intl';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { FeatureToggle } from '~api/featureToggleApi';
 import { ÅpentBrev } from '~assets/Illustrations';
-import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
 import LinkAsButton from '~components/linkAsButton/LinkAsButton';
-import UnderkjenteAttesteringer from '~components/underkjenteAttesteringer/UnderkjenteAttesteringer';
-import { useUserContext } from '~context/userContext';
-import * as sakSlice from '~features/saksoversikt/sak.slice';
 import { useFeatureToggle } from '~lib/featureToggles';
-import { pipe } from '~lib/fp';
-import { ApiResult, useAsyncActionCreator, useNotificationFromLocation } from '~lib/hooks';
+import { ApiResult, useNotificationFromLocation } from '~lib/hooks';
 import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import Utbetalinger from '~pages/saksbehandling/sakintro/Utbetalinger';
 import { Behandling } from '~types/Behandling';
-import { AbstraktRevurdering, RevurderingsStatus } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
-import { LukkSøknadBegrunnelse, Søknad } from '~types/Søknad';
-import { Vedtak } from '~types/Vedtak';
-import { erIverksatt, erTilAttestering, hentSisteVurdertSaksbehandlingssteg } from '~utils/behandling/behandlingUtils';
-import {
-    getIverksatteInnvilgedeSøknader,
-    søknadMottatt,
-    getIverksatteAvslåtteSøknader,
-} from '~utils/søknad/søknadUtils';
+import { Søknad } from '~types/Søknad';
+import { erIverksatt } from '~utils/behandling/behandlingUtils';
+import { getIverksatteInnvilgedeSøknader, getIverksatteAvslåtteSøknader } from '~utils/søknad/søknadUtils';
 
-import {
-    erRevurderingTilAttestering,
-    erRevurderingIverksatt,
-    erRevurderingSimulert,
-    erForhåndsvarselSendt,
-    finnNesteRevurderingsteg,
-    erRevurderingStans,
-    erRevurderingGjenopptak,
-    erRevurdering,
-} from '../../../utils/revurdering/revurderingUtils';
-import { RevurderingSteg } from '../types';
+import { getAvsluttedeOgIkkeAvsluttedeRevurderinger } from '../../../utils/revurdering/revurderingUtils';
 
+import { AvsluttedeRevurderinger, ÅpneRevurderinger } from './RevurderingsLister';
 import messages from './sakintro-nb';
 import styles from './sakintro.module.less';
+import { AvslåtteSøknader, IverksattInnvilgedeSøknader, LukkedeSøknader, ÅpneSøknader } from './SøknadsLister';
 
 const SuksessStatuser = (props: { locationState: Nullable<Routes.SuccessNotificationState> }) => {
     return (
@@ -54,19 +33,6 @@ const SuksessStatuser = (props: { locationState: Nullable<Routes.SuccessNotifica
             {props.locationState?.notification && <Alert variant="success">{props.locationState.notification}</Alert>}
         </div>
     );
-};
-
-const lukketBegrunnelseResourceId = (type?: LukkSøknadBegrunnelse) => {
-    switch (type) {
-        case LukkSøknadBegrunnelse.Avvist:
-            return 'søknad.lukket.avvist';
-        case LukkSøknadBegrunnelse.Bortfalt:
-            return 'søknad.lukket.bortfalt';
-        case LukkSøknadBegrunnelse.Trukket:
-            return 'søknad.lukket.trukket';
-        default:
-            return 'søknad.lukket.ukjentLukking';
-    }
 };
 
 const Sakintro = (props: { sak: Sak }) => {
@@ -90,7 +56,10 @@ const Sakintro = (props: { sak: Sak }) => {
 
     const avslåtteSøknader = getIverksatteAvslåtteSøknader(props.sak);
 
-    const revurderinger = props.sak.revurderinger;
+    const { avsluttedeRevurderinger, åpneRevurderinger } = getAvsluttedeOgIkkeAvsluttedeRevurderinger(
+        props.sak.revurderinger
+    );
+
     const kanRevurderes = !isEmpty(props.sak.utbetalinger);
 
     const revurderingToggle = useFeatureToggle(FeatureToggle.Revurdering) && kanRevurderes;
@@ -129,7 +98,9 @@ const Sakintro = (props: { sak: Sak }) => {
                         utbetalingsperioder={props.sak.utbetalinger}
                         kanStansesEllerGjenopptas={props.sak.utbetalingerKanStansesEllerGjenopptas}
                     />
-                    {revurderingToggle && <Revurderinger sak={props.sak} revurderinger={revurderinger} intl={intl} />}
+                    {revurderingToggle && (
+                        <ÅpneRevurderinger sak={props.sak} åpneRevurderinger={åpneRevurderinger} intl={intl} />
+                    )}
                     <IverksattInnvilgedeSøknader
                         sak={props.sak}
                         iverksatteInnvilgedeSøknader={iverksatteInnvilgedeSøknader}
@@ -137,6 +108,7 @@ const Sakintro = (props: { sak: Sak }) => {
                     />
                     <AvslåtteSøknader sak={props.sak} avslåtteSøknader={avslåtteSøknader} intl={intl} />
                     <LukkedeSøknader lukkedeSøknader={lukkedeSøknader} intl={intl} />
+                    <AvsluttedeRevurderinger avsluttedeRevurderinger={avsluttedeRevurderinger} intl={intl} />
                     <div>
                         <LinkPanel
                             href={Routes.alleDokumenterForSak.createURL({ sakId: props.sak.id })}
@@ -159,535 +131,7 @@ const Sakintro = (props: { sak: Sak }) => {
     );
 };
 
-const ÅpneSøknader = (props: {
-    åpneSøknader: Søknad[];
-    behandlinger: Behandling[];
-    sakId: string;
-    intl: IntlShape;
-}) => {
-    if (props.åpneSøknader.length === 0) return null;
-
-    return (
-        <div className={styles.søknadsContainer}>
-            <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({ id: 'søknad.åpneSøknader.tittel' })}
-            </Heading>
-            <ol>
-                {props.åpneSøknader.map((s) => {
-                    const behandling = props.behandlinger.find((b) => b.søknad.id === s.id);
-                    const attesteringer = behandling?.attesteringer ?? [];
-                    const senesteAttestering = pipe(attesteringer, last, toNullable);
-
-                    return (
-                        <div key={s.id}>
-                            <Panel border className={styles.søknad}>
-                                <div className={styles.info}>
-                                    <div>
-                                        <Heading level="3" size="medium">
-                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
-                                        </Heading>
-                                        <div className={styles.dato}>
-                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
-                                            <BodyShort>{søknadMottatt(s, props.intl)}</BodyShort>
-                                        </div>
-                                        {senesteAttestering?.underkjennelse && (
-                                            <UnderkjenteAttesteringer attesteringer={attesteringer} />
-                                        )}
-                                    </div>
-                                    <div className={styles.knapper}>
-                                        {!behandling ? (
-                                            <StartSøknadsbehandlingKnapper
-                                                sakId={props.sakId}
-                                                søknadId={s.id}
-                                                intl={props.intl}
-                                            />
-                                        ) : (
-                                            <SøknadsbehandlingStartetKnapper
-                                                sakId={props.sakId}
-                                                intl={props.intl}
-                                                behandling={behandling}
-                                                søknadId={s.id}
-                                            />
-                                        )}
-                                    </div>
-                                </div>
-                            </Panel>
-                        </div>
-                    );
-                })}
-            </ol>
-        </div>
-    );
-};
-
-const Revurderinger = (props: { sak: Sak; revurderinger: AbstraktRevurdering[]; intl: IntlShape }) => {
-    if (props.revurderinger.length === 0) return null;
-
-    return (
-        <div className={styles.søknadsContainer}>
-            <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({ id: 'revurdering.tittel' })}
-            </Heading>
-            <ol>
-                {props.revurderinger.map((r) => {
-                    const vedtakForBehandling = props.sak.vedtak.find((v) => v.behandlingId === r.id);
-                    const underkjenteRevurderinger = r.attesteringer.filter((a) => a.underkjennelse !== null);
-                    return (
-                        <div key={r.id}>
-                            <Panel border className={styles.søknad}>
-                                <div className={styles.info}>
-                                    <div>
-                                        <div className={styles.tittel}>
-                                            <Heading level="3" size="small" spacing>
-                                                {props.intl.formatMessage({ id: 'revurdering.undertittel' })}
-                                            </Heading>
-                                            {erRevurdering(r) && erForhåndsvarselSendt(r) && (
-                                                <Tag variant="info" className={styles.etikett}>
-                                                    {props.intl.formatMessage({
-                                                        id: 'revurdering.label.forhåndsvarselSendt',
-                                                    })}
-                                                </Tag>
-                                            )}
-                                        </div>
-                                        <div className={styles.dato}>
-                                            <Label>{props.intl.formatMessage({ id: 'revurdering.opprettet' })} </Label>
-                                            <BodyShort>{props.intl.formatDate(r.opprettet)}</BodyShort>
-                                        </div>
-                                        {vedtakForBehandling?.opprettet && (
-                                            <div className={styles.dato}>
-                                                <Label>
-                                                    {props.intl.formatMessage({ id: 'revurdering.iverksattDato' })}{' '}
-                                                </Label>
-                                                <BodyShort>
-                                                    {props.intl.formatDate(vedtakForBehandling.opprettet)}
-                                                </BodyShort>
-                                            </div>
-                                        )}
-                                        {underkjenteRevurderinger.length > 0 &&
-                                            erRevurdering(r) &&
-                                            !erRevurderingIverksatt(r) && (
-                                                <div className={styles.underkjenteAttesteringerContainer}>
-                                                    <UnderkjenteAttesteringer attesteringer={r.attesteringer} />
-                                                </div>
-                                            )}
-                                    </div>
-                                    <div className={styles.knapper}>
-                                        <RevurderingStartetKnapper
-                                            sakId={props.sak.id}
-                                            vedtak={props.sak.vedtak}
-                                            revurdering={r}
-                                            intl={props.intl}
-                                        />
-                                    </div>
-                                </div>
-                            </Panel>
-                        </div>
-                    );
-                })}
-            </ol>
-        </div>
-    );
-};
-
-const RevurderingStartetKnapper = (props: {
-    sakId: string;
-    revurdering: AbstraktRevurdering;
-    vedtak: Vedtak[];
-    intl: IntlShape;
-}) => {
-    const user = useUserContext();
-    const { revurdering } = props;
-    const vedtak = props.vedtak.find((v) => v.behandlingId === revurdering.id);
-
-    return (
-        <div className={styles.behandlingContainer}>
-            {erRevurdering(revurdering) &&
-                erRevurderingTilAttestering(revurdering) &&
-                (!user.isAttestant || user.navIdent === revurdering.saksbehandler) && (
-                    <div className={styles.ikonContainer}>
-                        <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
-                        <p>
-                            {props.intl.formatMessage({
-                                id: 'attestering.tilAttestering',
-                            })}
-                        </p>
-                    </div>
-                )}
-
-            {erRevurdering(revurdering) && erRevurderingIverksatt(revurdering) && vedtak && (
-                <LinkAsButton
-                    variant="secondary"
-                    href={Routes.vedtaksoppsummering.createURL({ sakId: props.sakId, vedtakId: vedtak.id })}
-                    size="small"
-                >
-                    Se oppsummering
-                </LinkAsButton>
-            )}
-
-            <div className={styles.knapper}>
-                {erRevurdering(revurdering) &&
-                erRevurderingTilAttestering(revurdering) &&
-                user.isAttestant &&
-                user.navIdent !== revurdering.saksbehandler ? (
-                    <LinkAsButton
-                        variant="secondary"
-                        size="small"
-                        href={Routes.attesterRevurdering.createURL({
-                            sakId: props.sakId,
-                            revurderingId: revurdering.id,
-                        })}
-                    >
-                        {props.intl.formatMessage({
-                            id: 'attestering.attester',
-                        })}
-                    </LinkAsButton>
-                ) : erRevurderingStans(revurdering) ? (
-                    <AvsluttOgStartFortsettButtons
-                        sakId={props.sakId}
-                        behandlingsId={revurdering.id}
-                        primaryButtonTekst={
-                            revurdering.status === RevurderingsStatus.IVERKSATT_STANS
-                                ? props.intl.formatMessage({ id: 'revurdering.oppsummering' })
-                                : props.intl.formatMessage({ id: 'revurdering.fortsett' })
-                        }
-                        usePrimaryAsLink={{
-                            url: Routes.stansOppsummeringRoute.createURL({
-                                sakId: props.sakId,
-                                revurderingId: revurdering.id,
-                            }),
-                        }}
-                        intl={props.intl}
-                    />
-                ) : erRevurderingGjenopptak(revurdering) ? (
-                    <AvsluttOgStartFortsettButtons
-                        sakId={props.sakId}
-                        behandlingsId={revurdering.id}
-                        primaryButtonTekst={
-                            revurdering.status === RevurderingsStatus.IVERKSATT_GJENOPPTAK
-                                ? props.intl.formatMessage({ id: 'revurdering.oppsummering' })
-                                : props.intl.formatMessage({ id: 'revurdering.fortsett' })
-                        }
-                        usePrimaryAsLink={{
-                            url: Routes.gjenopptaStansOppsummeringRoute.createURL({
-                                sakId: props.sakId,
-                                revurderingId: revurdering.id,
-                            }),
-                        }}
-                        intl={props.intl}
-                    />
-                ) : (
-                    erRevurdering(revurdering) &&
-                    !erRevurderingTilAttestering(revurdering) &&
-                    !erRevurderingIverksatt(revurdering) &&
-                    user.navIdent !== pipe(revurdering.attesteringer, last, toNullable)?.attestant && (
-                        <AvsluttOgStartFortsettButtons
-                            sakId={props.sakId}
-                            behandlingsId={revurdering.id}
-                            primaryButtonTekst={props.intl.formatMessage({ id: 'revurdering.fortsett' })}
-                            usePrimaryAsLink={{
-                                url: Routes.revurderValgtRevurdering.createURL({
-                                    sakId: props.sakId,
-                                    steg: erRevurderingSimulert(revurdering)
-                                        ? RevurderingSteg.Oppsummering
-                                        : finnNesteRevurderingsteg(revurdering.informasjonSomRevurderes),
-                                    revurderingId: revurdering.id,
-                                }),
-                            }}
-                            intl={props.intl}
-                        />
-                    )
-                )}
-            </div>
-        </div>
-    );
-};
-
-const IverksattInnvilgedeSøknader = (props: {
-    iverksatteInnvilgedeSøknader: Array<{
-        iverksattDato: string | undefined;
-        søknadensBehandlingsId: string | undefined;
-        søknad: Søknad;
-    }>;
-    sak: Sak;
-    intl: IntlShape;
-}) => {
-    if (props.iverksatteInnvilgedeSøknader.length === 0) return null;
-
-    return (
-        <div className={styles.søknadsContainer}>
-            <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({ id: 'søknad.godkjenteSøknader.tittel' })}
-            </Heading>
-            <ol>
-                {props.iverksatteInnvilgedeSøknader.map((s) => {
-                    if (!s.søknadensBehandlingsId) {
-                        return null;
-                    }
-                    const vedtak = props.sak.vedtak.find((v) => v.behandlingId === s.søknadensBehandlingsId);
-                    if (!vedtak) {
-                        return null;
-                    }
-
-                    return (
-                        <div key={s.søknad.id}>
-                            <Panel border className={styles.søknad}>
-                                <div className={styles.info}>
-                                    <div>
-                                        <Heading level="3" size="small" spacing>
-                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
-                                        </Heading>
-                                        <div className={styles.dato}>
-                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
-                                            <BodyShort>{søknadMottatt(s.søknad, props.intl)}</BodyShort>
-                                        </div>
-                                        <div className={styles.dato}>
-                                            <Label>
-                                                {`${props.intl.formatMessage({
-                                                    id: 'søknad.iverksattDato',
-                                                })}: `}
-                                            </Label>
-                                            <BodyShort>{props.intl.formatDate(s.iverksattDato)}</BodyShort>
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <LinkAsButton
-                                            variant="secondary"
-                                            href={Routes.vedtaksoppsummering.createURL({
-                                                sakId: props.sak.id,
-                                                vedtakId: vedtak.id,
-                                            })}
-                                            size="small"
-                                        >
-                                            {props.intl.formatMessage({ id: 'behandling.seOppsummering' })}
-                                        </LinkAsButton>
-                                    </div>
-                                </div>
-                            </Panel>
-                        </div>
-                    );
-                })}
-            </ol>
-        </div>
-    );
-};
-
-const StartSøknadsbehandlingKnapper = (props: { sakId: string; søknadId: string; intl: IntlShape }) => {
-    const history = useHistory();
-    const [behandlingStatus, startBehandling] = useAsyncActionCreator(sakSlice.startBehandling);
-
-    return (
-        <div>
-            <AvsluttOgStartFortsettButtons
-                sakId={props.sakId}
-                behandlingsId={props.søknadId}
-                primaryButtonTekst={props.intl.formatMessage({
-                    id: 'behandling.startBehandling',
-                })}
-                usePrimaryAsButton={{
-                    onClick: () =>
-                        startBehandling(
-                            {
-                                sakId: props.sakId,
-                                søknadId: props.søknadId,
-                            },
-                            (response) => {
-                                history.push(
-                                    Routes.saksbehandlingVilkårsvurdering.createURL({
-                                        sakId: props.sakId,
-                                        behandlingId: response.id,
-                                    })
-                                );
-                            }
-                        ),
-                    status: behandlingStatus,
-                }}
-                intl={props.intl}
-            />
-
-            {RemoteData.isFailure(behandlingStatus) && (
-                <div className={styles.feil}>
-                    <ApiErrorAlert error={behandlingStatus.error} />
-                </div>
-            )}
-        </div>
-    );
-};
-
-const SøknadsbehandlingStartetKnapper = (props: {
-    behandling: Behandling;
-    sakId: string;
-    søknadId: string;
-    intl: IntlShape;
-}) => {
-    const user = useUserContext();
-    const { behandling } = props;
-
-    return (
-        <div>
-            {erTilAttestering(behandling) && (!user.isAttestant || user.navIdent === behandling.saksbehandler) && (
-                <div className={styles.ikonContainer}>
-                    <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
-                    <p>
-                        {props.intl.formatMessage({
-                            id: 'attestering.tilAttestering',
-                        })}
-                    </p>
-                </div>
-            )}
-
-            <div className={styles.søknadsbehandlingKnapper}>
-                {erTilAttestering(behandling) && user.isAttestant && user.navIdent !== behandling.saksbehandler ? (
-                    <LinkAsButton
-                        variant="secondary"
-                        size="small"
-                        href={Routes.attesterSøknadsbehandling.createURL({
-                            sakId: props.sakId,
-                            behandlingId: behandling.id,
-                        })}
-                    >
-                        {props.intl.formatMessage({
-                            id: 'attestering.attester',
-                        })}
-                    </LinkAsButton>
-                ) : (
-                    !erTilAttestering(behandling) &&
-                    !erIverksatt(behandling) &&
-                    user.navIdent !== pipe(behandling.attesteringer ?? [], last, toNullable)?.attestant && (
-                        <AvsluttOgStartFortsettButtons
-                            sakId={props.sakId}
-                            behandlingsId={props.søknadId}
-                            primaryButtonTekst={props.intl.formatMessage({
-                                id: 'behandling.fortsettBehandling',
-                            })}
-                            usePrimaryAsLink={{
-                                url: Routes.saksbehandlingVilkårsvurdering.createURL({
-                                    sakId: props.sakId,
-                                    behandlingId: behandling.id,
-                                    vilkar: hentSisteVurdertSaksbehandlingssteg(behandling),
-                                }),
-                            }}
-                            intl={props.intl}
-                        />
-                    )
-                )}
-            </div>
-        </div>
-    );
-};
-
-const LukkedeSøknader = (props: { lukkedeSøknader: Søknad[]; intl: IntlShape }) => {
-    if (props.lukkedeSøknader.length === 0) return null;
-
-    return (
-        <div className={styles.søknadsContainer}>
-            <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({
-                    id: 'søknad.lukkedeSøknader.tittel',
-                })}
-            </Heading>
-            <ol>
-                {props.lukkedeSøknader.map((søknad) => (
-                    <li key={søknad.id}>
-                        <Panel border className={styles.søknad}>
-                            <div className={styles.info}>
-                                <div>
-                                    <Heading level="3" size="small" spacing>
-                                        {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
-                                    </Heading>
-                                    <div className={styles.dato}>
-                                        <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
-                                        <BodyShort>{søknadMottatt(søknad, props.intl)}</BodyShort>
-                                    </div>
-                                </div>
-                            </div>
-                            <div className={styles.ikonContainer}>
-                                <Ikon className={styles.ikon} kind="feil-sirkel-fyll" width={'24px'} />
-                                <p className={styles.ikonTekst}>
-                                    {props.intl.formatMessage({
-                                        id: lukketBegrunnelseResourceId(søknad.lukket?.type),
-                                    })}
-                                </p>
-                            </div>
-                        </Panel>
-                    </li>
-                ))}
-            </ol>
-        </div>
-    );
-};
-
-const AvslåtteSøknader = (props: {
-    sak: Sak;
-    avslåtteSøknader: Array<{
-        iverksattDato: string | undefined;
-        søknadensBehandlingsId: string | undefined;
-        søknad: Søknad;
-    }>;
-    intl: IntlShape;
-}) => {
-    if (props.avslåtteSøknader.length === 0) return null;
-
-    return (
-        <div className={styles.søknadsContainer}>
-            <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({
-                    id: 'søknad.avslåtteSøknader.tittel',
-                })}
-            </Heading>
-            <ol>
-                {props.avslåtteSøknader.map((s) => {
-                    if (!s.søknadensBehandlingsId) {
-                        return null;
-                    }
-                    const vedtak = props.sak.vedtak.find((v) => v.behandlingId === s.søknadensBehandlingsId);
-                    if (!vedtak) {
-                        return null;
-                    }
-
-                    return (
-                        <li key={s.søknad.id}>
-                            <Panel border className={styles.søknad}>
-                                <div className={styles.info}>
-                                    <div>
-                                        <Heading level="3" size="small" spacing>
-                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
-                                        </Heading>
-                                        <div className={styles.dato}>
-                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
-                                            <BodyShort>{søknadMottatt(s.søknad, props.intl)}</BodyShort>
-                                        </div>
-                                        <div className={styles.dato}>
-                                            <Label>
-                                                {`${props.intl.formatMessage({
-                                                    id: 'søknad.iverksattDato',
-                                                })}: `}
-                                            </Label>
-                                            <BodyShort>{props.intl.formatDate(s.iverksattDato)}</BodyShort>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div>
-                                    <LinkAsButton
-                                        variant="secondary"
-                                        href={Routes.vedtaksoppsummering.createURL({
-                                            sakId: props.sak.id,
-                                            vedtakId: vedtak.id,
-                                        })}
-                                        size="small"
-                                    >
-                                        {props.intl.formatMessage({ id: 'revurdering.oppsummering' })}
-                                    </LinkAsButton>
-                                </div>
-                            </Panel>
-                        </li>
-                    );
-                })}
-            </ol>
-        </div>
-    );
-};
-
-const AvsluttOgStartFortsettButtons = (props: {
+export const AvsluttOgStartFortsettButtons = (props: {
     sakId: string;
     behandlingsId: string;
     primaryButtonTekst: string;
@@ -699,21 +143,24 @@ const AvsluttOgStartFortsettButtons = (props: {
         onClick: () => Promise<void>;
         status: ApiResult<Behandling, string>;
     };
+    hideSecondaryButton?: boolean;
 }) => {
     return (
         <div className={styles.avsluttOgStartFortsettKnapperContainer}>
-            <LinkAsButton
-                variant="secondary"
-                size="small"
-                href={Routes.avsluttBehandling.createURL({
-                    sakId: props.sakId,
-                    id: props.behandlingsId,
-                })}
-            >
-                {props.intl.formatMessage({
-                    id: 'behandling.avsluttBehandling',
-                })}
-            </LinkAsButton>
+            {!props.hideSecondaryButton && (
+                <LinkAsButton
+                    variant="secondary"
+                    size="small"
+                    href={Routes.avsluttBehandling.createURL({
+                        sakId: props.sakId,
+                        id: props.behandlingsId,
+                    })}
+                >
+                    {props.intl.formatMessage({
+                        id: 'behandling.avsluttBehandling',
+                    })}
+                </LinkAsButton>
+            )}
             {props.usePrimaryAsButton ? (
                 <Button size="small" onClick={props.usePrimaryAsButton.onClick}>
                     {props.primaryButtonTekst}

--- a/src/pages/saksbehandling/sakintro/Sakintro.tsx
+++ b/src/pages/saksbehandling/sakintro/Sakintro.tsx
@@ -18,9 +18,8 @@ import { Behandling } from '~types/Behandling';
 import { Sak } from '~types/Sak';
 import { Søknad } from '~types/Søknad';
 import { erIverksatt } from '~utils/behandling/behandlingUtils';
+import { splittAvsluttedeOgÅpneRevurderinger } from '~utils/revurdering/revurderingUtils';
 import { getIverksatteInnvilgedeSøknader, getIverksatteAvslåtteSøknader } from '~utils/søknad/søknadUtils';
-
-import { getAvsluttedeOgIkkeAvsluttedeRevurderinger } from '../../../utils/revurdering/revurderingUtils';
 
 import { AvsluttedeRevurderinger, ÅpneRevurderinger } from './RevurderingsLister';
 import messages from './sakintro-nb';
@@ -56,9 +55,7 @@ const Sakintro = (props: { sak: Sak }) => {
 
     const avslåtteSøknader = getIverksatteAvslåtteSøknader(props.sak);
 
-    const { avsluttedeRevurderinger, åpneRevurderinger } = getAvsluttedeOgIkkeAvsluttedeRevurderinger(
-        props.sak.revurderinger
-    );
+    const { avsluttedeRevurderinger, åpneRevurderinger } = splittAvsluttedeOgÅpneRevurderinger(props.sak.revurderinger);
 
     const kanRevurderes = !isEmpty(props.sak.utbetalinger);
 

--- a/src/pages/saksbehandling/sakintro/Sakintro.tsx
+++ b/src/pages/saksbehandling/sakintro/Sakintro.tsx
@@ -58,13 +58,13 @@ const SuksessStatuser = (props: { locationState: Nullable<Routes.SuccessNotifica
 const lukketBegrunnelseResourceId = (type?: LukkSøknadBegrunnelse) => {
     switch (type) {
         case LukkSøknadBegrunnelse.Avvist:
-            return 'display.søknad.lukket.avvist';
+            return 'søknad.lukket.avvist';
         case LukkSøknadBegrunnelse.Bortfalt:
-            return 'display.søknad.lukket.bortfalt';
+            return 'søknad.lukket.bortfalt';
         case LukkSøknadBegrunnelse.Trukket:
-            return 'display.søknad.lukket.trukket';
+            return 'søknad.lukket.trukket';
         default:
-            return 'display.søknad.lukket.ukjentLukking';
+            return 'søknad.lukket.ukjentLukking';
     }
 };
 
@@ -99,7 +99,7 @@ const Sakintro = (props: { sak: Sak }) => {
             <SuksessStatuser locationState={locationState} />
             <div className={styles.pageHeader}>
                 <Heading level="1" size="xlarge" className={styles.tittel}>
-                    {intl.formatMessage({ id: 'display.saksoversikt.tittel' })}: {props.sak.saksnummer}
+                    {intl.formatMessage({ id: 'saksoversikt.tittel' })}: {props.sak.saksnummer}
                 </Heading>
                 <div className={styles.headerKnapper}>
                     {revurderingToggle && (
@@ -169,7 +169,7 @@ const ÅpneSøknader = (props: {
     return (
         <div className={styles.søknadsContainer}>
             <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({ id: 'display.åpneSøknader.tittel' })}
+                {props.intl.formatMessage({ id: 'søknad.åpneSøknader.tittel' })}
             </Heading>
             <ol>
                 {props.åpneSøknader.map((s) => {
@@ -183,12 +183,10 @@ const ÅpneSøknader = (props: {
                                 <div className={styles.info}>
                                     <div>
                                         <Heading level="3" size="medium">
-                                            {props.intl.formatMessage({ id: 'display.søknad.typeSøknad' })}
+                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
                                         </Heading>
                                         <div className={styles.dato}>
-                                            <Label>
-                                                {`${props.intl.formatMessage({ id: 'display.søknad.mottatt' })}: `}
-                                            </Label>
+                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
                                             <BodyShort>{søknadMottatt(s, props.intl)}</BodyShort>
                                         </div>
                                         {senesteAttestering?.underkjennelse && (
@@ -306,7 +304,7 @@ const RevurderingStartetKnapper = (props: {
                         <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
                         <p>
                             {props.intl.formatMessage({
-                                id: 'display.attestering.tilAttestering',
+                                id: 'attestering.tilAttestering',
                             })}
                         </p>
                     </div>
@@ -335,7 +333,7 @@ const RevurderingStartetKnapper = (props: {
                         })}
                     >
                         {props.intl.formatMessage({
-                            id: 'display.attestering.attester',
+                            id: 'attestering.attester',
                         })}
                     </LinkAsButton>
                 ) : erRevurderingStans(revurdering) ? (
@@ -368,19 +366,33 @@ const RevurderingStartetKnapper = (props: {
                     !erRevurderingTilAttestering(revurdering) &&
                     !erRevurderingIverksatt(revurdering) &&
                     user.navIdent !== pipe(revurdering.attesteringer, last, toNullable)?.attestant && (
-                        <LinkAsButton
-                            variant="secondary"
-                            size="small"
-                            href={Routes.revurderValgtRevurdering.createURL({
-                                sakId: props.sakId,
-                                steg: erRevurderingSimulert(revurdering)
-                                    ? RevurderingSteg.Oppsummering
-                                    : finnNesteRevurderingsteg(revurdering.informasjonSomRevurderes),
-                                revurderingId: revurdering.id,
-                            })}
-                        >
-                            {props.intl.formatMessage({ id: 'revurdering.fortsett' })}
-                        </LinkAsButton>
+                        <div>
+                            <LinkAsButton
+                                variant="secondary"
+                                size="small"
+                                href={Routes.avsluttBehandling.createURL({
+                                    sakId: props.sakId,
+                                    id: revurdering.id,
+                                })}
+                            >
+                                {props.intl.formatMessage({
+                                    id: 'behandling.avsluttBehandling',
+                                })}
+                            </LinkAsButton>
+                            <LinkAsButton
+                                variant="primary"
+                                size="small"
+                                href={Routes.revurderValgtRevurdering.createURL({
+                                    sakId: props.sakId,
+                                    steg: erRevurderingSimulert(revurdering)
+                                        ? RevurderingSteg.Oppsummering
+                                        : finnNesteRevurderingsteg(revurdering.informasjonSomRevurderes),
+                                    revurderingId: revurdering.id,
+                                })}
+                            >
+                                {props.intl.formatMessage({ id: 'revurdering.fortsett' })}
+                            </LinkAsButton>
+                        </div>
                     )
                 )}
             </div>
@@ -402,7 +414,7 @@ const IverksattInnvilgedeSøknader = (props: {
     return (
         <div className={styles.søknadsContainer}>
             <Heading level="2" size="medium" spacing>
-                {props.intl.formatMessage({ id: 'display.godkjenteSøknader.tittel' })}
+                {props.intl.formatMessage({ id: 'søknad.godkjenteSøknader.tittel' })}
             </Heading>
             <ol>
                 {props.iverksatteInnvilgedeSøknader.map((s) => {
@@ -420,18 +432,16 @@ const IverksattInnvilgedeSøknader = (props: {
                                 <div className={styles.info}>
                                     <div>
                                         <Heading level="3" size="small" spacing>
-                                            {props.intl.formatMessage({ id: 'display.søknad.typeSøknad' })}
+                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
                                         </Heading>
                                         <div className={styles.dato}>
-                                            <Label>
-                                                {`${props.intl.formatMessage({ id: 'display.søknad.mottatt' })}: `}
-                                            </Label>
+                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
                                             <BodyShort>{søknadMottatt(s.søknad, props.intl)}</BodyShort>
                                         </div>
                                         <div className={styles.dato}>
                                             <Label>
                                                 {`${props.intl.formatMessage({
-                                                    id: 'display.søknad.iverksattDato',
+                                                    id: 'søknad.iverksattDato',
                                                 })}: `}
                                             </Label>
                                             <BodyShort>{props.intl.formatDate(s.iverksattDato)}</BodyShort>
@@ -446,7 +456,7 @@ const IverksattInnvilgedeSøknader = (props: {
                                             })}
                                             size="small"
                                         >
-                                            {props.intl.formatMessage({ id: 'display.behandling.seOppsummering' })}
+                                            {props.intl.formatMessage({ id: 'behandling.seOppsummering' })}
                                         </LinkAsButton>
                                     </div>
                                 </div>
@@ -469,25 +479,13 @@ const StartSøknadsbehandlingKnapper = (props: { sakId: string; søknadId: strin
                 <LinkAsButton
                     size="small"
                     variant="secondary"
-                    href={Routes.avslagManglendeDokSøknadsbehandling.createURL({
+                    href={Routes.avsluttBehandling.createURL({
                         sakId: props.sakId,
-                        soknadId: props.søknadId,
+                        id: props.søknadId,
                     })}
                 >
                     {props.intl.formatMessage({
-                        id: 'display.søknad.avslag.manglendeDokumentajon',
-                    })}
-                </LinkAsButton>
-                <LinkAsButton
-                    size="small"
-                    variant="secondary"
-                    href={Routes.avsluttSøknadsbehandling.createURL({
-                        sakId: props.sakId,
-                        soknadId: props.søknadId,
-                    })}
-                >
-                    {props.intl.formatMessage({
-                        id: 'display.søknad.lukkSøknad',
+                        id: 'behandling.avsluttBehandling',
                     })}
                 </LinkAsButton>
                 <Button
@@ -511,7 +509,7 @@ const StartSøknadsbehandlingKnapper = (props: { sakId: string; søknadId: strin
                     }}
                 >
                     {props.intl.formatMessage({
-                        id: 'display.behandling.startBehandling',
+                        id: 'behandling.startBehandling',
                     })}
                     {RemoteData.isPending(behandlingStatus) && <Loader />}
                 </Button>
@@ -541,7 +539,7 @@ const SøknadsbehandlingStartetKnapper = (props: {
                     <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
                     <p>
                         {props.intl.formatMessage({
-                            id: 'display.attestering.tilAttestering',
+                            id: 'attestering.tilAttestering',
                         })}
                     </p>
                 </div>
@@ -558,7 +556,7 @@ const SøknadsbehandlingStartetKnapper = (props: {
                         })}
                     >
                         {props.intl.formatMessage({
-                            id: 'display.attestering.attester',
+                            id: 'attestering.attester',
                         })}
                     </LinkAsButton>
                 ) : (
@@ -569,25 +567,13 @@ const SøknadsbehandlingStartetKnapper = (props: {
                             <LinkAsButton
                                 variant="secondary"
                                 size="small"
-                                href={Routes.avslagManglendeDokSøknadsbehandling.createURL({
+                                href={Routes.avsluttBehandling.createURL({
                                     sakId: props.sakId,
-                                    soknadId: props.søknadId,
+                                    id: props.søknadId,
                                 })}
                             >
                                 {props.intl.formatMessage({
-                                    id: 'display.søknad.avslag.manglendeDokumentajon',
-                                })}
-                            </LinkAsButton>
-                            <LinkAsButton
-                                variant="secondary"
-                                size="small"
-                                href={Routes.avsluttSøknadsbehandling.createURL({
-                                    sakId: props.sakId,
-                                    soknadId: props.søknadId,
-                                })}
-                            >
-                                {props.intl.formatMessage({
-                                    id: 'display.søknad.lukkSøknad',
+                                    id: 'behandling.avsluttBehandling',
                                 })}
                             </LinkAsButton>
                             <LinkAsButton
@@ -599,7 +585,7 @@ const SøknadsbehandlingStartetKnapper = (props: {
                                 })}
                             >
                                 {props.intl.formatMessage({
-                                    id: 'display.behandling.fortsettBehandling',
+                                    id: 'behandling.fortsettBehandling',
                                 })}
                             </LinkAsButton>
                         </>
@@ -617,7 +603,7 @@ const LukkedeSøknader = (props: { lukkedeSøknader: Søknad[]; intl: IntlShape 
         <div className={styles.søknadsContainer}>
             <Heading level="2" size="medium" spacing>
                 {props.intl.formatMessage({
-                    id: 'display.lukkedeSøknader.tittel',
+                    id: 'søknad.lukkedeSøknader.tittel',
                 })}
             </Heading>
             <ol>
@@ -627,12 +613,10 @@ const LukkedeSøknader = (props: { lukkedeSøknader: Søknad[]; intl: IntlShape 
                             <div className={styles.info}>
                                 <div>
                                     <Heading level="3" size="small" spacing>
-                                        {props.intl.formatMessage({ id: 'display.søknad.typeSøknad' })}
+                                        {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
                                     </Heading>
                                     <div className={styles.dato}>
-                                        <Label>
-                                            {`${props.intl.formatMessage({ id: 'display.søknad.mottatt' })}: `}
-                                        </Label>
+                                        <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
                                         <BodyShort>{søknadMottatt(søknad, props.intl)}</BodyShort>
                                     </div>
                                 </div>
@@ -668,7 +652,7 @@ const AvslåtteSøknader = (props: {
         <div className={styles.søknadsContainer}>
             <Heading level="2" size="medium" spacing>
                 {props.intl.formatMessage({
-                    id: 'display.avslåtteSøknader.tittel',
+                    id: 'søknad.avslåtteSøknader.tittel',
                 })}
             </Heading>
             <ol>
@@ -687,18 +671,16 @@ const AvslåtteSøknader = (props: {
                                 <div className={styles.info}>
                                     <div>
                                         <Heading level="3" size="small" spacing>
-                                            {props.intl.formatMessage({ id: 'display.søknad.typeSøknad' })}
+                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
                                         </Heading>
                                         <div className={styles.dato}>
-                                            <Label>
-                                                {`${props.intl.formatMessage({ id: 'display.søknad.mottatt' })}: `}
-                                            </Label>
+                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
                                             <BodyShort>{søknadMottatt(s.søknad, props.intl)}</BodyShort>
                                         </div>
                                         <div className={styles.dato}>
                                             <Label>
                                                 {`${props.intl.formatMessage({
-                                                    id: 'display.søknad.iverksattDato',
+                                                    id: 'søknad.iverksattDato',
                                                 })}: `}
                                             </Label>
                                             <BodyShort>{props.intl.formatDate(s.iverksattDato)}</BodyShort>

--- a/src/pages/saksbehandling/sakintro/SøknadsLister.tsx
+++ b/src/pages/saksbehandling/sakintro/SøknadsLister.tsx
@@ -1,0 +1,384 @@
+import * as RemoteData from '@devexperts/remote-data-ts';
+import { BodyShort, Heading, Label, Panel } from '@navikt/ds-react';
+import { last } from 'fp-ts/lib/Array';
+import { toNullable } from 'fp-ts/lib/Option';
+import Ikon from 'nav-frontend-ikoner-assets';
+import React from 'react';
+import { IntlShape } from 'react-intl';
+import { useHistory } from 'react-router-dom';
+
+import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
+import LinkAsButton from '~components/linkAsButton/LinkAsButton';
+import UnderkjenteAttesteringer from '~components/underkjenteAttesteringer/UnderkjenteAttesteringer';
+import { useUserContext } from '~context/userContext';
+import * as sakSlice from '~features/saksoversikt/sak.slice';
+import { pipe } from '~lib/fp';
+import { useAsyncActionCreator } from '~lib/hooks';
+import * as Routes from '~lib/routes';
+import { Behandling } from '~types/Behandling';
+import { Sak } from '~types/Sak';
+import { LukkSøknadBegrunnelse, Søknad } from '~types/Søknad';
+import { erIverksatt, erTilAttestering, hentSisteVurdertSaksbehandlingssteg } from '~utils/behandling/behandlingUtils';
+import { søknadMottatt } from '~utils/søknad/søknadUtils';
+
+import { AvsluttOgStartFortsettButtons } from './Sakintro';
+import styles from './sakintro.module.less';
+
+const lukketBegrunnelseResourceId = (type?: LukkSøknadBegrunnelse) => {
+    switch (type) {
+        case LukkSøknadBegrunnelse.Avvist:
+            return 'søknad.lukket.avvist';
+        case LukkSøknadBegrunnelse.Bortfalt:
+            return 'søknad.lukket.bortfalt';
+        case LukkSøknadBegrunnelse.Trukket:
+            return 'søknad.lukket.trukket';
+        default:
+            return 'søknad.lukket.ukjentLukking';
+    }
+};
+
+export const ÅpneSøknader = (props: {
+    åpneSøknader: Søknad[];
+    behandlinger: Behandling[];
+    sakId: string;
+    intl: IntlShape;
+}) => {
+    if (props.åpneSøknader.length === 0) return null;
+
+    return (
+        <div className={styles.søknadsContainer}>
+            <Heading level="2" size="medium" spacing>
+                {props.intl.formatMessage({ id: 'søknad.åpneSøknader.tittel' })}
+            </Heading>
+            <ol>
+                {props.åpneSøknader.map((s) => {
+                    const behandling = props.behandlinger.find((b) => b.søknad.id === s.id);
+                    const attesteringer = behandling?.attesteringer ?? [];
+                    const senesteAttestering = pipe(attesteringer, last, toNullable);
+
+                    return (
+                        <div key={s.id}>
+                            <Panel border className={styles.søknad}>
+                                <div className={styles.info}>
+                                    <div>
+                                        <Heading level="3" size="medium">
+                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
+                                        </Heading>
+                                        <div className={styles.dato}>
+                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
+                                            <BodyShort>{søknadMottatt(s, props.intl)}</BodyShort>
+                                        </div>
+                                        {senesteAttestering?.underkjennelse && (
+                                            <UnderkjenteAttesteringer attesteringer={attesteringer} />
+                                        )}
+                                    </div>
+                                    <div className={styles.knapper}>
+                                        {!behandling ? (
+                                            <StartSøknadsbehandlingKnapper
+                                                sakId={props.sakId}
+                                                søknadId={s.id}
+                                                intl={props.intl}
+                                            />
+                                        ) : (
+                                            <SøknadsbehandlingStartetKnapper
+                                                sakId={props.sakId}
+                                                intl={props.intl}
+                                                behandling={behandling}
+                                                søknadId={s.id}
+                                            />
+                                        )}
+                                    </div>
+                                </div>
+                            </Panel>
+                        </div>
+                    );
+                })}
+            </ol>
+        </div>
+    );
+};
+
+export const IverksattInnvilgedeSøknader = (props: {
+    iverksatteInnvilgedeSøknader: Array<{
+        iverksattDato: string | undefined;
+        søknadensBehandlingsId: string | undefined;
+        søknad: Søknad;
+    }>;
+    sak: Sak;
+    intl: IntlShape;
+}) => {
+    if (props.iverksatteInnvilgedeSøknader.length === 0) return null;
+
+    return (
+        <div className={styles.søknadsContainer}>
+            <Heading level="2" size="medium" spacing>
+                {props.intl.formatMessage({ id: 'søknad.godkjenteSøknader.tittel' })}
+            </Heading>
+            <ol>
+                {props.iverksatteInnvilgedeSøknader.map((s) => {
+                    if (!s.søknadensBehandlingsId) {
+                        return null;
+                    }
+                    const vedtak = props.sak.vedtak.find((v) => v.behandlingId === s.søknadensBehandlingsId);
+                    if (!vedtak) {
+                        return null;
+                    }
+
+                    return (
+                        <div key={s.søknad.id}>
+                            <Panel border className={styles.søknad}>
+                                <div className={styles.info}>
+                                    <div>
+                                        <Heading level="3" size="small" spacing>
+                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
+                                        </Heading>
+                                        <div className={styles.dato}>
+                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
+                                            <BodyShort>{søknadMottatt(s.søknad, props.intl)}</BodyShort>
+                                        </div>
+                                        <div className={styles.dato}>
+                                            <Label>
+                                                {`${props.intl.formatMessage({
+                                                    id: 'søknad.iverksattDato',
+                                                })}: `}
+                                            </Label>
+                                            <BodyShort>{props.intl.formatDate(s.iverksattDato)}</BodyShort>
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <LinkAsButton
+                                            variant="secondary"
+                                            href={Routes.vedtaksoppsummering.createURL({
+                                                sakId: props.sak.id,
+                                                vedtakId: vedtak.id,
+                                            })}
+                                            size="small"
+                                        >
+                                            {props.intl.formatMessage({ id: 'behandling.seOppsummering' })}
+                                        </LinkAsButton>
+                                    </div>
+                                </div>
+                            </Panel>
+                        </div>
+                    );
+                })}
+            </ol>
+        </div>
+    );
+};
+
+const StartSøknadsbehandlingKnapper = (props: { sakId: string; søknadId: string; intl: IntlShape }) => {
+    const history = useHistory();
+    const [behandlingStatus, startBehandling] = useAsyncActionCreator(sakSlice.startBehandling);
+
+    return (
+        <div>
+            <AvsluttOgStartFortsettButtons
+                sakId={props.sakId}
+                behandlingsId={props.søknadId}
+                primaryButtonTekst={props.intl.formatMessage({
+                    id: 'behandling.startBehandling',
+                })}
+                usePrimaryAsButton={{
+                    onClick: () =>
+                        startBehandling(
+                            {
+                                sakId: props.sakId,
+                                søknadId: props.søknadId,
+                            },
+                            (response) => {
+                                history.push(
+                                    Routes.saksbehandlingVilkårsvurdering.createURL({
+                                        sakId: props.sakId,
+                                        behandlingId: response.id,
+                                    })
+                                );
+                            }
+                        ),
+                    status: behandlingStatus,
+                }}
+                intl={props.intl}
+            />
+
+            {RemoteData.isFailure(behandlingStatus) && (
+                <div className={styles.feil}>
+                    <ApiErrorAlert error={behandlingStatus.error} />
+                </div>
+            )}
+        </div>
+    );
+};
+
+const SøknadsbehandlingStartetKnapper = (props: {
+    behandling: Behandling;
+    sakId: string;
+    søknadId: string;
+    intl: IntlShape;
+}) => {
+    const user = useUserContext();
+    const { behandling } = props;
+
+    return (
+        <div>
+            {erTilAttestering(behandling) && (!user.isAttestant || user.navIdent === behandling.saksbehandler) && (
+                <div className={styles.ikonContainer}>
+                    <Ikon className={styles.ikon} kind="info-sirkel-fyll" width={'24px'} />
+                    <p>
+                        {props.intl.formatMessage({
+                            id: 'attestering.tilAttestering',
+                        })}
+                    </p>
+                </div>
+            )}
+
+            <div className={styles.søknadsbehandlingKnapper}>
+                {erTilAttestering(behandling) && user.isAttestant && user.navIdent !== behandling.saksbehandler ? (
+                    <LinkAsButton
+                        variant="secondary"
+                        size="small"
+                        href={Routes.attesterSøknadsbehandling.createURL({
+                            sakId: props.sakId,
+                            behandlingId: behandling.id,
+                        })}
+                    >
+                        {props.intl.formatMessage({
+                            id: 'attestering.attester',
+                        })}
+                    </LinkAsButton>
+                ) : (
+                    !erTilAttestering(behandling) &&
+                    !erIverksatt(behandling) &&
+                    user.navIdent !== pipe(behandling.attesteringer ?? [], last, toNullable)?.attestant && (
+                        <AvsluttOgStartFortsettButtons
+                            sakId={props.sakId}
+                            behandlingsId={props.søknadId}
+                            primaryButtonTekst={props.intl.formatMessage({
+                                id: 'behandling.fortsettBehandling',
+                            })}
+                            usePrimaryAsLink={{
+                                url: Routes.saksbehandlingVilkårsvurdering.createURL({
+                                    sakId: props.sakId,
+                                    behandlingId: behandling.id,
+                                    vilkar: hentSisteVurdertSaksbehandlingssteg(behandling),
+                                }),
+                            }}
+                            intl={props.intl}
+                        />
+                    )
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const LukkedeSøknader = (props: { lukkedeSøknader: Søknad[]; intl: IntlShape }) => {
+    if (props.lukkedeSøknader.length === 0) return null;
+
+    return (
+        <div className={styles.søknadsContainer}>
+            <Heading level="2" size="medium" spacing>
+                {props.intl.formatMessage({
+                    id: 'søknad.lukkedeSøknader.tittel',
+                })}
+            </Heading>
+            <ol>
+                {props.lukkedeSøknader.map((søknad) => (
+                    <li key={søknad.id}>
+                        <Panel border className={styles.søknad}>
+                            <div className={styles.info}>
+                                <div>
+                                    <Heading level="3" size="small" spacing>
+                                        {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
+                                    </Heading>
+                                    <div className={styles.dato}>
+                                        <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
+                                        <BodyShort>{søknadMottatt(søknad, props.intl)}</BodyShort>
+                                    </div>
+                                </div>
+                            </div>
+                            <div className={styles.ikonContainer}>
+                                <Ikon className={styles.ikon} kind="feil-sirkel-fyll" width={'24px'} />
+                                <p className={styles.ikonTekst}>
+                                    {props.intl.formatMessage({
+                                        id: lukketBegrunnelseResourceId(søknad.lukket?.type),
+                                    })}
+                                </p>
+                            </div>
+                        </Panel>
+                    </li>
+                ))}
+            </ol>
+        </div>
+    );
+};
+
+export const AvslåtteSøknader = (props: {
+    sak: Sak;
+    avslåtteSøknader: Array<{
+        iverksattDato: string | undefined;
+        søknadensBehandlingsId: string | undefined;
+        søknad: Søknad;
+    }>;
+    intl: IntlShape;
+}) => {
+    if (props.avslåtteSøknader.length === 0) return null;
+
+    return (
+        <div className={styles.søknadsContainer}>
+            <Heading level="2" size="medium" spacing>
+                {props.intl.formatMessage({
+                    id: 'søknad.avslåtteSøknader.tittel',
+                })}
+            </Heading>
+            <ol>
+                {props.avslåtteSøknader.map((s) => {
+                    if (!s.søknadensBehandlingsId) {
+                        return null;
+                    }
+                    const vedtak = props.sak.vedtak.find((v) => v.behandlingId === s.søknadensBehandlingsId);
+                    if (!vedtak) {
+                        return null;
+                    }
+
+                    return (
+                        <li key={s.søknad.id}>
+                            <Panel border className={styles.søknad}>
+                                <div className={styles.info}>
+                                    <div>
+                                        <Heading level="3" size="small" spacing>
+                                            {props.intl.formatMessage({ id: 'søknad.typeSøknad' })}
+                                        </Heading>
+                                        <div className={styles.dato}>
+                                            <Label>{`${props.intl.formatMessage({ id: 'søknad.mottatt' })}: `}</Label>
+                                            <BodyShort>{søknadMottatt(s.søknad, props.intl)}</BodyShort>
+                                        </div>
+                                        <div className={styles.dato}>
+                                            <Label>
+                                                {`${props.intl.formatMessage({
+                                                    id: 'søknad.iverksattDato',
+                                                })}: `}
+                                            </Label>
+                                            <BodyShort>{props.intl.formatDate(s.iverksattDato)}</BodyShort>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div>
+                                    <LinkAsButton
+                                        variant="secondary"
+                                        href={Routes.vedtaksoppsummering.createURL({
+                                            sakId: props.sak.id,
+                                            vedtakId: vedtak.id,
+                                        })}
+                                        size="small"
+                                    >
+                                        {props.intl.formatMessage({ id: 'revurdering.oppsummering' })}
+                                    </LinkAsButton>
+                                </div>
+                            </Panel>
+                        </li>
+                    );
+                })}
+            </ol>
+        </div>
+    );
+};

--- a/src/pages/saksbehandling/sakintro/SøknadsLister.tsx
+++ b/src/pages/saksbehandling/sakintro/SøknadsLister.tsx
@@ -57,7 +57,7 @@ export const ÅpneSøknader = (props: {
                     const senesteAttestering = pipe(attesteringer, last, toNullable);
 
                     return (
-                        <div key={s.id}>
+                        <li key={s.id}>
                             <Panel border className={styles.søknad}>
                                 <div className={styles.info}>
                                     <div>
@@ -90,7 +90,7 @@ export const ÅpneSøknader = (props: {
                                     </div>
                                 </div>
                             </Panel>
-                        </div>
+                        </li>
                     );
                 })}
             </ol>

--- a/src/pages/saksbehandling/sakintro/sakintro-nb.ts
+++ b/src/pages/saksbehandling/sakintro/sakintro-nb.ts
@@ -34,8 +34,12 @@ export default {
     'revurdering.undertittel': 'Revurdering',
     'revurdering.opprettet': 'Opprettet:',
     'revurdering.iverksattDato': 'Iverksatt dato:',
+    'revurdering.type': 'Type: ',
+    'revurdering.type.stansGjenoppta.label': 'Stans/Gjenoppta av utbetaling',
 
     'revurdering.label.forhåndsvarselSendt': 'Forhåndsvarsel sendt',
+
+    'revurdering.avsluttede.tittel': 'Avsluttede revurderinger',
 
     'suksess.forhåndsvarsel': 'Forhåndsvarsel er sendt til bruker og oppgave i Gosys er opprettet',
     'suksess.sendtTilAttestering': 'Revurderingen er sendt til attestering',

--- a/src/pages/saksbehandling/sakintro/sakintro-nb.ts
+++ b/src/pages/saksbehandling/sakintro/sakintro-nb.ts
@@ -34,6 +34,7 @@ export default {
     'revurdering.undertittel': 'Revurdering',
     'revurdering.opprettet': 'Opprettet:',
     'revurdering.iverksattDato': 'Iverksatt dato:',
+    'revurdering.seOppsummering': 'Se oppsummering',
     'revurdering.type': 'Type: ',
     'revurdering.type.stansGjenoppta.label': 'Stans/Gjenoppta av utbetaling',
 

--- a/src/pages/saksbehandling/sakintro/sakintro-nb.ts
+++ b/src/pages/saksbehandling/sakintro/sakintro-nb.ts
@@ -1,46 +1,27 @@
 export default {
-    'display.attestering.attester': 'Attester',
-    'display.attestering.iverksatt': 'Iverksatt',
-    'display.attestering.tilAttestering': 'Til attestering',
-    'display.attestering.sendtTilbakeFordi': 'Sendt tilbake fordi',
-    'display.attestering.kommentar': 'Kommentar',
-    'display.attestering.tidspunkt': 'Tidspunkt',
+    'attestering.attester': 'Attester',
+    'attestering.tilAttestering': 'Til attestering',
 
-    'display.avslåtteSøknader.tittel': 'Avslåtte søknader',
+    'behandling.fortsettBehandling': 'Fortsett behandling',
+    'behandling.seOppsummering': 'Se oppsummering',
+    'behandling.startBehandling': 'Start behandling',
+    'behandling.avsluttBehandling': 'Avslutt behandling',
 
-    'display.lukkedeSøknader.tittel': 'Lukkede søknader',
+    'saksoversikt.tittel': 'Saksnummer',
 
-    'display.behandling.fortsettBehandling': 'Fortsett behandling',
-    'display.behandling.seOppsummering': 'Se oppsummering',
+    'søknad.avslått': 'Avslått',
+    'søknad.iverksattDato': 'Iverksatt dato',
+    'søknad.lukket.avvist': 'Avvist',
+    'søknad.lukket.bortfalt': 'Bortfalt',
+    'søknad.lukket.trukket': 'Trukket',
+    'søknad.lukket.ukjentLukking': 'Ukjent lukking',
+    'søknad.mottatt': 'Mottatt',
+    'søknad.typeSøknad': 'Søknad',
 
-    'display.behandling.startBehandling': 'Start behandling',
-
-    'display.godkjenteSøknader.tittel': 'Godkjente søknader',
-
-    'behandling.attestering.advarsel': 'Sendt tilbake fra attestering',
-
-    'behandling.underkjent.dokumentasjonMangler': 'Dokumentasjon mangler',
-    'behandling.underkjent.beregningenErFeil': 'Beregningen er feil',
-    'behandling.underkjent.InngangsvilkåreneErFeilvurdert': 'Inngangsvilkårene er feilvurdert',
-    'behandling.underkjent.vedtaksbrevetErFeil': 'Vedtaksbrevet er feil',
-    'behandling.underkjent.andreForhold': 'Andre forhold',
-
-    'display.saksoversikt.tittel': 'Saksnummer',
-
-    'display.søknad.avslag.manglendeDokumentajon': 'Avslag pga manglende dokumentasjon',
-    'display.søknad.avslått': 'Avslått',
-    'display.søknad.iverksattDato': 'Iverksatt dato',
-    'display.søknad.lukket.avvist': 'Avvist',
-    'display.søknad.lukket.bortfalt': 'Bortfalt',
-    'display.søknad.lukket.trukket': 'Trukket',
-    'display.søknad.lukket.ukjentLukking': 'Ukjent lukking',
-    'display.søknad.lukkSøknad': 'Lukk søknad',
-    'display.søknad.mottatt': 'Mottatt',
-    'display.søknad.typeSøknad': 'Søknad',
-
-    'display.utbetalinger.tittel': 'Utbetalinger',
-
-    'display.åpneSøknader.tittel': 'Åpne søknader',
+    'søknad.avslåtteSøknader.tittel': 'Avslåtte søknader',
+    'søknad.lukkedeSøknader.tittel': 'Lukkede søknader',
+    'søknad.godkjenteSøknader.tittel': 'Godkjente søknader',
+    'søknad.åpneSøknader.tittel': 'Åpne søknader',
 
     'knapp.revurder': 'Revurder',
     'knapp.stoppUtbetaling': 'Stopp utbetaling',

--- a/src/pages/saksbehandling/sakintro/sakintro.module.less
+++ b/src/pages/saksbehandling/sakintro/sakintro.module.less
@@ -3,38 +3,12 @@
 .knapper {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
-
-    > :not(:last-child) {
-        margin-right: @spacing;
-    }
 }
 
 .suksessStatuserContainer {
     display: flex;
     padding-left: 10rem;
     margin-top: @spacing-xs;
-}
-
-.søknadsbehandlingKnapperContainer {
-    display: flex;
-    flex-direction: column;
-
-    .søknadsbehandlingKnapper {
-        align-self: flex-end;
-        display: flex;
-        flex-wrap: wrap;
-
-        button {
-            margin-right: @spacing-xs;
-            margin-top: @spacing-xxs;
-            margin-bottom: @spacing-xxs;
-        }
-
-        > :last-child {
-            margin-right: 0;
-        }
-    }
 }
 
 .sakintroContainer {
@@ -125,10 +99,6 @@
     margin-right: @spacing-xs;
 }
 
-.flexColumn {
-    flex-direction: column;
-}
-
 .ikonContainer {
     align-self: flex-start;
     display: flex;
@@ -159,4 +129,10 @@
 
 .dokumenterLinkIcon {
     margin-right: @spacing-xs;
+}
+
+.avsluttOgStartFortsettKnapperContainer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
 }

--- a/src/pages/saksbehandling/sakintro/sakintro.module.less
+++ b/src/pages/saksbehandling/sakintro/sakintro.module.less
@@ -80,6 +80,10 @@
                 display: flex;
             }
 
+            .informasjonsTekst {
+                display: flex;
+            }
+
             .underkjenteAttesteringerContainer {
                 margin-top: @spacing-xs;
             }

--- a/src/pages/saksbehandling/stans/Stans.tsx
+++ b/src/pages/saksbehandling/stans/Stans.tsx
@@ -14,7 +14,7 @@ import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup, { getDateErrorMessage } from '~lib/validering';
-import { AbstraktRevurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
+import { Revurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { StansAvYtelse } from '~types/Stans';
 import { getRevurderingsårsakMessageId } from '~utils/revurdering/revurderingUtils';
@@ -33,7 +33,7 @@ interface FormData {
     begrunnelse: string;
 }
 
-function hentDefaultVerdier(r: Nullable<AbstraktRevurdering>): FormData {
+function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
     if (r) {
         return {
             stansDato: new Date(r.periode.fraOgMed),

--- a/src/pages/saksbehandling/stans/Stans.tsx
+++ b/src/pages/saksbehandling/stans/Stans.tsx
@@ -14,7 +14,7 @@ import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup, { getDateErrorMessage } from '~lib/validering';
-import { OpprettetRevurderingGrunn, Revurdering } from '~types/Revurdering';
+import { AbstraktRevurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { StansAvYtelse } from '~types/Stans';
 import { getRevurderingsårsakMessageId } from '~utils/revurdering/revurderingUtils';
@@ -33,7 +33,7 @@ interface FormData {
     begrunnelse: string;
 }
 
-function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
+function hentDefaultVerdier(r: Nullable<AbstraktRevurdering>): FormData {
     if (r) {
         return {
             stansDato: new Date(r.periode.fraOgMed),

--- a/src/pages/saksbehandling/stans/components/StansOppsummeringskomponent.tsx
+++ b/src/pages/saksbehandling/stans/components/StansOppsummeringskomponent.tsx
@@ -9,7 +9,7 @@ import StansOppsummeringsblokk from '~components/revurdering/oppsummering/stanso
 import sharedMessages from '~features/revurdering/sharedMessages-nb';
 import { useI18n } from '~lib/i18n';
 import { Nullable } from '~lib/types';
-import { Revurdering } from '~types/Revurdering';
+import { AbstraktRevurdering } from '~types/Revurdering';
 
 import messages from '../stans-nb';
 import styles from '../stans.module.less';
@@ -24,7 +24,7 @@ interface Input {
     verdi: string;
 }
 interface Props {
-    revurdering: Revurdering;
+    revurdering: AbstraktRevurdering;
     knapper?: { tilbake?: KnappProps; neste?: KnappProps };
     error?: Nullable<ApiError<string>>;
     inputs: Input[];

--- a/src/pages/saksbehandling/stans/components/StansOppsummeringskomponent.tsx
+++ b/src/pages/saksbehandling/stans/components/StansOppsummeringskomponent.tsx
@@ -9,7 +9,7 @@ import StansOppsummeringsblokk from '~components/revurdering/oppsummering/stanso
 import sharedMessages from '~features/revurdering/sharedMessages-nb';
 import { useI18n } from '~lib/i18n';
 import { Nullable } from '~lib/types';
-import { AbstraktRevurdering } from '~types/Revurdering';
+import { Revurdering } from '~types/Revurdering';
 
 import messages from '../stans-nb';
 import styles from '../stans.module.less';
@@ -24,7 +24,7 @@ interface Input {
     verdi: string;
 }
 interface Props {
-    revurdering: AbstraktRevurdering;
+    revurdering: Revurdering;
     knapper?: { tilbake?: KnappProps; neste?: KnappProps };
     error?: Nullable<ApiError<string>>;
     inputs: Input[];

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -13,7 +13,7 @@ import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
-import { AbstraktRevurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
+import { Revurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Gjenopptak } from '~types/Stans';
 import { getRevurderingsårsakMessageId } from '~utils/revurdering/revurderingUtils';
@@ -31,7 +31,7 @@ interface FormData {
     begrunnelse: string;
 }
 
-function hentDefaultVerdier(r: Nullable<AbstraktRevurdering>): FormData {
+function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
     if (r) {
         return {
             begrunnelse: r.begrunnelse ?? '',

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -13,7 +13,7 @@ import { useI18n } from '~lib/i18n';
 import * as Routes from '~lib/routes';
 import { Nullable } from '~lib/types';
 import yup from '~lib/validering';
-import { OpprettetRevurderingGrunn, Revurdering } from '~types/Revurdering';
+import { AbstraktRevurdering, OpprettetRevurderingGrunn } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Gjenopptak } from '~types/Stans';
 import { getRevurderingsårsakMessageId } from '~utils/revurdering/revurderingUtils';
@@ -31,7 +31,7 @@ interface FormData {
     begrunnelse: string;
 }
 
-function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
+function hentDefaultVerdier(r: Nullable<AbstraktRevurdering>): FormData {
     if (r) {
         return {
             begrunnelse: r.begrunnelse ?? '',

--- a/src/pages/saksbehandling/vedtak/revurderingsvedtakWithSnapshot/RevurderingsoppsummeringWithSnapshot.tsx
+++ b/src/pages/saksbehandling/vedtak/revurderingsvedtakWithSnapshot/RevurderingsoppsummeringWithSnapshot.tsx
@@ -7,10 +7,10 @@ import { hentTidligereGrunnlagsdataForVedtak } from '~api/revurderingApi';
 import Revurderingoppsummering from '~components/revurdering/oppsummering/Revurderingoppsummering';
 import { pipe } from '~lib/fp';
 import { useApiCall } from '~lib/hooks';
-import { Revurdering } from '~types/Revurdering';
+import { InformasjonsRevurdering } from '~types/Revurdering';
 
 const RevurderingsoppsummeringWithSnapshot = (props: {
-    revurdering: Revurdering;
+    revurdering: InformasjonsRevurdering;
     sakId: string;
     vedtakId: string;
     intl: IntlShape;

--- a/src/pages/saksbehandling/vedtak/utils.ts
+++ b/src/pages/saksbehandling/vedtak/utils.ts
@@ -3,7 +3,7 @@ import { Behandling } from '~types/Behandling';
 import { IverksattRevurdering } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Vedtak } from '~types/Vedtak';
-import { erRevurdering, erRevurderingIverksatt } from '~utils/revurdering/revurderingUtils';
+import { erInformasjonsRevurdering, erRevurderingIverksatt } from '~utils/revurdering/revurderingUtils';
 
 interface Søknadsbehandlingsoppsummering {
     behandling: Behandling;
@@ -26,7 +26,7 @@ export function hentInformasjonKnyttetTilVedtak(sak: Sak, vedtak: Vedtak): Nulla
     }
 
     const revurdering = sak.revurderinger.find((r) => r.id === vedtak.behandlingId);
-    if (revurdering && erRevurdering(revurdering) && erRevurderingIverksatt(revurdering)) {
+    if (revurdering && erInformasjonsRevurdering(revurdering) && erRevurderingIverksatt(revurdering)) {
         return {
             revurdering: revurdering,
             type: 'revurdering',

--- a/src/pages/saksbehandling/vedtak/utils.ts
+++ b/src/pages/saksbehandling/vedtak/utils.ts
@@ -3,7 +3,7 @@ import { Behandling } from '~types/Behandling';
 import { IverksattRevurdering } from '~types/Revurdering';
 import { Sak } from '~types/Sak';
 import { Vedtak } from '~types/Vedtak';
-import { erRevurderingIverksatt } from '~utils/revurdering/revurderingUtils';
+import { erRevurdering, erRevurderingIverksatt } from '~utils/revurdering/revurderingUtils';
 
 interface Søknadsbehandlingsoppsummering {
     behandling: Behandling;
@@ -26,7 +26,7 @@ export function hentInformasjonKnyttetTilVedtak(sak: Sak, vedtak: Vedtak): Nulla
     }
 
     const revurdering = sak.revurderinger.find((r) => r.id === vedtak.behandlingId);
-    if (revurdering && erRevurderingIverksatt(revurdering)) {
+    if (revurdering && erRevurdering(revurdering) && erRevurderingIverksatt(revurdering)) {
         return {
             revurdering: revurdering,
             type: 'revurdering',

--- a/src/types/Revurdering.ts
+++ b/src/types/Revurdering.ts
@@ -7,7 +7,8 @@ import { Periode } from './Periode';
 import { Simulering } from './Simulering';
 import { Vedtak } from './Vedtak';
 
-export interface Revurdering<T extends RevurderingsStatus = RevurderingsStatus> {
+//Dette er feltene som deles av backends 'abstrakte' revurdering. Hadde vært fint å skille på dem litt mer, både bak og fram
+export interface AbstraktRevurdering<T extends RevurderingsStatus = RevurderingsStatus> {
     id: string;
     status: T;
     opprettet: string;
@@ -15,60 +16,66 @@ export interface Revurdering<T extends RevurderingsStatus = RevurderingsStatus> 
     tilRevurdering: Vedtak;
     saksbehandler: string;
     attesteringer: Attestering[];
-    fritekstTilBrev: string;
     årsak: OpprettetRevurderingGrunn;
     begrunnelse: Nullable<string>;
-    forhåndsvarsel: Nullable<Forhåndsvarsel>;
     grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger;
-    informasjonSomRevurderes: Record<InformasjonSomRevurderes, Vurderingstatus>;
 }
 
-interface Beregninger {
-    beregning: Beregning;
-    revurdert: Beregning;
+export interface Revurdering<T extends RevurderingsStatus = RevurderingsStatus> extends AbstraktRevurdering {
+    status: T;
+    fritekstTilBrev: string;
+    forhåndsvarsel: Nullable<Forhåndsvarsel>;
+    informasjonSomRevurderes: Record<InformasjonSomRevurderes, Vurderingstatus>;
 }
 
 export type OpprettetRevurdering = Revurdering<RevurderingsStatus.OPPRETTET>;
 
 export interface BeregnetInnvilget extends Revurdering<RevurderingsStatus.BEREGNET_INNVILGET> {
-    beregninger: Beregninger;
+    beregninger: Beregning;
 }
 
 export interface BeregnetIngenEndring extends Revurdering<RevurderingsStatus.BEREGNET_INGEN_ENDRING> {
-    beregninger: Beregninger;
+    beregninger: Beregning;
 }
 
 export interface SimulertRevurdering
     extends Revurdering<RevurderingsStatus.SIMULERT_INNVILGET | RevurderingsStatus.SIMULERT_OPPHØRT> {
-    beregninger: Beregninger;
+    beregninger: Beregning;
     simulering: Simulering;
 }
 
 export interface RevurderingTilAttestering
     extends Revurdering<RevurderingsStatus.TIL_ATTESTERING_INNVILGET | RevurderingsStatus.TIL_ATTESTERING_OPPHØRT> {
-    beregninger: Beregninger;
+    beregninger: Beregning;
     skalFøreTilBrevutsending: boolean;
     simulering: Nullable<Simulering>;
 }
 
 export interface IverksattRevurdering
     extends Revurdering<RevurderingsStatus.IVERKSATT_INNVILGET | RevurderingsStatus.IVERKSATT_OPPHØRT> {
-    beregninger: Beregninger;
+    beregninger: Beregning;
     skalFøreTilBrevutsending: boolean;
     simulering: Nullable<Simulering>;
 }
 
 export interface UnderkjentRevurdering
     extends Revurdering<RevurderingsStatus.UNDERKJENT_INNVILGET | RevurderingsStatus.UNDERKJENT_OPPHØRT> {
-    beregninger: Beregninger;
+    beregninger: Beregning;
     skalFøreTilBrevutsending: boolean;
     simulering: Nullable<Simulering>;
 }
 
-export function harBeregninger(r: Revurdering): r is Revurdering & { beregninger: Beregninger } {
+export interface AvsluttetRevurdering extends Revurdering<RevurderingsStatus.AVSLUTTET> {
+    simulering: Nullable<Simulering>;
+    fritekstTilBrev: string;
+    forhåndsvarsel: Nullable<Forhåndsvarsel>;
+    informasjonSomRevurderes: Record<InformasjonSomRevurderes, Vurderingstatus>;
+}
+
+export function harBeregninger(r: Revurdering): r is Revurdering & { beregninger: Beregning } {
     return 'beregninger' in r;
 }
-export function harSimulering(r: Revurdering): r is Revurdering & { simulering: Simulering } {
+export function harSimulering(r: AbstraktRevurdering): r is AbstraktRevurdering & { simulering: Simulering } {
     return 'simulering' in r && (r as SimulertRevurdering).simulering !== null;
 }
 
@@ -103,6 +110,7 @@ export enum RevurderingsStatus {
     SIMULERT_OPPHØRT = 'SIMULERT_OPPHØRT',
     SIMULERT_INNVILGET = 'SIMULERT_INNVILGET',
     SIMULERT_STANS = 'SIMULERT_STANS',
+    AVSLUTTET_STANS = 'AVSLUTTET_STANS',
     SIMULERT_GJENOPPTAK = 'SIMULERT_GJENOPPTAK',
     TIL_ATTESTERING_INNVILGET = 'TIL_ATTESTERING_INNVILGET',
     TIL_ATTESTERING_OPPHØRT = 'TIL_ATTESTERING_OPPHØRT',
@@ -111,10 +119,12 @@ export enum RevurderingsStatus {
     IVERKSATT_OPPHØRT = 'IVERKSATT_OPPHØRT',
     IVERKSATT_INGEN_ENDRING = 'IVERKSATT_INGEN_ENDRING',
     IVERKSATT_STANS = 'IVERKSATT_STANS',
+    AVSLUTTET_GJENOPPTAK = 'AVSLUTTET_GJENOPPTAK',
     IVERKSATT_GJENOPPTAK = 'IVERKSATT_GJENOPPTAK',
     UNDERKJENT_INNVILGET = 'UNDERKJENT_INNVILGET',
     UNDERKJENT_OPPHØRT = 'UNDERKJENT_OPPHØRT',
     UNDERKJENT_INGEN_ENDRING = 'UNDERKJENT_INGEN_ENDRING',
+    AVSLUTTET = 'AVSLUTTET',
 }
 
 export enum OpprettetRevurderingGrunn {

--- a/src/types/Revurdering.ts
+++ b/src/types/Revurdering.ts
@@ -31,36 +31,36 @@ export interface Revurdering<T extends RevurderingsStatus = RevurderingsStatus> 
 export type OpprettetRevurdering = Revurdering<RevurderingsStatus.OPPRETTET>;
 
 export interface BeregnetInnvilget extends Revurdering<RevurderingsStatus.BEREGNET_INNVILGET> {
-    beregninger: Beregning;
+    beregning: Beregning;
 }
 
 export interface BeregnetIngenEndring extends Revurdering<RevurderingsStatus.BEREGNET_INGEN_ENDRING> {
-    beregninger: Beregning;
+    beregning: Beregning;
 }
 
 export interface SimulertRevurdering
     extends Revurdering<RevurderingsStatus.SIMULERT_INNVILGET | RevurderingsStatus.SIMULERT_OPPHØRT> {
-    beregninger: Beregning;
+    beregning: Beregning;
     simulering: Simulering;
 }
 
 export interface RevurderingTilAttestering
     extends Revurdering<RevurderingsStatus.TIL_ATTESTERING_INNVILGET | RevurderingsStatus.TIL_ATTESTERING_OPPHØRT> {
-    beregninger: Beregning;
+    beregning: Beregning;
     skalFøreTilBrevutsending: boolean;
     simulering: Nullable<Simulering>;
 }
 
 export interface IverksattRevurdering
     extends Revurdering<RevurderingsStatus.IVERKSATT_INNVILGET | RevurderingsStatus.IVERKSATT_OPPHØRT> {
-    beregninger: Beregning;
+    beregning: Beregning;
     skalFøreTilBrevutsending: boolean;
     simulering: Nullable<Simulering>;
 }
 
 export interface UnderkjentRevurdering
     extends Revurdering<RevurderingsStatus.UNDERKJENT_INNVILGET | RevurderingsStatus.UNDERKJENT_OPPHØRT> {
-    beregninger: Beregning;
+    beregning: Beregning;
     skalFøreTilBrevutsending: boolean;
     simulering: Nullable<Simulering>;
 }
@@ -72,8 +72,8 @@ export interface AvsluttetRevurdering extends Revurdering<RevurderingsStatus.AVS
     informasjonSomRevurderes: Record<InformasjonSomRevurderes, Vurderingstatus>;
 }
 
-export function harBeregninger(r: Revurdering): r is Revurdering & { beregninger: Beregning } {
-    return 'beregninger' in r;
+export function harBeregninger(r: Revurdering): r is Revurdering & { beregning: Beregning } {
+    return 'beregning' in r;
 }
 export function harSimulering(r: AbstraktRevurdering): r is AbstraktRevurdering & { simulering: Simulering } {
     return 'simulering' in r && (r as SimulertRevurdering).simulering !== null;

--- a/src/types/Sak.ts
+++ b/src/types/Sak.ts
@@ -3,7 +3,7 @@ import { Utbetalingsperiode } from '~types/Utbetalingsperiode';
 
 import { Behandling } from './Behandling';
 import { Periode } from './Periode';
-import { Revurdering } from './Revurdering';
+import { AbstraktRevurdering } from './Revurdering';
 import { Søknad } from './Søknad';
 import { Vedtak } from './Vedtak';
 
@@ -15,7 +15,7 @@ export interface Sak {
     søknader: Søknad[];
     utbetalinger: Utbetalingsperiode[];
     utbetalingerKanStansesEllerGjenopptas: KanStansesEllerGjenopptas;
-    revurderinger: Revurdering[];
+    revurderinger: AbstraktRevurdering[];
     vedtak: Vedtak[];
 }
 

--- a/src/types/Sak.ts
+++ b/src/types/Sak.ts
@@ -3,7 +3,7 @@ import { Utbetalingsperiode } from '~types/Utbetalingsperiode';
 
 import { Behandling } from './Behandling';
 import { Periode } from './Periode';
-import { AbstraktRevurdering } from './Revurdering';
+import { Revurdering } from './Revurdering';
 import { Søknad } from './Søknad';
 import { Vedtak } from './Vedtak';
 
@@ -15,7 +15,7 @@ export interface Sak {
     søknader: Søknad[];
     utbetalinger: Utbetalingsperiode[];
     utbetalingerKanStansesEllerGjenopptas: KanStansesEllerGjenopptas;
-    revurderinger: AbstraktRevurdering[];
+    revurderinger: Revurdering[];
     vedtak: Vedtak[];
 }
 

--- a/src/types/Stans.ts
+++ b/src/types/Stans.ts
@@ -1,12 +1,12 @@
-import { RevurderingsStatus, AbstraktRevurdering } from './Revurdering';
+import { RevurderingsStatus, UtbetalingsRevurdering } from './Revurdering';
 import { Simulering } from './Simulering';
 
 export interface StansAvYtelse
-    extends AbstraktRevurdering<RevurderingsStatus.SIMULERT_STANS | RevurderingsStatus.IVERKSATT_STANS> {
+    extends UtbetalingsRevurdering<RevurderingsStatus.SIMULERT_STANS | RevurderingsStatus.IVERKSATT_STANS> {
     simulering: Simulering;
 }
 
 export interface Gjenopptak
-    extends AbstraktRevurdering<RevurderingsStatus.SIMULERT_GJENOPPTAK | RevurderingsStatus.IVERKSATT_GJENOPPTAK> {
+    extends UtbetalingsRevurdering<RevurderingsStatus.SIMULERT_GJENOPPTAK | RevurderingsStatus.IVERKSATT_GJENOPPTAK> {
     simulering: Simulering;
 }

--- a/src/types/Stans.ts
+++ b/src/types/Stans.ts
@@ -1,12 +1,12 @@
-import { RevurderingsStatus, Revurdering } from './Revurdering';
+import { RevurderingsStatus, AbstraktRevurdering } from './Revurdering';
 import { Simulering } from './Simulering';
 
 export interface StansAvYtelse
-    extends Revurdering<RevurderingsStatus.SIMULERT_STANS | RevurderingsStatus.IVERKSATT_STANS> {
+    extends AbstraktRevurdering<RevurderingsStatus.SIMULERT_STANS | RevurderingsStatus.IVERKSATT_STANS> {
     simulering: Simulering;
 }
 
 export interface Gjenopptak
-    extends Revurdering<RevurderingsStatus.SIMULERT_GJENOPPTAK | RevurderingsStatus.IVERKSATT_GJENOPPTAK> {
+    extends AbstraktRevurdering<RevurderingsStatus.SIMULERT_GJENOPPTAK | RevurderingsStatus.IVERKSATT_GJENOPPTAK> {
     simulering: Simulering;
 }

--- a/src/utils/revurdering/revurderingUtils.ts
+++ b/src/utils/revurdering/revurderingUtils.ts
@@ -31,6 +31,9 @@ export const erBeregnetIngenEndring = (r: Revurdering): r is BeregnetIngenEndrin
 
 export const erRevurderingForhåndsvarslet = (r: Revurdering) =>
     erForhåndsvarselSendt(r) || erForhåndsvarslingBesluttet(r) || erIngenForhåndsvarsel(r);
+
+export const erForhåndsvarselSendtEllerBesluttet = (r: Revurdering) =>
+    erForhåndsvarselSendt(r) || erForhåndsvarslingBesluttet(r);
 export const erForhåndsvarselSendt = (r: Revurdering) => r.forhåndsvarsel?.type === Forhåndsvarseltype.SkalVarslesSendt;
 export const erForhåndsvarslingBesluttet = (r: Revurdering) =>
     r.forhåndsvarsel?.type === Forhåndsvarseltype.SkalVarslesBesluttet;
@@ -68,6 +71,11 @@ export const erRevurderingGjenopptak = (r: AbstraktRevurdering): r is Gjenopptak
 
 export const erGregulering = (årsak: OpprettetRevurderingGrunn): boolean =>
     årsak === OpprettetRevurderingGrunn.REGULER_GRUNNBELØP;
+
+export const erAbstraktRevurderingAvsluttet = (r: AbstraktRevurdering): boolean =>
+    r.status === RevurderingsStatus.AVSLUTTET ||
+    r.status === RevurderingsStatus.AVSLUTTET_GJENOPPTAK ||
+    r.status === RevurderingsStatus.AVSLUTTET_STANS;
 
 export function getRevurderingsårsakMessageId(årsak: OpprettetRevurderingGrunn): keyof typeof sharedMessages {
     switch (årsak) {
@@ -128,4 +136,21 @@ export const finnNesteRevurderingsteg = (
     });
 
     return førsteIkkeVurderteSteg ?? RevurderingSteg.Oppsummering;
+};
+
+export const getAvsluttedeOgIkkeAvsluttedeRevurderinger = (
+    revurderinger: AbstraktRevurdering[]
+): { avsluttedeRevurderinger: AbstraktRevurdering[]; åpneRevurderinger: AbstraktRevurdering[] } => {
+    const avsluttedeRevurderinger: AbstraktRevurdering[] = [];
+    const åpneRevurderinger: AbstraktRevurdering[] = [];
+
+    revurderinger.forEach((r) => {
+        if (erAbstraktRevurderingAvsluttet(r)) {
+            avsluttedeRevurderinger.push(r);
+        } else {
+            åpneRevurderinger.push(r);
+        }
+    });
+
+    return { avsluttedeRevurderinger, åpneRevurderinger };
 };

--- a/src/utils/revurdering/revurderingUtils.ts
+++ b/src/utils/revurdering/revurderingUtils.ts
@@ -145,7 +145,7 @@ export const splittAvsluttedeOgÅpneRevurderinger = (
     revurderinger: Revurdering[]
 ): { avsluttedeRevurderinger: Revurdering[]; åpneRevurderinger: Revurdering[] } => {
     return pipe(revurderinger, A.partition(erRevurderingAvsluttet), ({ left, right }) => ({
-        avsluttedeRevurderinger: left,
-        åpneRevurderinger: right,
+        åpneRevurderinger: left,
+        avsluttedeRevurderinger: right,
     }));
 };

--- a/src/utils/revurdering/revurderingUtils.ts
+++ b/src/utils/revurdering/revurderingUtils.ts
@@ -3,7 +3,6 @@ import {
     Revurdering,
     SimulertRevurdering,
     RevurderingsStatus,
-    OpprettetRevurdering,
     RevurderingTilAttestering,
     IverksattRevurdering,
     BeregnetIngenEndring,
@@ -12,13 +11,15 @@ import {
     OpprettetRevurderingGrunn,
     InformasjonSomRevurderes,
     Vurderingstatus,
+    AbstraktRevurdering,
 } from '~types/Revurdering';
 import { Gjenopptak, StansAvYtelse } from '~types/Stans';
 
 import { RevurderingSteg } from '../../pages/saksbehandling/types';
 
-export const erRevurderingOpprettet = (r: Revurdering): r is OpprettetRevurdering =>
-    r.status === RevurderingsStatus.OPPRETTET;
+export const erRevurdering = (r: AbstraktRevurdering): r is Revurdering => {
+    return 'forhåndsvarsel' in r && 'fritekstTilBrev' in r && 'informasjonSomRevurderes' in r;
+};
 
 export const erRevurderingSimulert = (r: Revurdering): r is SimulertRevurdering =>
     r.status === RevurderingsStatus.SIMULERT_INNVILGET ||
@@ -59,10 +60,10 @@ export const erRevurderingUnderkjent = (r: Revurdering): r is UnderkjentRevurder
     r.status === RevurderingsStatus.UNDERKJENT_OPPHØRT ||
     r.status === RevurderingsStatus.UNDERKJENT_INGEN_ENDRING;
 
-export const erRevurderingStans = (r: Revurdering): r is StansAvYtelse =>
+export const erRevurderingStans = (r: AbstraktRevurdering): r is StansAvYtelse =>
     r.status === RevurderingsStatus.SIMULERT_STANS || r.status === RevurderingsStatus.IVERKSATT_STANS;
 
-export const erRevurderingGjenopptak = (r: Revurdering): r is Gjenopptak =>
+export const erRevurderingGjenopptak = (r: AbstraktRevurdering): r is Gjenopptak =>
     r.status === RevurderingsStatus.SIMULERT_GJENOPPTAK || r.status === RevurderingsStatus.IVERKSATT_GJENOPPTAK;
 
 export const erGregulering = (årsak: OpprettetRevurderingGrunn): boolean =>


### PR DESCRIPTION
Bruk 1 endepunkt for vanlig revurdering brev (ikke mye poeng å ha 1 med fritekst, og 1 uten, når fritekst er i alle tilfellene nullable)

Laget en ‘avsluttBehandling’ komponent som er Parent av lukkSøknad/avlså & avslutt revurdering
Slått sammen siden ved ‘avslå pga manglende dok’ & ‘lukk søknad’ til LukkSøknadOgAvsluttBehandling. 
Ryddet litt i ‘avvist, trukket, bortfalt’ komponentene
Flyttet kode fra Sakintro til mindre komponenter som lister dem ut. Blir kanskje litt ryddigere der inne. Følte jeg scrollet litt for mye. 

Tvunget inn konseptet med ‘abstrakt revurdering’ til frontend. Litt pga jeg var avhengig pga det, som ikke er gjort på en så god måte heller. 

gjorde litt andre ting enn kanskje hva jeg 'skulle'. Skal prøve å holdet det litt fokusert neste gang 😅