### PR TITLE
Bruk forskjellig label for vedtaksbrev hvis utkast eller iverksatt

### DIFF
--- a/src/components/søknadsbehandlingoppsummering/SøknadsbehandlingHeader.tsx
+++ b/src/components/søknadsbehandlingoppsummering/SøknadsbehandlingHeader.tsx
@@ -147,7 +147,9 @@ const Tilleggsinfo = (props: {
                 {props.medBrevutkastknapp && (
                     <div>
                         <Label size="small" spacing>
-                            {props.intl.formatMessage({ id: 'brev.utkastVedtaksbrev' })}
+                            {erIverksatt(props.behandling)
+                                ? props.intl.formatMessage({ id: 'brev.vedtaksbrev' })
+                                : props.intl.formatMessage({ id: 'brev.utkastVedtaksbrev' })}
                         </Label>
                         <Button variant="secondary" size="small" type="button" onClick={hentBrev}>
                             {props.intl.formatMessage({ id: 'knapp.vis' })}

--- a/src/components/søknadsbehandlingoppsummering/søknadsbehandling-nb.ts
+++ b/src/components/søknadsbehandlingoppsummering/søknadsbehandling-nb.ts
@@ -13,6 +13,7 @@ export default {
     'behandling.iverksattDato': 'Iverksatt dato',
 
     'brev.utkastVedtaksbrev': 'Utkast til vedtaksbrev',
+    'brev.vedtaksbrev': 'Vedtaksbrev',
 
     'feilmelding.ikkeGjortEnBeregning': 'Det er ikke gjort en beregning',
     'feilmelding.ukjentFeil': 'Ukjent feil',

--- a/src/pages/saksbehandling/søknadsbehandling/sendTilAttesteringPage/sendTilAttesteringPage-nb.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/sendTilAttesteringPage/sendTilAttesteringPage-nb.ts
@@ -5,6 +5,7 @@ export default {
     'behandling.søknadsdato': 'Søknadsdato',
 
     'brev.utkastVedtaksbrev': 'Utkast til vedtaksbrev',
+    'brev.vedtaksbrev': 'Vedtaksbrev',
 
     'feilmelding.errorkode': 'Error kode:',
     'feilmelding.fantIkkeBehandlingsId': 'Fant ikke behandlingsid',


### PR DESCRIPTION
Akkurat nå står det `Utkast til vedtaksbrev` selv om det er iverksatt.