### PR TITLE
Fiks bug i yup validering for epsFnr

### DIFF
--- a/src/pages/saksbehandling/søknadsbehandling/formue/Formue.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/formue/Formue.tsx
@@ -109,7 +109,7 @@ const schema = yup
             .typeError('Feltet må fylles ut'),
         epsFnr: yup.mixed<string>().when('borSøkerMedEPS', {
             is: true,
-            then: yup.string().required('Du må legge inn ektefelle/samboers fødselsnummer').length(11),
+            then: yup.string().typeError('Du må legge inn ektefelle/samboers fødselsnummer').length(11),
         }),
     })
     .required();


### PR DESCRIPTION
Denne tilbakemelding fick vi tidligere:
epsFnr must be a `string` type, but the final value was: `null`. If "null" is intended as an empty value be sure to mark the schema as `.nullable()`