### PR TITLE
React router 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
                 "react-modal": "^3.14.4",
                 "react-redux": "^7.2.8",
                 "react-router-dom": "^5.3.0",
+                "react-router-dom-v5-compat": "^6.3.0",
                 "redux": "^4.1.2",
                 "redux-thunk": "^2.4.1",
                 "regenerator-runtime": "^0.13.9",
@@ -10619,6 +10620,39 @@
                 "react": ">=15"
             }
         },
+        "node_modules/react-router-dom-v5-compat": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz",
+            "integrity": "sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==",
+            "dependencies": {
+                "history": "^5.3.0",
+                "react-router": "6.3.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8",
+                "react-dom": ">=16.8",
+                "react-router-dom": "4 || 5"
+            }
+        },
+        "node_modules/react-router-dom-v5-compat/node_modules/history": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.7.6"
+            }
+        },
+        "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+            "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+            "dependencies": {
+                "history": "^5.2.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
+            }
+        },
         "node_modules/react-router/node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -20181,6 +20215,33 @@
                 "react-router": "5.2.1",
                 "tiny-invariant": "^1.0.2",
                 "tiny-warning": "^1.0.0"
+            }
+        },
+        "react-router-dom-v5-compat": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz",
+            "integrity": "sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==",
+            "requires": {
+                "history": "^5.3.0",
+                "react-router": "6.3.0"
+            },
+            "dependencies": {
+                "history": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+                    "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.7.6"
+                    }
+                },
+                "react-router": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+                    "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+                    "requires": {
+                        "history": "^5.2.0"
+                    }
+                }
             }
         },
         "react-shallow-renderer": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "react-modal": "^3.14.4",
         "react-redux": "^7.2.8",
         "react-router-dom": "^5.3.0",
