### PR TITLE
Vis warning for opphør og tilbakekreving

### DIFF
--- a/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
+++ b/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
@@ -156,7 +156,13 @@ const AttesterRevurdering = (props: {
 const hentIdForWarning = (revurdering: Revurdering): Nullable<keyof typeof messages> => {
     const tilbakekreving = revurdering.tilbakekrevingsbehandling?.avgjørelse === Tilbakekrevingsavgjørelse.TILBAKEKREV;
     const opphør = revurdering.status === InformasjonsRevurderingStatus.TIL_ATTESTERING_OPPHØRT;
-    if (harSimulering(revurdering) && periodenInneholderTilbakekrevingOgAndreTyper(revurdering.simulering)) {
+    if (
+        harSimulering(revurdering) &&
+        periodenInneholderTilbakekrevingOgAndreTyper(
+            revurdering.simulering,
+            revurdering.status === InformasjonsRevurderingStatus.SIMULERT_OPPHØRT
+        )
+    ) {
         return 'tilbakekrevingFlereTyper';
     } else if (tilbakekreving && opphør) {
         return 'tilbakekrevingOgOpphør';

--- a/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
+++ b/src/pages/saksbehandling/revurdering/OppsummeringPage/RevurderingOppsummeringPage.tsx
@@ -27,6 +27,7 @@ import {
     BeregnetIngenEndring,
     BeslutningEtterForhåndsvarsling,
     InformasjonsRevurdering,
+    InformasjonsRevurderingStatus,
     SimulertRevurdering,
     UnderkjentRevurdering,
 } from '~types/Revurdering';
@@ -225,9 +226,10 @@ const RevurderingOppsummeringPage = (props: {
                         forrigeGrunnlagsdataOgVilkårsvurderinger={grunnlagsdataOgVilkårsvurderinger}
                     />
                     {harSimulering(props.revurdering) &&
-                        periodenInneholderTilbakekrevingOgAndreTyper(props.revurdering.simulering) && (
-                            <Alert variant={'warning'}>{formatMessage('tilbakekreving.alert')}</Alert>
-                        )}
+                        periodenInneholderTilbakekrevingOgAndreTyper(
+                            props.revurdering.simulering,
+                            props.revurdering.status === InformasjonsRevurderingStatus.SIMULERT_OPPHØRT
+                        ) && <Alert variant={'warning'}>{formatMessage('tilbakekreving.alert')}</Alert>}
                     {erRevurderingSimulert(props.revurdering) ||
                     erBeregnetIngenEndring(props.revurdering) ||
                     erRevurderingUnderkjent(props.revurdering) ? (

--- a/src/utils/revurdering/revurderingUtils.ts
+++ b/src/utils/revurdering/revurderingUtils.ts
@@ -163,11 +163,12 @@ export const splittAvsluttedeOgÅpneRevurderinger = (
     }));
 };
 
-export const periodenInneholderTilbakekrevingOgAndreTyper = (simulering: Simulering) =>
+export const periodenInneholderTilbakekrevingOgAndreTyper = (simulering: Simulering, erOpphør: boolean) =>
     simulering.perioder.some((periode) => periode.type === SimulertUtbetalingstype.FEILUTBETALING) &&
-    !simulering.perioder.every(
-        (periode) =>
-            periode.type === SimulertUtbetalingstype.FEILUTBETALING ||
-            periode.type === SimulertUtbetalingstype.INGEN_UTBETALING ||
-            periode.type === SimulertUtbetalingstype.UENDRET
-    );
+    (erOpphør ||
+        !simulering.perioder.every(
+            (periode) =>
+                periode.type === SimulertUtbetalingstype.FEILUTBETALING ||
+                periode.type === SimulertUtbetalingstype.INGEN_UTBETALING ||
+                periode.type === SimulertUtbetalingstype.UENDRET
+        ));


### PR DESCRIPTION
Må sjekke om revurderingen fører til opphør, da simuleringen i prod ikke gir ut ingen endringer-perioder som det gjør lokalt.
![image](https://user-images.githubusercontent.com/6595794/160838188-8146a262-b796-486a-80d4-ec95e9911033.png)

vs

![image](https://user-images.githubusercontent.com/6595794/160838233-9cbe9c91-bd85-4335-9701-88af4bf446e9.png)
