### PR TITLE
Vis sats-info ved avslag og opphør pga. inntekt

### DIFF
--- a/src/components/oppsummering/vilkårsOppsummering/VilkårsOppsummering.tsx
+++ b/src/components/oppsummering/vilkårsOppsummering/VilkårsOppsummering.tsx
@@ -30,6 +30,7 @@ function shouldShowSats(status: Behandlingsstatus) {
         Behandlingsstatus.TIL_ATTESTERING_INNVILGET,
         Behandlingsstatus.UNDERKJENT_INNVILGET,
         Behandlingsstatus.IVERKSATT_INNVILGET,
+        Behandlingsstatus.BEREGNET_AVSLAG,
     ].includes(status);
 }
 

--- a/src/components/revurdering/oppsummering/vedtaksinformasjon/Vedtaksinformasjon.tsx
+++ b/src/components/revurdering/oppsummering/vedtaksinformasjon/Vedtaksinformasjon.tsx
@@ -11,7 +11,12 @@ import { FormueResultat, FormueVilkår } from '~types/grunnlagsdataOgVilkårsvur
 import { GrunnlagsdataOgVilkårsvurderinger } from '~types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
 import { UføreVilkår } from '~types/grunnlagsdataOgVilkårsvurderinger/uføre/Uførevilkår';
 import { Utenlandsopphold } from '~types/grunnlagsdataOgVilkårsvurderinger/utenlandsopphold/Utenlandsopphold';
-import { Vurderingstatus, InformasjonSomRevurderes, InformasjonsRevurdering } from '~types/Revurdering';
+import {
+    Vurderingstatus,
+    InformasjonSomRevurderes,
+    InformasjonsRevurdering,
+    InformasjonsRevurderingStatus,
+} from '~types/Revurdering';
 import { regnUtFormuegrunnlag } from '~utils/revurdering/formue/RevurderFormueUtils';
 import { hentBosituasjongrunnlag } from '~utils/søknadsbehandlingOgRevurdering/bosituasjon/bosituasjonUtils';
 
@@ -211,7 +216,7 @@ const Vedtaksinformasjon = (props: {
                     gamleData={props.grunnlagsdataOgVilkårsvurderinger.uføre}
                 />
             )}
-            {props.revurdering.informasjonSomRevurderes.Bosituasjon === Vurderingstatus.Vurdert && (
+            {revurdertBosituasjonEllerOpphørtPgaInntekt(props.revurdering) && (
                 <Bosituasjonblokk
                     nyeData={props.revurdering.grunnlagsdataOgVilkårsvurderinger}
                     gamleData={props.grunnlagsdataOgVilkårsvurderinger}
@@ -238,5 +243,10 @@ const Vedtaksinformasjon = (props: {
         </div>
     );
 };
+
+const revurdertBosituasjonEllerOpphørtPgaInntekt = (revurdering: InformasjonsRevurdering) =>
+    revurdering.informasjonSomRevurderes.Bosituasjon === Vurderingstatus.Vurdert ||
+    (revurdering.informasjonSomRevurderes.Inntekt === Vurderingstatus.Vurdert &&
+        revurdering.status === InformasjonsRevurderingStatus.SIMULERT_OPPHØRT);
 
 export default Vedtaksinformasjon;


### PR DESCRIPTION
Saksbehandlerne ønsker å se hva som ble gjort på sats hvis det blir et avslag eller et opphør pga. inntekt (hvor satsen da er et ledd i beregningen).