+        "react-router-dom-v5-compat": "^6.3.0",
         "redux": "^4.1.2",
         "redux-thunk": "^2.4.1",
         "regenerator-runtime": "^0.13.9",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -28,6 +28,9 @@ const Attestering = React.lazy(() => import('~/src/pages/saksbehandling/attester
 const Drift = React.lazy(() => import('~/src/pages/drift'));
 const HomePage = React.lazy(() => import('~/src/pages/HomePage'));
 const Saksoversikt = React.lazy(() => import('~/src/pages/saksbehandling/Saksoversikt'));
+const Behandlingsoversikt = React.lazy(
+    () => import('~/src/pages/saksbehandling/behandlingsoversikt/Behandlingsoversikt')
+);
 const Soknad = React.lazy(() => import('~/src/pages/søknad'));
 
 const ScrollToTop = () => {
@@ -55,6 +58,12 @@ const Root = () => (
                                     </Route>
                                     <Route path={routes.soknad.path}>
                                         <WithDocTitle title="Søknad" Page={Soknad} />
+                                    </Route>
+                                    <Route path={routes.saksoversiktValgtSak.path}>
+                                        <WithDocTitle title="Saksbehandling" Page={Saksoversikt} />
+                                    </Route>
+                                    <Route path={routes.saksoversiktIndex.path}>
+                                        <WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />
                                     </Route>
                                     <Route path={routes.saksoversiktIndex.path}>
                                         <WithDocTitle title="Saksbehandling" Page={Saksoversikt} />

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -3,7 +3,8 @@ import * as RemoteData from '@devexperts/remote-data-ts';
 import { Heading, Link, Loader } from '@navikt/ds-react';
 import React, { useEffect, Suspense } from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter as Router, Switch, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Route, Switch, useLocation } from 'react-router-dom';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 
 import { ErrorCode } from '~src/api/apiClient';
 import { LOGIN_URL } from '~src/api/authUrl';
@@ -39,43 +40,41 @@ const ScrollToTop = () => {
     return null;
 };
 
-const Root = () => {
-    return (
-        <Provider store={Store}>
-            <ErrorBoundary>
-                <FeatureToggleProvider>
-                    <Router>
-                        <Route>
-                            <ContentWrapper>
-                                <Suspense fallback={<Loader />}>
-                                    <ScrollToTop />
-                                    <Switch>
-                                        <Route exact path={routes.home.path}>
-                                            <WithDocTitle title="Hjem" Page={HomePage} />
-                                        </Route>
-                                        <Route path={routes.soknad.path}>
-                                            <WithDocTitle title="Søknad" Page={Soknad} />
-                                        </Route>
-                                        <Route path={routes.saksoversiktIndex.path}>
-                                            <WithDocTitle title="Saksbehandling" Page={Saksoversikt} />
-                                        </Route>
-                                        <Route path={routes.attestering.path}>
-                                            <WithDocTitle title="Attestering" Page={Attestering} />
-                                        </Route>
-                                        <Route path={routes.drift.path}>
-                                            <WithDocTitle title="Drift" Page={Drift} />
-                                        </Route>
-                                        <Route>404</Route>
-                                    </Switch>
-                                </Suspense>
-                            </ContentWrapper>
-                        </Route>
-                    </Router>
-                </FeatureToggleProvider>
-            </ErrorBoundary>
-        </Provider>
-    );
-};
+const Root = () => (
+    <Provider store={Store}>
+        <ErrorBoundary>
+            <FeatureToggleProvider>
+                <BrowserRouter>
+                    <CompatRouter>
+                        <ContentWrapper>
+                            <Suspense fallback={<Loader />}>
+                                <ScrollToTop />
+                                <Switch>
+                                    <Route exact path={routes.home.path}>
+                                        <WithDocTitle title="Hjem" Page={HomePage} />
+                                    </Route>
+                                    <Route path={routes.soknad.path}>
+                                        <WithDocTitle title="Søknad" Page={Soknad} />
+                                    </Route>
+                                    <Route path={routes.saksoversiktIndex.path}>
+                                        <WithDocTitle title="Saksbehandling" Page={Saksoversikt} />
+                                    </Route>
+                                    <Route path={routes.attestering.path}>
+                                        <WithDocTitle title="Attestering" Page={Attestering} />
+                                    </Route>
+                                    <Route path={routes.drift.path}>
+                                        <WithDocTitle title="Drift" Page={Drift} />
+                                    </Route>
+                                    <Route>404</Route>
+                                </Switch>
+                            </Suspense>
+                        </ContentWrapper>
+                    </CompatRouter>
+                </BrowserRouter>
+            </FeatureToggleProvider>
+        </ErrorBoundary>
+    </Provider>
+);
 
 const ContentWrapper: React.FC = (props) => {
     const loggedInUser = useAppSelector((s) => s.me.me);

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -4,7 +4,7 @@ import { Heading, Link, Loader } from '@navikt/ds-react';
 import React, { useEffect, Suspense } from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Switch, useLocation } from 'react-router-dom';
-import { CompatRouter } from 'react-router-dom-v5-compat';
+import { CompatRouter, CompatRoute } from 'react-router-dom-v5-compat';
 
 import { ErrorCode } from '~src/api/apiClient';
 import { LOGIN_URL } from '~src/api/authUrl';
@@ -53,9 +53,9 @@ const Root = () => (
                             <Suspense fallback={<Loader />}>
                                 <ScrollToTop />
                                 <Switch>
-                                    <Route exact path={routes.home.path}>
+                                    <CompatRoute exact path={routes.home.path}>
                                         <WithDocTitle title="Hjem" Page={HomePage} />
-                                    </Route>
+                                    </CompatRoute>
                                     <Route path={routes.soknad.path}>
                                         <WithDocTitle title="Søknad" Page={Soknad} />
                                     </Route>
@@ -65,16 +65,13 @@ const Root = () => (
                                     <Route path={routes.saksoversiktIndex.path}>
                                         <WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />
                                     </Route>
-                                    <Route path={routes.saksoversiktIndex.path}>
-                                        <WithDocTitle title="Saksbehandling" Page={Saksoversikt} />
-                                    </Route>
                                     <Route path={routes.attestering.path}>
                                         <WithDocTitle title="Attestering" Page={Attestering} />
                                     </Route>
-                                    <Route path={routes.drift.path}>
+                                    <CompatRoute path={routes.drift.path}>
                                         <WithDocTitle title="Drift" Page={Drift} />
-                                    </Route>
-                                    <Route>404</Route>
+                                    </CompatRoute>
+                                    <CompatRouter>404</CompatRouter>
                                 </Switch>
                             </Suspense>
                         </ContentWrapper>

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -49,14 +49,14 @@ export const søkandskvittering: Route<never> = {
 
 //-------------Saksoversikt--------------------------------
 export const saksoversiktIndex: Route<never> = {
-    path: '/saksoversikt/:sakId?/:behandlingId?/:meny?/:vilkar?/',
+    path: '/saksoversikt/',
     createURL: () => '/saksoversikt',
 };
 
 export const saksoversiktValgtSak: Route<{
     sakId: string;
 }> = {
-    path: '/saksoversikt/:sakId/:behandlingId?/:meny?/',
+    path: '/saksoversikt/:sakId/',
     createURL: (args) => `/saksoversikt/${args.sakId}`,
 };
 
@@ -148,14 +148,24 @@ export const attesterKlage: Route<{ sakId: string; klageId: string }> = {
 };
 
 //---------------Stans------------------------------
-export const stansRoute: Route<{ sakId: string; revurderingId?: string }> = {
-    path: `/saksoversikt/:sakId/stans/:revurderingId?`,
-    createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/stans/${revurderingId ?? ''}`,
+export const stansRoot: Route<{ sakId: string }> = {
+    path: `/saksoversikt/:sakId/stans`,
+    createURL: ({ sakId }) => `/saksoversikt/${sakId}/stans`,
+};
+
+export const stansRoute: Route<{ sakId: string; revurderingId: string }> = {
+    path: `/saksoversikt/:sakId/stans/:revurderingId`,
+    createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/stans/${revurderingId}`,
 };
 
 export const stansOppsummeringRoute: Route<{ sakId: string; revurderingId: string }> = {
     path: '/saksoversikt/:sakId/stans/:revurderingId/oppsummering',
     createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/stans/${revurderingId}/oppsummering`,
+};
+
+export const gjenopptaStansRoot: Route<{ sakId: string }> = {
+    path: '/saksoversikt/:sakId/gjenoppta/',
+    createURL: ({ sakId }) => `/saksoversikt/${sakId}/gjenoppta/`,
 };
 
 export const gjenopptaStansRoute: Route<{ sakId: string; revurderingId?: string }> = {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -103,9 +103,9 @@ export const saksbehandlingSendTilAttestering: Route<{
 export const saksbehandlingVilkårsvurdering: Route<{
     sakId: string;
     behandlingId: string;
-    vilkar?: Vilkårtype;
+    vilkar: Vilkårtype;
 }> = {
-    path: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vilkår}/:vilkar?/`,
+    path: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vilkår}/:vilkar/`,
     createURL: ({ vilkar = Vilkårtype.Virkningstidspunkt, ...args }) =>
         `/saksoversikt/${args.sakId}/${args.behandlingId}/${SaksbehandlingMenyvalg.Vilkår}/${vilkar}`,
 };

--- a/src/pages/klage/Klage.tsx
+++ b/src/pages/klage/Klage.tsx
@@ -1,6 +1,7 @@
 import { Heading } from '@navikt/ds-react';
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import Framdriftsindikator from '~src/components/framdriftsindikator/Framdriftsindikator';
 import { useI18n } from '~src/lib/i18n';
@@ -48,18 +49,6 @@ const Klage = (props: { sak: Sak }) => {
         });
     };
 
-    const pathsForFramdriftsindikator = lagFramdriftsindikatorLinjer()
-        .filter(
-            (l) =>
-                l.url !==
-                Routes.klage.createURL({
-                    sakId: props.sak.id,
-                    klageId: klage.id,
-                    steg: KlageSteg.Oppsummering,
-                })
-        )
-        .map((l) => l.url);
-
     return (
         <div className={styles.pageContainer}>
             <Switch>
@@ -68,11 +57,16 @@ const Klage = (props: { sak: Sak }) => {
                         {formatMessage('page.tittel')}
                     </Heading>
                     <div className={styles.klageContainerMedFramdriftsindikator}>
-                        <Route path={pathsForFramdriftsindikator}>
-                            <Framdriftsindikator aktivId={urlParams.steg} elementer={lagFramdriftsindikatorLinjer()} />
-                        </Route>
+                        {urlParams.steg !== KlageSteg.Oppsummering && (
+                            <CompatRoute path={Routes.klage.path}>
+                                <Framdriftsindikator
+                                    aktivId={urlParams.steg}
+                                    elementer={lagFramdriftsindikatorLinjer()}
+                                />
+                            </CompatRoute>
+                        )}
 
-                        <Route
+                        <CompatRoute
                             path={Routes.klage.createURL({
                                 sakId: props.sak.id,
                                 klageId: klage.id,
@@ -80,8 +74,8 @@ const Klage = (props: { sak: Sak }) => {
                             })}
                         >
                             <VurderFormkrav sakId={props.sak.id} vedtaker={props.sak.vedtak} klage={klage} />
-                        </Route>
-                        <Route
+                        </CompatRoute>
+                        <CompatRoute
                             path={Routes.klage.createURL({
                                 sakId: props.sak.id,
                                 klageId: klage.id,
@@ -89,8 +83,8 @@ const Klage = (props: { sak: Sak }) => {
                             })}
                         >
                             <VurderingAvKlage sakId={props.sak.id} klage={klage} />
-                        </Route>
-                        <Route
+                        </CompatRoute>
+                        <CompatRoute
                             path={Routes.klage.createURL({
                                 sakId: props.sak.id,
                                 klageId: klage.id,
@@ -98,18 +92,18 @@ const Klage = (props: { sak: Sak }) => {
                             })}
                         >
                             <AvvistKlage sakId={props.sak.id} klage={klage} />
-                        </Route>
+                        </CompatRoute>
                     </div>
-
-                    <Route
+                    <CompatRoute
                         path={Routes.klage.createURL({
                             sakId: props.sak.id,
                             klageId: klage.id,
                             steg: KlageSteg.Oppsummering,
                         })}
+                        exact
                     >
                         <SendKlageTilAttestering sakId={props.sak.id} klage={klage} vedtaker={props.sak.vedtak} />
-                    </Route>
+                    </CompatRoute>
                 </>
             </Switch>
         </div>

--- a/src/pages/klage/Klage.tsx
+++ b/src/pages/klage/Klage.tsx
@@ -1,7 +1,5 @@
 import { Heading } from '@navikt/ds-react';
 import React from 'react';
-import { Switch } from 'react-router-dom';
-import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import Framdriftsindikator from '~src/components/framdriftsindikator/Framdriftsindikator';
 import { useI18n } from '~src/lib/i18n';
@@ -51,61 +49,22 @@ const Klage = (props: { sak: Sak }) => {
 
     return (
         <div className={styles.pageContainer}>
-            <Switch>
-                <>
-                    <Heading level="1" size="large" className={styles.pageTittel}>
-                        {formatMessage('page.tittel')}
-                    </Heading>
-                    <div className={styles.klageContainerMedFramdriftsindikator}>
-                        {urlParams.steg !== KlageSteg.Oppsummering && (
-                            <CompatRoute path={Routes.klage.path}>
-                                <Framdriftsindikator
-                                    aktivId={urlParams.steg}
-                                    elementer={lagFramdriftsindikatorLinjer()}
-                                />
-                            </CompatRoute>
-                        )}
-
-                        <CompatRoute
-                            path={Routes.klage.createURL({
-                                sakId: props.sak.id,
-                                klageId: klage.id,
-                                steg: KlageSteg.Formkrav,
-                            })}
-                        >
-                            <VurderFormkrav sakId={props.sak.id} vedtaker={props.sak.vedtak} klage={klage} />
-                        </CompatRoute>
-                        <CompatRoute
-                            path={Routes.klage.createURL({
-                                sakId: props.sak.id,
-                                klageId: klage.id,
-                                steg: KlageSteg.Vurdering,
-                            })}
-                        >
-                            <VurderingAvKlage sakId={props.sak.id} klage={klage} />
-                        </CompatRoute>
-                        <CompatRoute
-                            path={Routes.klage.createURL({
-                                sakId: props.sak.id,
-                                klageId: klage.id,
-                                steg: KlageSteg.Avvisning,
-                            })}
-                        >
-                            <AvvistKlage sakId={props.sak.id} klage={klage} />
-                        </CompatRoute>
-                    </div>
-                    <CompatRoute
-                        path={Routes.klage.createURL({
-                            sakId: props.sak.id,
-                            klageId: klage.id,
-                            steg: KlageSteg.Oppsummering,
-                        })}
-                        exact
-                    >
-                        <SendKlageTilAttestering sakId={props.sak.id} klage={klage} vedtaker={props.sak.vedtak} />
-                    </CompatRoute>
-                </>
-            </Switch>
+            <Heading level="1" size="large" className={styles.pageTittel}>
+                {formatMessage('page.tittel')}
+            </Heading>
+            <div className={styles.klageContainerMedFramdriftsindikator}>
+                {urlParams.steg !== KlageSteg.Oppsummering && (
+                    <Framdriftsindikator aktivId={urlParams.steg} elementer={lagFramdriftsindikatorLinjer()} />
+                )}
+                {urlParams.steg == KlageSteg.Formkrav && (
+                    <VurderFormkrav sakId={props.sak.id} vedtaker={props.sak.vedtak} klage={klage} />
+                )}
+                {urlParams.steg == KlageSteg.Vurdering && <VurderingAvKlage sakId={props.sak.id} klage={klage} />}
+                {urlParams.steg == KlageSteg.Avvisning && <AvvistKlage sakId={props.sak.id} klage={klage} />}
+                {urlParams.steg == KlageSteg.Oppsummering && (
+                    <SendKlageTilAttestering sakId={props.sak.id} klage={klage} vedtaker={props.sak.vedtak} />
+                )}
+            </div>
         </div>
     );
 };

--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -14,13 +14,15 @@ import * as sakSlice from '~src/features/saksoversikt/sak.slice';
 import { pipe } from '~src/lib/fp';
 import { Languages } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
+import GjenopptaOppsummering from '~src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { erInformasjonsRevurdering } from '~src/utils/revurdering/revurderingUtils';
 
 import messages from './saksoversikt-nb';
 import * as styles from './saksoversikt.module.less';
-import Gjenoppta from './stans/gjenoppta/gjenoppta';
 
+const Gjenoppta = React.lazy(() => import('./stans/gjenoppta/gjenoppta'));
+const StansOppsummering = React.lazy(() => import('~src/pages/saksbehandling/stans/stansOppsummering'));
 const Vilkår = React.lazy(() => import('./søknadsbehandling/vilkår/Vilkår'));
 const SendTilAttesteringPage = React.lazy(
     () => import('./søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage')
@@ -62,118 +64,121 @@ const Saksoversikt = () => {
 
     return (
         <IntlProvider locale={Languages.nb} messages={messages}>
-            <Switch>
-                <Route path={Routes.saksoversiktValgtSak.path}>
-                    {pipe(
-                        RemoteData.combine(søker, sak),
-                        RemoteData.fold(
-                            () => null,
-                            () => <Loader />,
-                            () =>
-                                RemoteData.isFailure(søker) ? (
-                                    <ApiErrorAlert error={søker.error} />
-                                ) : (
-                                    RemoteData.isFailure(sak) && <ApiErrorAlert error={sak.error} />
-                                ),
-                            ([søker, sak]) => (
-                                <>
-                                    <Personlinje
-                                        søker={søker}
-                                        sakInfo={{ sakId: sak.id, saksnummer: sak.saksnummer }}
-                                    />
-                                    <div className={styles.container}>
-                                        <Switch>
-                                            <CompatRoute path={Routes.klageOpprett.createURL({ sakId: sak.id })}>
-                                                <div className={styles.mainContent}>
-                                                    <OpprettKlage sak={sak} />
-                                                </div>
-                                            </CompatRoute>
-                                            <Route path={Routes.klage.path}>
-                                                <div className={styles.mainContent}>
-                                                    <Klage sak={sak} />
-                                                </div>
-                                            </Route>
-                                            <Route path={Routes.stansRoot.path}>
-                                                <div className={styles.mainContent}>
-                                                    <StansPage sak={sak} />
-                                                </div>
-                                            </Route>
-                                            <Route path={Routes.gjenopptaStansRoot.path}>
-                                                <div className={styles.mainContent}>
-                                                    <Gjenoppta sak={sak} />
-                                                </div>
-                                            </Route>
-                                            <Route path={Routes.avsluttBehandling.path}>
-                                                <div className={styles.mainContent}>
-                                                    <AvsluttBehandling sak={sak} />
-                                                </div>
-                                            </Route>
-                                            <Route path={Routes.revurderValgtSak.path}>
-                                                <div className={styles.mainContent}>
-                                                    <Revurdering
-                                                        sakId={sak.id}
-                                                        utbetalinger={sak.utbetalinger}
-                                                        informasjonsRevurderinger={sak.revurderinger.filter(
-                                                            erInformasjonsRevurdering
-                                                        )}
-                                                    />
-                                                </div>
-                                            </Route>
-                                            <Route path={Routes.revurderValgtRevurdering.path}>
-                                                <div className={styles.mainContent}>
-                                                    <Revurdering
-                                                        sakId={sak.id}
-                                                        utbetalinger={sak.utbetalinger}
-                                                        informasjonsRevurderinger={sak.revurderinger.filter(
-                                                            erInformasjonsRevurdering
-                                                        )}
-                                                    />
-                                                </div>
-                                            </Route>
-                                            <CompatRoute path={Routes.vedtaksoppsummering.path}>
-                                                <div className={styles.mainContent}>
-                                                    <Vedtaksoppsummering sak={sak} />
-                                                </div>
-                                            </CompatRoute>
-                                            <Route path={Routes.saksoversiktValgtBehandling.path}>
-                                                <SøknadsbehandlingDraftProvider>
-                                                    <div className={styles.mainContent}>
-                                                        <Switch>
-                                                            <Route path={Routes.saksbehandlingSendTilAttestering.path}>
-                                                                <SendTilAttesteringPage sak={sak} />
-                                                            </Route>
-                                                            <Route path={Routes.saksbehandlingVilkårsvurdering.path}>
-                                                                <Vilkår sak={sak} søker={søker} />
-                                                            </Route>
-                                                        </Switch>
-                                                    </div>
-                                                </SøknadsbehandlingDraftProvider>
-                                            </Route>
-                                            <CompatRoute path={Routes.alleDokumenterForSak.path}>
-                                                <div className={styles.mainContent}>
-                                                    <DokumenterPage sak={sak} />
-                                                </div>
-                                            </CompatRoute>
-                                            <CompatRoute path={Routes.kontrollsamtale.path} exact>
-                                                <div className={styles.mainContent}>
-                                                    <NyDatoForKontrollsamtale
-                                                        sakId={sak.id}
-                                                        kanKalleInn={!isEmpty(sak.utbetalinger)}
-                                                    />
-                                                </div>
-                                            </CompatRoute>
+            {pipe(
+                RemoteData.combine(søker, sak),
+                RemoteData.fold(
+                    () => null,
+                    () => <Loader />,
+                    () =>
+                        RemoteData.isFailure(søker) ? (
+                            <ApiErrorAlert error={søker.error} />
+                        ) : (
+                            RemoteData.isFailure(sak) && <ApiErrorAlert error={sak.error} />
+                        ),
+                    ([søker, sak]) => (
+                        <>
+                            <Personlinje søker={søker} sakInfo={{ sakId: sak.id, saksnummer: sak.saksnummer }} />
+                            <div className={styles.container}>
+                                <Switch>
+                                    <CompatRoute path={Routes.klageOpprett.createURL({ sakId: sak.id })}>
+                                        <div className={styles.mainContent}>
+                                            <OpprettKlage sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.klage.path}>
+                                        <div className={styles.mainContent}>
+                                            <Klage sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.stansOppsummeringRoute.path}>
+                                        <div className={styles.mainContent}>
+                                            <StansOppsummering sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.stansRoot.path}>
+                                        <div className={styles.mainContent}>
+                                            <StansPage sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.gjenopptaStansOppsummeringRoute.path}>
+                                        <div className={styles.mainContent}>
+                                            <GjenopptaOppsummering sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.gjenopptaStansRoot.path}>
+                                        <div className={styles.mainContent}>
+                                            <Gjenoppta sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.avsluttBehandling.path}>
+                                        <div className={styles.mainContent}>
+                                            <AvsluttBehandling sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <Route path={Routes.revurderValgtSak.path}>
+                                        <div className={styles.mainContent}>
+                                            <Revurdering
+                                                sakId={sak.id}
+                                                utbetalinger={sak.utbetalinger}
+                                                informasjonsRevurderinger={sak.revurderinger.filter(
+                                                    erInformasjonsRevurdering
+                                                )}
+                                            />
+                                        </div>
+                                    </Route>
+                                    <Route path={Routes.revurderValgtRevurdering.path}>
+                                        <div className={styles.mainContent}>
+                                            <Revurdering
+                                                sakId={sak.id}
+                                                utbetalinger={sak.utbetalinger}
+                                                informasjonsRevurderinger={sak.revurderinger.filter(
+                                                    erInformasjonsRevurdering
+                                                )}
+                                            />
+                                        </div>
+                                    </Route>
+                                    <CompatRoute path={Routes.vedtaksoppsummering.path}>
+                                        <div className={styles.mainContent}>
+                                            <Vedtaksoppsummering sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <Route path={Routes.saksoversiktValgtBehandling.path}>
+                                        <SøknadsbehandlingDraftProvider>
+                                            <div className={styles.mainContent}>
+                                                <Switch>
+                                                    <CompatRoute path={Routes.saksbehandlingSendTilAttestering.path}>
+                                                        <SendTilAttesteringPage sak={sak} />
+                                                    </CompatRoute>
+                                                    <CompatRoute path={Routes.saksbehandlingVilkårsvurdering.path}>
+                                                        <Vilkår sak={sak} søker={søker} />
+                                                    </CompatRoute>
+                                                </Switch>
+                                            </div>
+                                        </SøknadsbehandlingDraftProvider>
+                                    </Route>
+                                    <CompatRoute path={Routes.alleDokumenterForSak.path}>
+                                        <div className={styles.mainContent}>
+                                            <DokumenterPage sak={sak} />
+                                        </div>
+                                    </CompatRoute>
+                                    <CompatRoute path={Routes.kontrollsamtale.path} exact>
+                                        <div className={styles.mainContent}>
+                                            <NyDatoForKontrollsamtale
+                                                sakId={sak.id}
+                                                kanKalleInn={!isEmpty(sak.utbetalinger)}
+                                            />
+                                        </div>
+                                    </CompatRoute>
 
-                                            <Route path={Routes.saksoversiktValgtSak.path}>
-                                                <Sakintro sak={sak} />
-                                            </Route>
-                                        </Switch>
-                                    </div>
-                                </>
-                            )
-                        )
-                    )}
-                </Route>
-            </Switch>
+                                    <CompatRoute path={Routes.saksoversiktValgtSak.path}>
+                                        <Sakintro sak={sak} />
+                                    </CompatRoute>
+                                </Switch>
+                            </div>
+                        </>
+                    )
+                )
+            )}
         </IntlProvider>
     );
 };

--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -4,6 +4,7 @@ import { isEmpty } from 'fp-ts/lib/Array';
 import React, { useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import { Route, Switch, useHistory } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import Personlinje from '~src/components/personlinje/Personlinje';
@@ -13,7 +14,6 @@ import * as sakSlice from '~src/features/saksoversikt/sak.slice';
 import { pipe } from '~src/lib/fp';
 import { Languages } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
-import { Behandlingsoversikt } from '~src/pages/saksbehandling/behandlingsoversikt/Behandlingsoversikt';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { erInformasjonsRevurdering } from '~src/utils/revurdering/revurderingUtils';
 
@@ -83,22 +83,22 @@ const Saksoversikt = () => {
                                     />
                                     <div className={styles.container}>
                                         <Switch>
-                                            <Route path={Routes.klageOpprett.createURL({ sakId: sak.id })}>
+                                            <CompatRoute path={Routes.klageOpprett.createURL({ sakId: sak.id })}>
                                                 <div className={styles.mainContent}>
                                                     <OpprettKlage sak={sak} />
                                                 </div>
-                                            </Route>
+                                            </CompatRoute>
                                             <Route path={Routes.klage.path}>
                                                 <div className={styles.mainContent}>
                                                     <Klage sak={sak} />
                                                 </div>
                                             </Route>
-                                            <Route path={Routes.stansRoute.path}>
+                                            <Route path={Routes.stansRoot.path}>
                                                 <div className={styles.mainContent}>
                                                     <StansPage sak={sak} />
                                                 </div>
                                             </Route>
-                                            <Route path={Routes.gjenopptaStansRoute.path}>
+                                            <Route path={Routes.gjenopptaStansRoot.path}>
                                                 <div className={styles.mainContent}>
                                                     <Gjenoppta sak={sak} />
                                                 </div>
@@ -130,11 +130,11 @@ const Saksoversikt = () => {
                                                     />
                                                 </div>
                                             </Route>
-                                            <Route path={Routes.vedtaksoppsummering.path}>
+                                            <CompatRoute path={Routes.vedtaksoppsummering.path}>
                                                 <div className={styles.mainContent}>
                                                     <Vedtaksoppsummering sak={sak} />
                                                 </div>
-                                            </Route>
+                                            </CompatRoute>
                                             <Route path={Routes.saksoversiktValgtBehandling.path}>
                                                 <SøknadsbehandlingDraftProvider>
                                                     <div className={styles.mainContent}>
@@ -149,21 +149,21 @@ const Saksoversikt = () => {
                                                     </div>
                                                 </SøknadsbehandlingDraftProvider>
                                             </Route>
-                                            <Route path={Routes.alleDokumenterForSak.path}>
+                                            <CompatRoute path={Routes.alleDokumenterForSak.path}>
                                                 <div className={styles.mainContent}>
                                                     <DokumenterPage sak={sak} />
                                                 </div>
-                                            </Route>
-                                            <Route path={Routes.kontrollsamtale.path}>
+                                            </CompatRoute>
+                                            <CompatRoute path={Routes.kontrollsamtale.path} exact>
                                                 <div className={styles.mainContent}>
                                                     <NyDatoForKontrollsamtale
                                                         sakId={sak.id}
                                                         kanKalleInn={!isEmpty(sak.utbetalinger)}
                                                     />
                                                 </div>
-                                            </Route>
+                                            </CompatRoute>
 
-                                            <Route path="*">
+                                            <Route path={Routes.saksoversiktValgtSak.path}>
                                                 <Sakintro sak={sak} />
                                             </Route>
                                         </Switch>
@@ -172,9 +172,6 @@ const Saksoversikt = () => {
                             )
                         )
                     )}
-                </Route>
-                <Route path={Routes.saksoversiktIndex.path}>
-                    <Behandlingsoversikt sak={sak} søker={søker} />
                 </Route>
             </Switch>
         </IntlProvider>

--- a/src/pages/saksbehandling/attestering/Attestering.tsx
+++ b/src/pages/saksbehandling/attestering/Attestering.tsx
@@ -1,7 +1,8 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { Alert, Loader } from '@navikt/ds-react';
 import React, { useEffect } from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import Personlinje from '~src/components/personlinje/Personlinje';
 import * as personSlice from '~src/features/person/person.slice';
@@ -53,22 +54,22 @@ const Attestering = () => {
                     />
                     <div className={styles.attesteringsKomponentContainer}>
                         <Switch>
-                            <Route path={Routes.attesterSøknadsbehandling.path}>
+                            <CompatRoute path={Routes.attesterSøknadsbehandling.path}>
                                 <AttesterSøknadsbehandling sak={sakValue} søker={søkerValue} />
-                            </Route>
-                            <Route path={Routes.attesterRevurdering.path}>
+                            </CompatRoute>
+                            <CompatRoute path={Routes.attesterRevurdering.path}>
                                 <AttesterRevurdering
                                     sakInfo={{ sakId: sakValue.id, saksnummer: sakValue.saksnummer }}
                                     informasjonsRevurderinger={sakValue.revurderinger.filter(erInformasjonsRevurdering)}
                                 />
-                            </Route>
-                            <Route path={Routes.attesterKlage.path}>
+                            </CompatRoute>
+                            <CompatRoute path={Routes.attesterKlage.path}>
                                 <AttesterKlage
                                     sakId={sakValue.id}
                                     klager={sakValue.klager}
                                     vedtaker={sakValue.vedtak}
                                 />
-                            </Route>
+                            </CompatRoute>
                         </Switch>
                     </div>
                 </div>

--- a/src/pages/saksbehandling/behandlingsoversikt/Behandlingsoversikt.tsx
+++ b/src/pages/saksbehandling/behandlingsoversikt/Behandlingsoversikt.tsx
@@ -1,23 +1,19 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
 import { Heading } from '@navikt/ds-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import classNames from 'classnames';
 import * as A from 'fp-ts/Array';
 import React, { useEffect, useState } from 'react';
 
-import { Person } from '~src/api/personApi';
 import { hentReguleringsstatus } from '~src/api/reguleringApi';
 import { Person as PersonIkon } from '~src/assets/Icons';
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import Personsøk from '~src/components/Personsøk/Personsøk';
 import * as personSlice from '~src/features/person/person.slice';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
 import { pipe } from '~src/lib/fp';
-import { ApiResult, useApiCall } from '~src/lib/hooks';
+import { useApiCall } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
-import { useAppDispatch } from '~src/redux/Store';
+import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { Regulering, Reguleringstype } from '~src/types/Regulering';
-import { Sak } from '~src/types/Sak';
 
 import messages from './behandlingsoversikt-nb';
 import * as styles from './behandlingsoversikt.module.less';
@@ -37,11 +33,6 @@ const splittAutomatiskeOgManuelleReguleringer = (reguleringer: Regulering[]) => 
     );
 };
 
-interface Props {
-    søker: ApiResult<Person>;
-    sak: ApiResult<Sak>;
-}
-
 enum Tab {
     ÅPNE_BEHANDLINGER = 'ÅPNE_BEHANDLINGER',
     FERDIGE_BEHANDLINGER = 'FERDIGE_BEHANDLINGER',
@@ -49,8 +40,9 @@ enum Tab {
     REGULERING = 'REGULERING',
 }
 
-export const Behandlingsoversikt = ({ sak, søker }: Props) => {
+const Behandlingsoversikt = () => {
     const dispatch = useAppDispatch();
+    const { søker } = useAppSelector((s) => ({ søker: s.søker.søker }));
     const { formatMessage } = useI18n({ messages });
     const [, hentReguleringer] = useApiCall(hentReguleringsstatus);
     const [reguleringer, setReguleringer] = useState<{ automatiske: Regulering[]; manuelle: Regulering[] }>({
@@ -102,9 +94,6 @@ export const Behandlingsoversikt = ({ sak, søker }: Props) => {
                     }}
                     person={søker}
                 />
-                {RemoteData.isFailure(sak) && !RemoteData.isFailure(søker) && (
-                    <ApiErrorAlert className={styles.alert} error={sak.error} />
-                )}
             </div>
 
             <Tabs.Root
@@ -144,3 +133,5 @@ export const Behandlingsoversikt = ({ sak, søker }: Props) => {
         </div>
     );
 };
+
+export default Behandlingsoversikt;

--- a/src/pages/saksbehandling/revurdering/Revurdering.tsx
+++ b/src/pages/saksbehandling/revurdering/Revurdering.tsx
@@ -4,7 +4,8 @@ import * as A from 'fp-ts/Array';
 import { pipe } from 'fp-ts/lib/function';
 import * as O from 'fp-ts/Option';
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import { ApiError } from '~src/api/apiClient';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
@@ -123,7 +124,7 @@ const RevurderingPage = (props: {
     return (
         <div className={styles.pageContainer}>
             <Switch>
-                <Route
+                <CompatRoute
                     path={Routes.revurderValgtSak.createURL({
                         sakId: props.sakId,
                     })}
@@ -133,7 +134,7 @@ const RevurderingPage = (props: {
                         utbetalinger={props.utbetalinger}
                         informasjonsRevurdering={undefined}
                     />
-                </Route>
+                </CompatRoute>
                 {!påbegyntRevurdering ? (
                     <Alert variant="error">{formatMessage('feil.fantIkkeRevurdering')}</Alert>
                 ) : (
@@ -141,20 +142,20 @@ const RevurderingPage = (props: {
                         <Heading level="1" size="large" className={styles.tittel}>
                             {formatMessage('revurdering.tittel')}
                         </Heading>
-                        <Route path={createRevurderingsPath(RevurderingSteg.Periode)}>
+                        <CompatRoute path={createRevurderingsPath(RevurderingSteg.Periode)}>
                             <RevurderingIntroPage
                                 sakId={props.sakId}
                                 utbetalinger={props.utbetalinger}
                                 informasjonsRevurdering={påbegyntRevurdering}
                             />
-                        </Route>
+                        </CompatRoute>
                         <div className={styles.sideMedFramdriftsindikatorContainer}>
-                            <Route path={alleSteg.map((s) => s.url)}>
+                            {alleSteg.map((s) => s.id).includes(urlParams.steg) && (
                                 <Framdriftsindikator
                                     aktivId={urlParams.steg}
                                     elementer={aktiveSteg(påbegyntRevurdering)}
                                 />
-                            </Route>
+                            )}
                             {aktiveSteg(påbegyntRevurdering).map((el, idx) => {
                                 const forrigeUrl = aktiveSteg(påbegyntRevurdering)[idx - 1]?.url;
                                 const forrige = forrigeUrl
@@ -164,7 +165,7 @@ const RevurderingPage = (props: {
                                     aktiveSteg(revurdering)[idx + 1]?.url ??
                                     createRevurderingsPath(RevurderingSteg.Oppsummering);
                                 return (
-                                    <Route path={el.url} key={el.id}>
+                                    <CompatRoute path={el.url} key={el.id}>
                                         <RevurderingstegPage
                                             steg={el.id}
                                             sakId={props.sakId}
@@ -174,11 +175,11 @@ const RevurderingPage = (props: {
                                             nesteUrl={nesteUrl}
                                             avsluttUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })}
                                         />
-                                    </Route>
+                                    </CompatRoute>
                                 );
                             })}
                         </div>
-                        <Route path={createRevurderingsPath(RevurderingSteg.Oppsummering)}>
+                        <CompatRoute path={createRevurderingsPath(RevurderingSteg.Oppsummering)}>
                             <RevurderingOppsummeringPage
                                 sakId={props.sakId}
                                 revurdering={påbegyntRevurdering}
@@ -192,7 +193,7 @@ const RevurderingPage = (props: {
                                 }
                                 grunnlagsdataOgVilkårsvurderinger={grunnlag}
                             />
-                        </Route>
+                        </CompatRoute>
                     </>
                 )}
             </Switch>

--- a/src/pages/saksbehandling/sakintro/SøknadsLister.tsx
+++ b/src/pages/saksbehandling/sakintro/SøknadsLister.tsx
@@ -18,6 +18,7 @@ import * as Routes from '~src/lib/routes';
 import { Behandling } from '~src/types/Behandling';
 import { Sak } from '~src/types/Sak';
 import { LukkSøknadBegrunnelse, Søknad } from '~src/types/Søknad';
+import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 import {
     erIverksatt,
     erTilAttestering,
@@ -194,6 +195,7 @@ const StartSøknadsbehandlingKnapper = (props: { sakId: string; søknadId: strin
                             (response) => {
                                 history.push(
                                     Routes.saksbehandlingVilkårsvurdering.createURL({
+                                        vilkar: Vilkårtype.Virkningstidspunkt,
                                         sakId: props.sakId,
                                         behandlingId: response.id,
                                     })

--- a/src/pages/saksbehandling/sakintro/Utbetalinger.tsx
+++ b/src/pages/saksbehandling/sakintro/Utbetalinger.tsx
@@ -90,7 +90,7 @@ export const Utbetalinger = (props: {
                                 <Button
                                     variant="danger"
                                     size="small"
-                                    onClick={() => history.push(Routes.stansRoute.createURL({ sakId: props.sakId }))}
+                                    onClick={() => history.push(Routes.stansRoot.createURL({ sakId: props.sakId }))}
                                 >
                                     {formatMessage('display.utbetalingsperiode.stoppUtbetaling')}
                                 </Button>

--- a/src/pages/saksbehandling/stans/Stans.tsx
+++ b/src/pages/saksbehandling/stans/Stans.tsx
@@ -3,8 +3,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Heading, Loader, Select, Textarea } from '@navikt/ds-react';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Switch, useHistory } from 'react-router-dom';
-import { CompatRoute } from 'react-router-dom-v5-compat';
+import { useHistory } from 'react-router-dom';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import DatePicker from '~src/components/datePicker/DatePicker';
@@ -20,7 +19,6 @@ import { Sak } from '~src/types/Sak';
 
 import messages from './stans-nb';
 import * as styles from './stans.module.less';
-import StansOppsummering from './stansOppsummering';
 
 interface Props {
     sak: Sak;
@@ -103,95 +101,81 @@ const Stans = (props: Props) => {
     };
 
     return (
-        <Switch>
-            <CompatRoute path={Routes.stansOppsummeringRoute.path}>
-                <Heading level="1" size="large" className={styles.tittel}>
-                    {formatMessage('stans.tittel')}
-                </Heading>
-                <StansOppsummering sak={props.sak} />
-            </CompatRoute>
-            <CompatRoute path={Routes.stansRoot.path}>
-                <form className={styles.pageContainer} onSubmit={form.handleSubmit((values) => handleSubmit(values))}>
-                    <Heading level="1" size="large" className={styles.tittel}>
-                        {formatMessage('stans.tittel')}
-                    </Heading>
-                    <div className={styles.content}>
-                        <Controller
-                            control={form.control}
-                            name="årsak"
-                            render={({ field, fieldState }) => (
-                                <Select
-                                    error={fieldState.error?.message}
-                                    value={field.value ?? undefined}
-                                    onChange={field.onChange}
-                                    label={formatMessage('stans.årsak.tittel')}
-                                >
-                                    <option>{formatMessage('stans.årsak.label')}</option>
-                                    <option value={OpprettetRevurderingGrunn.MANGLENDE_KONTROLLERKLÆRING}>
-                                        {formatMessage(OpprettetRevurderingGrunn.MANGLENDE_KONTROLLERKLÆRING)}
-                                    </option>
-                                </Select>
-                            )}
+        <form className={styles.pageContainer} onSubmit={form.handleSubmit((values) => handleSubmit(values))}>
+            <Heading level="1" size="large" className={styles.tittel}>
+                {formatMessage('stans.tittel')}
+            </Heading>
+            <div className={styles.content}>
+                <Controller
+                    control={form.control}
+                    name="årsak"
+                    render={({ field, fieldState }) => (
+                        <Select
+                            error={fieldState.error?.message}
+                            value={field.value ?? undefined}
+                            onChange={field.onChange}
+                            label={formatMessage('stans.årsak.tittel')}
+                        >
+                            <option>{formatMessage('stans.årsak.label')}</option>
+                            <option value={OpprettetRevurderingGrunn.MANGLENDE_KONTROLLERKLÆRING}>
+                                {formatMessage(OpprettetRevurderingGrunn.MANGLENDE_KONTROLLERKLÆRING)}
+                            </option>
+                        </Select>
+                    )}
+                />
+                <Controller
+                    control={form.control}
+                    name="stansDato"
+                    render={({ field, fieldState }) => (
+                        <DatePicker
+                            label={formatMessage('stans.dato.label')}
+                            dateFormat="MM/yyyy"
+                            showMonthYearPicker
+                            isClearable
+                            autoComplete="off"
+                            value={field.value}
+                            onChange={(date: Date | null) => field.onChange(date)}
+                            feil={getDateErrorMessage(fieldState.error)}
                         />
-                        <Controller
-                            control={form.control}
-                            name="stansDato"
-                            render={({ field, fieldState }) => (
-                                <DatePicker
-                                    label={formatMessage('stans.dato.label')}
-                                    dateFormat="MM/yyyy"
-                                    showMonthYearPicker
-                                    isClearable
-                                    autoComplete="off"
-                                    value={field.value}
-                                    onChange={(date: Date | null) => field.onChange(date)}
-                                    feil={getDateErrorMessage(fieldState.error)}
-                                />
-                            )}
-                        />
-                        <Controller
-                            control={form.control}
+                    )}
+                />
+                <Controller
+                    control={form.control}
+                    name="begrunnelse"
+                    render={({ field, fieldState }) => (
+                        <Textarea
+                            label="Begrunnelse"
                             name="begrunnelse"
-                            render={({ field, fieldState }) => (
-                                <Textarea
-                                    label="Begrunnelse"
-                                    name="begrunnelse"
-                                    value={field.value}
-                                    onChange={field.onChange}
-                                    error={fieldState.error?.message}
-                                />
-                            )}
+                            value={field.value}
+                            onChange={field.onChange}
+                            error={fieldState.error?.message}
                         />
-                        {RemoteData.isFailure(status) && (
-                            <div className={styles.error}>
-                                <ApiErrorAlert error={status.error} />
-                            </div>
-                        )}
-                        <div className={styles.bunnknapper}>
-                            <Button
-                                variant="secondary"
-                                onClick={() => {
-                                    if (urlParams.revurderingId) {
-                                        return history.push(
-                                            Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })
-                                        );
-                                    }
-                                    history.goBack();
-                                }}
-                            >
-                                {formatMessage('stans.bunnknapper.tilbake')}
-                            </Button>
-                            <Button variant="secondary">
-                                {formatMessage('stans.bunnknapper.neste')}
-                                {(RemoteData.isPending(opprettStatus) || RemoteData.isPending(oppdaterStatus)) && (
-                                    <Loader />
-                                )}
-                            </Button>
-                        </div>
+                    )}
+                />
+                {RemoteData.isFailure(status) && (
+                    <div className={styles.error}>
+                        <ApiErrorAlert error={status.error} />
                     </div>
-                </form>
-            </CompatRoute>
-        </Switch>
+                )}
+                <div className={styles.bunnknapper}>
+                    <Button
+                        variant="secondary"
+                        onClick={() => {
+                            if (urlParams.revurderingId) {
+                                return history.push(Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id }));
+                            }
+                            history.goBack();
+                        }}
+                    >
+                        {formatMessage('stans.bunnknapper.tilbake')}
+                    </Button>
+                    <Button variant="secondary">
+                        {formatMessage('stans.bunnknapper.neste')}
+                        {(RemoteData.isPending(opprettStatus) || RemoteData.isPending(oppdaterStatus)) && <Loader />}
+                    </Button>
+                </div>
+            </div>
+        </form>
     );
 };
 

--- a/src/pages/saksbehandling/stans/Stans.tsx
+++ b/src/pages/saksbehandling/stans/Stans.tsx
@@ -3,7 +3,8 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Heading, Loader, Select, Textarea } from '@navikt/ds-react';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Route, Switch, useHistory } from 'react-router-dom';
+import { Switch, useHistory } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import DatePicker from '~src/components/datePicker/DatePicker';
@@ -103,13 +104,13 @@ const Stans = (props: Props) => {
 
     return (
         <Switch>
-            <Route path={Routes.stansOppsummeringRoute.path}>
+            <CompatRoute path={Routes.stansOppsummeringRoute.path}>
                 <Heading level="1" size="large" className={styles.tittel}>
                     {formatMessage('stans.tittel')}
                 </Heading>
                 <StansOppsummering sak={props.sak} />
-            </Route>
-            <Route path="*">
+            </CompatRoute>
+            <CompatRoute path={Routes.stansRoot.path}>
                 <form className={styles.pageContainer} onSubmit={form.handleSubmit((values) => handleSubmit(values))}>
                     <Heading level="1" size="large" className={styles.tittel}>
                         {formatMessage('stans.tittel')}
@@ -189,7 +190,7 @@ const Stans = (props: Props) => {
                         </div>
                     </div>
                 </form>
-            </Route>
+            </CompatRoute>
         </Switch>
     );
 };

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -3,7 +3,8 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Heading, Loader, Select, Textarea } from '@navikt/ds-react';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Route, Switch, useHistory } from 'react-router-dom';
+import { Switch, useHistory } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import * as revurderingActions from '~src/features/revurdering/revurderingActions';
@@ -13,7 +14,7 @@ import * as Routes from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
 import yup from '~src/lib/validering';
 import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb';
-import { Revurdering, OpprettetRevurderingGrunn, Gjenopptak } from '~src/types/Revurdering';
+import { Gjenopptak, OpprettetRevurderingGrunn, Revurdering } from '~src/types/Revurdering';
 import { Sak } from '~src/types/Sak';
 
 import messages from './gjenoppta-nb';
@@ -99,9 +100,9 @@ const Gjenoppta = (props: Props) => {
                 {formatMessage('gjenoppta.tittel')}
             </Heading>
             <Switch>
-                <Route path={Routes.gjenopptaStansOppsummeringRoute.path}>
+                <CompatRoute path={Routes.gjenopptaStansOppsummeringRoute.path}>
                     <GjenopptaOppsummering sak={props.sak} />
-                </Route>
+                </CompatRoute>
                 <form className={styles.container} onSubmit={form.handleSubmit((values) => handleSubmit(values))}>
                     <Controller
                         control={form.control}

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -3,8 +3,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Heading, Loader, Select, Textarea } from '@navikt/ds-react';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Switch, useHistory } from 'react-router-dom';
-import { CompatRoute } from 'react-router-dom-v5-compat';
+import { useHistory } from 'react-router-dom';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import * as revurderingActions from '~src/features/revurdering/revurderingActions';
@@ -19,7 +18,6 @@ import { Sak } from '~src/types/Sak';
 
 import messages from './gjenoppta-nb';
 import * as styles from './gjenoppta.module.less';
-import GjenopptaOppsummering from './gjenopptaOppsummering';
 
 interface Props {
     sak: Sak;
@@ -45,7 +43,7 @@ function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
 }
 
 const Gjenoppta = (props: Props) => {
-    const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansRoute>();
+    const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansOppsummeringRoute>();
     const { formatMessage } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const history = useHistory();
 
@@ -99,61 +97,56 @@ const Gjenoppta = (props: Props) => {
             <Heading level="1" size="large" className={styles.tittel}>
                 {formatMessage('gjenoppta.tittel')}
             </Heading>
-            <Switch>
-                <CompatRoute path={Routes.gjenopptaStansOppsummeringRoute.path}>
-                    <GjenopptaOppsummering sak={props.sak} />
-                </CompatRoute>
-                <form className={styles.container} onSubmit={form.handleSubmit((values) => handleSubmit(values))}>
-                    <Controller
-                        control={form.control}
-                        name="årsak"
-                        render={({ field, fieldState }) => (
-                            <Select
-                                error={fieldState.error?.message}
-                                value={field.value ?? undefined}
-                                onChange={field.onChange}
-                                label={formatMessage('gjenoppta.årsak.tittel')}
-                            >
-                                <option>{formatMessage('gjenoppta.årsak.label')}</option>
-                                <option value={OpprettetRevurderingGrunn.MOTTATT_KONTROLLERKLÆRING}>
-                                    {formatMessage(OpprettetRevurderingGrunn.MOTTATT_KONTROLLERKLÆRING)}
-                                </option>
-                            </Select>
-                        )}
-                    />
-
-                    <Controller
-                        control={form.control}
-                        name="begrunnelse"
-                        render={({ field, fieldState }) => (
-                            <Textarea
-                                label="Begrunnelse"
-                                name="begrunnelse"
-                                value={field.value}
-                                onChange={field.onChange}
-                                error={fieldState.error?.message}
-                            />
-                        )}
-                    />
-                    {RemoteData.isFailure(status) && (
-                        <div className={styles.error}>
-                            <ApiErrorAlert error={status.error} />
-                        </div>
-                    )}
-                    <div className={styles.knapper}>
-                        <Button
-                            variant="secondary"
-                            onClick={() => history.push(Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id }))}
+            <form className={styles.container} onSubmit={form.handleSubmit((values) => handleSubmit(values))}>
+                <Controller
+                    control={form.control}
+                    name="årsak"
+                    render={({ field, fieldState }) => (
+                        <Select
+                            error={fieldState.error?.message}
+                            value={field.value ?? undefined}
+                            onChange={field.onChange}
+                            label={formatMessage('gjenoppta.årsak.tittel')}
                         >
-                            {formatMessage('gjenoppta.oppsummering.tilbake')}
-                        </Button>
-                        <Button variant="secondary">
-                            {formatMessage('gjenoppta.oppsummering.iverksett')}
-                            {RemoteData.isPending(gjenopptaStatus) && <Loader />}
-                        </Button>
+                            <option>{formatMessage('gjenoppta.årsak.label')}</option>
+                            <option value={OpprettetRevurderingGrunn.MOTTATT_KONTROLLERKLÆRING}>
+                                {formatMessage(OpprettetRevurderingGrunn.MOTTATT_KONTROLLERKLÆRING)}
+                            </option>
+                        </Select>
+                    )}
+                />
+
+                <Controller
+                    control={form.control}
+                    name="begrunnelse"
+                    render={({ field, fieldState }) => (
+                        <Textarea
+                            label="Begrunnelse"
+                            name="begrunnelse"
+                            value={field.value}
+                            onChange={field.onChange}
+                            error={fieldState.error?.message}
+                        />
+                    )}
+                />
+                {RemoteData.isFailure(status) && (
+                    <div className={styles.error}>
+                        <ApiErrorAlert error={status.error} />
                     </div>
-                </form>
-            </Switch>
+                )}
+                <div className={styles.knapper}>
+                    <Button
+                        variant="secondary"
+                        onClick={() => history.push(Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id }))}
+                    >
+                        {formatMessage('gjenoppta.oppsummering.tilbake')}
+                    </Button>
+                    <Button variant="secondary">
+                        {formatMessage('gjenoppta.oppsummering.iverksett')}
+                        {RemoteData.isPending(gjenopptaStatus) && <Loader />}
+                    </Button>
+                </div>
+            </form>
         </>
     );
 };

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering.tsx
@@ -1,5 +1,5 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert } from '@navikt/ds-react';
+import { Alert, Heading } from '@navikt/ds-react';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -10,6 +10,7 @@ import { useApiCall } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb';
+import * as styles from '~src/pages/saksbehandling/stans/gjenoppta/gjenoppta.module.less';
 import { useAppDispatch } from '~src/redux/Store';
 import { UtbetalingsRevurderingStatus } from '~src/types/Revurdering';
 import { Sak } from '~src/types/Sak';
@@ -22,13 +23,13 @@ interface Props {
     sak: Sak;
 }
 
-const GjenopptaOppsummering = (props: Props) => {
+const GjenopptaOppsummering = ({ sak }: Props) => {
     const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansOppsummeringRoute>();
     const { formatMessage } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const history = useHistory();
     const dispatch = useAppDispatch();
 
-    const revurdering = props.sak.revurderinger.find((r) => r.id === urlParams.revurderingId);
+    const revurdering = sak.revurderinger.find((r) => r.id === urlParams.revurderingId);
     const [iverksettStatus, iverksettGjenopptak] = useApiCall(revurderingApi.iverksettGjenopptak);
     const error = RemoteData.isFailure(iverksettStatus) ? iverksettStatus.error : null;
 
@@ -36,7 +37,7 @@ const GjenopptaOppsummering = (props: Props) => {
         return (
             <div>
                 <Alert variant="error"> {formatMessage('gjenoppta.oppsummering.error.fant.ingen')}</Alert>
-                <LinkAsButton href={Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id })}>
+                <LinkAsButton href={Routes.saksoversiktValgtSak.createURL({ sakId: sak.id })}>
                     {formatMessage('gjenoppta.bunnknapper.tilbake')}
                 </LinkAsButton>
             </div>
@@ -44,9 +45,9 @@ const GjenopptaOppsummering = (props: Props) => {
     }
 
     const iverksettOgGåVidere = () => {
-        iverksettGjenopptak({ sakId: props.sak.id, revurderingId: revurdering.id }, async () => {
-            await dispatch(fetchSak({ fnr: props.sak.fnr }));
-            history.push(Routes.createSakIntroLocation(formatMessage('gjenoppta.notification'), props.sak.id));
+        iverksettGjenopptak({ sakId: sak.id, revurderingId: revurdering.id }, async () => {
+            await dispatch(fetchSak({ fnr: sak.fnr }));
+            history.push(Routes.createSakIntroLocation(formatMessage('gjenoppta.notification'), sak.id));
         });
     };
     const erIverksatt = revurdering.status === UtbetalingsRevurderingStatus.IVERKSATT_GJENOPPTAK;
@@ -66,25 +67,30 @@ const GjenopptaOppsummering = (props: Props) => {
     }
 
     return (
-        <StansOppsummeringskomponent
-            revurdering={revurdering}
-            inputs={oppsummeringsinputs}
-            error={error}
-            knapper={{
-                tilbake: {
-                    tekst: formatMessage('gjenoppta.oppsummering.tilbake'),
-                    onClick: () =>
-                        history.push(
-                            Routes.gjenopptaStansRoute.createURL({ sakId: props.sak.id, revurderingId: revurdering.id })
-                        ),
-                },
-                neste: {
-                    tekst: formatMessage('gjenoppta.oppsummering.iverksett'),
-                    onClick: iverksettOgGåVidere,
-                    spinner: RemoteData.isPending(iverksettStatus),
-                },
-            }}
-        />
+        <>
+            <Heading level="1" size="large" className={styles.tittel}>
+                {formatMessage('gjenoppta.tittel')}
+            </Heading>
+            <StansOppsummeringskomponent
+                revurdering={revurdering}
+                inputs={oppsummeringsinputs}
+                error={error}
+                knapper={{
+                    tilbake: {
+                        tekst: formatMessage('gjenoppta.oppsummering.tilbake'),
+                        onClick: () =>
+                            history.push(
+                                Routes.gjenopptaStansRoute.createURL({ sakId: sak.id, revurderingId: revurdering.id })
+                            ),
+                    },
+                    neste: {
+                        tekst: formatMessage('gjenoppta.oppsummering.iverksett'),
+                        onClick: iverksettOgGåVidere,
+                        spinner: RemoteData.isPending(iverksettStatus),
+                    },
+                }}
+            />
+        </>
     );
 };
 

--- a/src/pages/saksbehandling/stans/stansOppsummering.tsx
+++ b/src/pages/saksbehandling/stans/stansOppsummering.tsx
@@ -1,5 +1,5 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
-import { Alert } from '@navikt/ds-react';
+import { Alert, Heading } from '@navikt/ds-react';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -16,6 +16,7 @@ import { Sak } from '~src/types/Sak';
 
 import StansOppsummeringskomponent from './components/StansOppsummeringskomponent';
 import messages from './stans-nb';
+import * as styles from './stans.module.less';
 
 interface Props {
     sak: Sak;
@@ -66,25 +67,32 @@ const StansOppsummering = (props: Props) => {
     }
 
     return (
-        <StansOppsummeringskomponent
-            revurdering={revurdering}
-            inputs={oppsummeringsinputs}
-            error={error}
-            knapper={{
-                tilbake: {
-                    tekst: formatMessage('stans.bunnknapper.tilbake'),
-                    onClick: () =>
-                        history.push(
-                            Routes.stansRoute.createURL({ sakId: props.sak.id, revurderingId: revurdering.id })
-                        ),
-                },
-                neste: {
-                    tekst: formatMessage('stans.oppsummering.iverksett'),
-                    onClick: iverksettOgGåVidere,
-                    spinner: RemoteData.isPending(iverksettStatus),
-                },
-            }}
-        />
+        <div className={styles.pageContainer}>
+            <Heading level="1" size="large" className={styles.tittel}>
+                {formatMessage('stans.tittel')}
+            </Heading>
+            <div className={styles.content}>
+                <StansOppsummeringskomponent
+                    revurdering={revurdering}
+                    inputs={oppsummeringsinputs}
+                    error={error}
+                    knapper={{
+                        tilbake: {
+                            tekst: formatMessage('stans.bunnknapper.tilbake'),
+                            onClick: () =>
+                                history.push(
+                                    Routes.stansRoute.createURL({ sakId: props.sak.id, revurderingId: revurdering.id })
+                                ),
+                        },
+                        neste: {
+                            tekst: formatMessage('stans.oppsummering.iverksett'),
+                            onClick: iverksettOgGåVidere,
+                            spinner: RemoteData.isPending(iverksettStatus),
+                        },
+                    }}
+                />
+            </div>
+        </div>
     );
 };
 

--- a/src/pages/saksbehandling/søknadsbehandling/sats/Sats.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/sats/Sats.tsx
@@ -172,7 +172,7 @@ const Sats = (props: VilkårsvurderingBaseProps) => {
     const [epsStatus, fetchEps] = useApiCall(fetchPerson);
     const { formatMessage } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const history = useHistory();
-    const epsFnr = hentBosituasjongrunnlag(props.behandling.grunnlagsdataOgVilkårsvurderinger).fnr;
+    const epsFnr = hentBosituasjongrunnlag(props.behandling.grunnlagsdataOgVilkårsvurderinger)?.fnr;
 
     useEffect(() => {
         if (epsFnr) {

--- a/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
 
 import { Person } from '~src/api/personApi';
 import Beregning from '~src/components/beregningOgSimulering/beregning/Beregning';
@@ -52,102 +51,97 @@ const Vilkår = (props: { sak: Sak; søker: Person }) => {
         <div className={styles.container}>
             <SaksbehandlingFramdriftsindikator sakId={props.sak.id} behandling={behandling} vilkår={vilkar} />
             <div className={styles.content}>
-                <Switch>
-                    <Route path={vilkårUrl(Vilkårtype.Virkningstidspunkt)}>
-                        <Virkningstidspunkt
-                            behandling={behandling}
-                            forrigeUrl={saksoversiktUrl}
-                            nesteUrl={vilkårUrl(Vilkårtype.Uførhet)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.Uførhet)}>
-                        <Uførhet
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.Virkningstidspunkt)}
-                            nesteUrl={vilkårUrl(Vilkårtype.Flyktning)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.Flyktning)}>
-                        <Flyktning
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.Uførhet)}
-                            nesteUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.LovligOpphold)}>
-                        <LovligOppholdINorge
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.Flyktning)}
-                            nesteUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.FastOppholdINorge)}>
-                        <FastOppholdINorge
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
-                            nesteUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.Institusjonsopphold)}>
-                        <Institusjonsopphold
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
-                            nesteUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.OppholdIUtlandet)}>
-                        <OppholdIUtlandet
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
-                            nesteUrl={vilkårUrl(Vilkårtype.Formue)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.Formue)}>
-                        <Formue
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
-                            søker={props.søker}
-                            nesteUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.PersonligOppmøte)}>
-                        <PersonligOppmøte
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.Formue)}
-                            nesteUrl={vilkårUrl(Vilkårtype.Sats)}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.Sats)}>
-                        <Sats
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
-                            nesteUrl={
-                                erVilkårsvurderingerVurdertAvslag(behandling)
-                                    ? vedtakUrl
-                                    : vilkårUrl(Vilkårtype.Beregning)
-                            }
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path={vilkårUrl(Vilkårtype.Beregning)}>
-                        <Beregning
-                            behandling={behandling}
-                            forrigeUrl={vilkårUrl(Vilkårtype.Sats)}
-                            nesteUrl={vedtakUrl}
-                            sakId={urlParams.sakId}
-                        />
-                    </Route>
-                    <Route path="*">404</Route>
-                </Switch>
+                {vilkar === Vilkårtype.Virkningstidspunkt && (
+                    <Virkningstidspunkt
+                        behandling={behandling}
+                        forrigeUrl={saksoversiktUrl}
+                        nesteUrl={vilkårUrl(Vilkårtype.Uførhet)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.Uførhet && (
+                    <Uførhet
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.Virkningstidspunkt)}
+                        nesteUrl={vilkårUrl(Vilkårtype.Flyktning)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.Flyktning && (
+                    <Flyktning
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.Uførhet)}
+                        nesteUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.LovligOpphold && (
+                    <LovligOppholdINorge
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.Flyktning)}
+                        nesteUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.FastOppholdINorge && (
+                    <FastOppholdINorge
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
+                        nesteUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.Institusjonsopphold && (
+                    <Institusjonsopphold
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
+                        nesteUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.OppholdIUtlandet && (
+                    <OppholdIUtlandet
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
+                        nesteUrl={vilkårUrl(Vilkårtype.Formue)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.Formue && (
+                    <Formue
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
+                        søker={props.søker}
+                        nesteUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.PersonligOppmøte && (
+                    <PersonligOppmøte
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.Formue)}
+                        nesteUrl={vilkårUrl(Vilkårtype.Sats)}
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.Sats && (
+                    <Sats
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
+                        nesteUrl={
+                            erVilkårsvurderingerVurdertAvslag(behandling) ? vedtakUrl : vilkårUrl(Vilkårtype.Beregning)
+                        }
+                        sakId={urlParams.sakId}
+                    />
+                )}
+                {vilkar === Vilkårtype.Beregning && (
+                    <Beregning
+                        behandling={behandling}
+                        forrigeUrl={vilkårUrl(Vilkårtype.Sats)}
+                        nesteUrl={vedtakUrl}
+                        sakId={urlParams.sakId}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -1,6 +1,7 @@
 import { Heading } from '@navikt/ds-react';
 import * as React from 'react';
-import { Route, Switch, useHistory } from 'react-router-dom';
+import { Switch, useHistory } from 'react-router-dom';
+import { CompatRoute } from 'react-router-dom-v5-compat';
 
 import { useI18n } from '~src/lib/i18n';
 import * as routes from '~src/lib/routes';
@@ -33,11 +34,11 @@ const index = () => {
             </div>
             <div className={styles.contentContainer}>
                 <Switch>
-                    <Route exact={true} path={routes.soknadsutfylling.path}>
+                    <CompatRoute exact={true} path={routes.soknadsutfylling.path}>
                         <StartUtfylling />
-                    </Route>
+                    </CompatRoute>
                     <Switch>
-                        <Route exact={true} path={routes.soknad.path}>
+                        <CompatRoute exact={true} path={routes.soknad.path}>
                             <SøknadInfoWrapper>
                                 <Infoside
                                     nesteUrl={routes.soknadPersonSøk.createURL({
@@ -45,8 +46,8 @@ const index = () => {
                                     })}
                                 />
                             </SøknadInfoWrapper>
-                        </Route>
-                        <Route exact={true} path={routes.soknadPersonSøk.path}>
+                        </CompatRoute>
+                        <CompatRoute exact={true} path={routes.soknadPersonSøk.path}>
                             <SøknadInfoWrapper>
                                 <Inngang
                                     nesteUrl={routes.soknadsutfylling.createURL({
@@ -55,12 +56,12 @@ const index = () => {
                                     })}
                                 />
                             </SøknadInfoWrapper>
-                        </Route>
-                        <Route exact={true} path={routes.søkandskvittering.path}>
+                        </CompatRoute>
+                        <CompatRoute exact={true} path={routes.søkandskvittering.path}>
                             <SøknadInfoWrapper>
                                 <Kvittering />
                             </SøknadInfoWrapper>
-                        </Route>
+                        </CompatRoute>
                     </Switch>
                 </Switch>
             </div>


### PR DESCRIPTION
Steg 1 for å få inn v6

Installert en migreringspakke som støtter både v5 og v6
Erstattet Route med CompatRoute der det er mulig. Nested Switch og CompatRoute ser ut til å funke litt dårlig, så har ikke fått fjernet alle Route - men nesten. Resten forsvinner i de neste migreringene.

En stor endring fra v5 til v6 er at v6 ikke tillater optional arguments i urlen:
```
- <Route path="/one/:two?" element={Comp} />
+ <CompatRoute path="/one/:two" element={Comp} />
+ <CompatRoute path="/one" element={Comp} />
```
Det kommer til å komme litt PR-er på denne migreringen (før den da er helt i boks), da det er ganske store endringer hele veien