### PR TITLE
Fjern avsluttede behandlinger & legg inn nye statuser

### DIFF
--- a/src/pages/saksbehandling/behandlingsoversikt/ferdigeBehandlinger/FerdigeBehandlinger.tsx
+++ b/src/pages/saksbehandling/behandlingsoversikt/ferdigeBehandlinger/FerdigeBehandlinger.tsx
@@ -40,7 +40,9 @@ export const FerdigeBehandlinger = () => {
         [RestansStatus.AVSLAG]: false,
         [RestansStatus.INGEN_ENDRING]: false,
         [RestansStatus.INNVILGET]: false,
-        [RestansStatus.AVSLUTTET]: false,
+        [RestansStatus.STANS]: false,
+        [RestansStatus.GJENOPPTAK]: false,
+        [RestansStatus.OVERSENDT]: false,
     });
 
     const filtrerRestanser = (restanser: Restans[]): Restans[] => {

--- a/src/pages/saksbehandling/behandlingsoversikt/filter/Filter.tsx
+++ b/src/pages/saksbehandling/behandlingsoversikt/filter/Filter.tsx
@@ -1,4 +1,5 @@
 import { Checkbox, Label } from '@navikt/ds-react';
+import * as DateFns from 'date-fns';
 import React from 'react';
 
 import DatePicker from '~components/datePicker/DatePicker';
@@ -27,7 +28,9 @@ export type RestansResultatFilter = {
     [RestansStatus.AVSLAG]: boolean;
     [RestansStatus.INGEN_ENDRING]: boolean;
     [RestansStatus.INNVILGET]: boolean;
-    [RestansStatus.AVSLUTTET]: boolean;
+    [RestansStatus.STANS]: boolean;
+    [RestansStatus.GJENOPPTAK]: boolean;
+    [RestansStatus.OVERSENDT]: boolean;
 };
 
 export interface FilterProps {
@@ -63,15 +66,17 @@ export const Filter = ({ tilOgMedState, fraOgMedState, ...props }: FilterProps) 
                     {fraOgMedState && (
                         <DatePicker
                             label={formatMessage('fraOgMed')}
+                            dateFormat={'dd.MM.yyyy'}
                             value={fraOgMedState[0]}
-                            onChange={fraOgMedState[1]}
+                            onChange={(dato) => fraOgMedState[1](dato ? DateFns.startOfDay(dato) : dato)}
                         />
                     )}
                     {tilOgMedState && (
                         <DatePicker
                             label={formatMessage('tilOgMed')}
                             value={tilOgMedState[0]}
-                            onChange={tilOgMedState[1]}
+                            dateFormat={'dd.MM.yyyy'}
+                            onChange={(dato) => tilOgMedState[1](dato ? DateFns.endOfDay(dato) : dato)}
                             feil={
                                 tilOgMedErGyldig(fraOgMedState?.[0], tilOgMedState[0])
                                     ? undefined

--- a/src/pages/saksbehandling/restans/restanser-nb.ts
+++ b/src/pages/saksbehandling/restans/restanser-nb.ts
@@ -15,7 +15,7 @@ export const restansStatus: { [key in RestansStatus]: string } = {
     [RestansStatus.UNDER_BEHANDLING]: 'Under behandling',
     [RestansStatus.TIL_ATTESTERING]: 'Til attestering',
     [RestansStatus.UNDERKJENT]: 'Underkjent',
-    [RestansStatus.STANS]: 'Stans',
+    [RestansStatus.STANS]: 'Stanset',
     [RestansStatus.GJENOPPTAK]: 'Gjenopptatt',
     [RestansStatus.OVERSENDT]: 'Oversendt',
 };

--- a/src/pages/saksbehandling/restans/restanser-nb.ts
+++ b/src/pages/saksbehandling/restans/restanser-nb.ts
@@ -9,13 +9,15 @@ export const restansTypeMessages: { [key in RestansType]: string } = {
 export const restansStatus: { [key in RestansStatus]: string } = {
     [RestansStatus.INGEN_ENDRING]: 'Ingen endring',
     [RestansStatus.AVSLAG]: 'Avslått',
-    [RestansStatus.AVSLUTTET]: 'Avsluttet / lukket',
     [RestansStatus.INNVILGET]: 'Innvilget',
     [RestansStatus.OPPHØR]: 'Opphørt',
     [RestansStatus.NY_SØKNAD]: 'Ny søknad',
     [RestansStatus.UNDER_BEHANDLING]: 'Under behandling',
     [RestansStatus.TIL_ATTESTERING]: 'Til attestering',
     [RestansStatus.UNDERKJENT]: 'Underkjent',
+    [RestansStatus.STANS]: 'Stans',
+    [RestansStatus.GJENOPPTAK]: 'Gjenopptatt',
+    [RestansStatus.OVERSENDT]: 'Oversendt',
 };
 
 export default {

--- a/src/types/Restans.ts
+++ b/src/types/Restans.ts
@@ -23,5 +23,7 @@ export enum RestansStatus {
     OPPHØR = 'OPPHØR',
     AVSLAG = 'AVSLAG',
     INGEN_ENDRING = 'INGEN_ENDRING',
-    AVSLUTTET = 'AVSLUTTET',
+    STANS = 'STANS',
+    GJENOPPTAK = 'GJENOPPTAK',
+    OVERSENDT = 'OVERSENDT',
 }


### PR DESCRIPTION
Fom og Tom endres til starten/slutten av dagen (dette fikser bug hvis man velger samme dato for fom og tom, så vises ingenting, når det skal vises for den dagen)

nye statuser er: Stans, gjenopptak, og oversendt