### PR TITLE
Vis fødselsdato i saksbehandlersøknad

### DIFF
--- a/src/api/personApi.ts
+++ b/src/api/personApi.ts
@@ -60,7 +60,7 @@ export interface Person {
     aktorId: string;
     navn: Navn;
     kjønn: Nullable<Kjønn>;
-    fødselsdato: Nullable<Date>;
+    fødselsdato: Nullable<string>;
     alder: Nullable<number>;
     telefonnummer: {
         landskode: string;

--- a/src/components/toKolonner/toKolonner.module.less
+++ b/src/components/toKolonner/toKolonner.module.less
@@ -11,6 +11,10 @@
     width: 50%;
     padding: @spacing-s;
     border-right: 1px solid @navBorder;
+
+    textarea {
+        max-width: 25.5rem;
+    }
 }
 
 .rightContainer {

--- a/src/pages/saksbehandling/revurdering/utenlandsopphold/utenlandsopphold.module.less
+++ b/src/pages/saksbehandling/revurdering/utenlandsopphold/utenlandsopphold.module.less
@@ -22,8 +22,7 @@
             flex-wrap: wrap;
 
             .dato {
-                min-width: 2rem;
-                max-width: 10rem;
+                max-width: 11.75rem;
             }
         }
     }

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -13,6 +13,7 @@ import { ApiError, ErrorCode } from '~api/apiClient';
 import ApiErrorAlert from '~components/apiErrorAlert/ApiErrorAlert';
 import DatePicker from '~components/datePicker/DatePicker';
 import Feiloppsummering from '~components/feiloppsummering/Feiloppsummering';
+import Faktablokk from '~components/oppsummering/vilkårsOppsummering/faktablokk/Faktablokk';
 import ToKolonner from '~components/toKolonner/ToKolonner';
 import { useSøknadsbehandlingDraftContextFor } from '~context/søknadsbehandlingDraftContext';
 import * as SakSlice from '~features/saksoversikt/sak.slice';
@@ -24,6 +25,7 @@ import yup, { getDateErrorMessage, hookFormErrorsTilFeiloppsummering } from '~li
 import { useAppDispatch, useAppSelector } from '~redux/Store';
 import { Vilkårtype } from '~types/Vilkårsvurdering';
 import * as DateUtils from '~utils/date/dateUtils';
+import { formatDate } from '~utils/date/dateUtils';
 import { er67EllerEldre } from '~utils/person/personUtils';
 
 import sharedMessages from '../sharedI18n-nb';
@@ -255,7 +257,19 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                         </form>
                     </>
                 ),
-                right: <div />,
+                right: RemoteData.isSuccess(søker) ? (
+                    <Faktablokk
+                        tittel={formatMessage('søker.personalia')}
+                        fakta={[
+                            {
+                                tittel: formatMessage('søker.fødselsdato'),
+                                verdi: søker.value.fødselsdato ? formatDate(søker.value.fødselsdato) : '',
+                            },
+                        ]}
+                    />
+                ) : (
+                    <></>
+                ),
             }}
         </ToKolonner>
     );

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -194,6 +194,7 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                                 render={({ field, fieldState }) => (
                                     <DatePicker
                                         {...field}
+                                        className={styles.dato}
                                         id="fraOgMed"
                                         label={formatMessage('datovelger.fom.label')}
                                         dateFormat="MM/yyyy"
@@ -212,6 +213,7 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                                 render={({ field, fieldState }) => (
                                     <DatePicker
                                         {...field}
+                                        className={styles.dato}
                                         id="tilOgMed"
                                         label={formatMessage('datovelger.tom.label')}
                                         dateFormat="MM/yyyy"

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt-nb.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt-nb.ts
@@ -11,4 +11,7 @@ export default {
 
     'state.lagrer': 'Lagrer...',
     'state.lagringFeilet': 'Lagring feilet',
+
+    'søker.personalia': 'Søkers personalia',
+    'søker.fødselsdato': 'Fødselsdato',
 };

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt.module.less
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt.module.less
@@ -8,4 +8,9 @@
     > :not(:last-child) {
         margin-bottom: @spacing;
     }
+
+    .dato {
+        min-width: 2rem;
+        max-width: 25.5rem;
+    }
 }

--- a/src/pages/søknad/steg/inngang/inngang-nb.ts
+++ b/src/pages/søknad/steg/inngang/inngang-nb.ts
@@ -17,7 +17,7 @@ export default {
 
     'heading.advarsel.alder': 'Alder',
     'advarsel.alder':
-        'Du kan får supplerende stønad for uføre flyktninger hvis du er under 67 år. Er du over 67 år kan du søke <navLink>Supplerende stønad for personer med kort botid i Norge</navLink>. Har du akkurat fylt 67 år kan du ha rett på etterbetaling for supplerende stønad for uføre flyktninger. Da må du fylle ut to søknader, en som ufør flyktning under 67 år og en som person med kort botid i Norge.',
+        'Du kan få supplerende stønad for uføre flyktninger hvis du er under 67 år. Er du over 67 år kan du søke <navLink>Supplerende stønad for personer med kort botid i Norge</navLink>. Har du akkurat fylt 67 år kan du ha rett på etterbetaling for supplerende stønad for uføre flyktninger. Da må du fylle ut to søknader, en som ufør flyktning under 67 år og en som person med kort botid i Norge.',
 
     'finnSøker.tittel': 'Finn søker',
     'finnSøker.tekst': 'For å starte søknaden, må du skrive inn fødselsnummeret til søkeren',


### PR DESCRIPTION
Vise fødselsdato til søker (ettersom saksbehandler blir bedt om å ta stilling til denne), samt en typo-fix

![image](https://user-images.githubusercontent.com/6595794/142876531-c0199973-a182-449e-b844-dd76b5f3f042.png)
