### PR TITLE
Router cleanup

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -25,6 +25,27 @@ const Behandlingsoversikt = React.lazy(
     () => import('~/src/pages/saksbehandling/behandlingsoversikt/Behandlingsoversikt')
 );
 const Soknad = React.lazy(() => import('~/src/pages/søknad'));
+const Gjenoppta = React.lazy(() => import('~/src/pages/saksbehandling/stans/gjenoppta/gjenoppta'));
+const StansOppsummering = React.lazy(() => import('~src/pages/saksbehandling/stans/stansOppsummering'));
+const Vilkår = React.lazy(() => import('~/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår'));
+const SendTilAttesteringPage = React.lazy(
+    () => import('~/src/pages/saksbehandling/søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage')
+);
+const Vedtaksoppsummering = React.lazy(() => import('~src/pages/saksbehandling/vedtak/Vedtaksoppsummering'));
+const AvsluttBehandling = React.lazy(() => import('~/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling'));
+const Revurdering = React.lazy(() => import('~/src/pages/saksbehandling/revurdering/Revurdering'));
+const Sakintro = React.lazy(() => import('~/src/pages/saksbehandling/sakintro/Sakintro'));
+const DokumenterPage = React.lazy(() => import('~src/pages/saksbehandling/dokumenter/DokumenterPage'));
+const StansPage = React.lazy(() => import('~/src/pages/saksbehandling/stans/Stans'));
+const OpprettKlage = React.lazy(() => import('~src/pages/klage/opprettKlage/OpprettKlage'));
+const Klage = React.lazy(() => import('~src/pages/klage/Klage'));
+const NyDatoForKontrollsamtale = React.lazy(() => import('~src/pages/kontrollsamtale/KontrollsamtalePage'));
+const RevurderingIntroPage = React.lazy(
+    () => import('~src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroPage')
+);
+const GjenopptaOppsummering = React.lazy(
+    () => import('~src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering')
+);
 
 const ScrollToTop = () => {
     const { pathname } = useLocation();
@@ -60,7 +81,28 @@ const AppRoutes = () => (
         <Route
             path={routes.saksoversiktValgtSak.path + '*'}
             element={<WithDocTitle title="Saksbehandling" Page={Saksoversikt} />}
-        />
+        >
+            <Route path="" element={<Sakintro />} />
+            <Route path={routes.klageRoot.path}>
+                <Route path={routes.klageOpprett.path} element={<OpprettKlage />} />
+                <Route path={routes.klage.path} element={<Klage />} />
+            </Route>
+            <Route path={routes.stansRoot.path}>
+                <Route path={routes.stansRoute.path} element={<StansPage />} />
+                <Route path={routes.stansOppsummeringRoute.path} element={<StansOppsummering />} />
+            </Route>
+            <Route path={routes.gjenopptaStansRoot.path} element={<Gjenoppta />}>
+                <Route path={routes.gjenopptaStansOppsummeringRoute.path} element={<GjenopptaOppsummering />} />
+            </Route>
+            <Route path={routes.avsluttBehandling.path} element={<AvsluttBehandling />} />
+            <Route path={routes.revurderValgtSak.path} element={<RevurderingIntroPage />} />
+            <Route path={routes.revurderValgtRevurdering.path} element={<Revurdering />} />
+            <Route path={routes.vedtaksoppsummering.path} element={<Vedtaksoppsummering />} />
+            <Route path={routes.saksbehandlingSendTilAttestering.path} element={<SendTilAttesteringPage />} />
+            <Route path={routes.saksbehandlingVilkårsvurdering.path} element={<Vilkår />} />
+            <Route path={routes.alleDokumenterForSak.path} element={<DokumenterPage />} />
+            <Route path={routes.kontrollsamtale.path} element={<NyDatoForKontrollsamtale />} />
+        </Route>
         <Route
             path={routes.saksoversiktIndex.path}
             element={<WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -13,6 +13,9 @@ import { FeatureToggleProvider, useFeatureToggle } from '~src/lib/featureToggles
 import { pipe } from '~src/lib/fp';
 import enableHotjar from '~src/lib/tracking/hotjar';
 import Attestering from '~src/pages/saksbehandling/attestering/Attestering';
+import AttesterKlage from '~src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage';
+import AttesterRevurdering from '~src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering';
+import AttesterSøknadsbehandling from '~src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling';
 import { LoggedInUser } from '~src/types/LoggedInUser';
 
 import ErrorBoundary from './components/errorBoundary/ErrorBoundary';
@@ -51,36 +54,35 @@ const Root = () => (
                     <ContentWrapper>
                         <Suspense fallback={<Loader />}>
                             <ScrollToTop />
-                            <Routes>
-                                <Route
-                                    path={routes.home.path}
-                                    element={<WithDocTitle title="Hjem" Page={HomePage} />}
-                                />
-                                <Route
-                                    path={routes.soknad.path + '*'}
-                                    element={<WithDocTitle title="Søknad" Page={Soknad} />}
-                                />
-                                <Route
-                                    path={routes.saksoversiktValgtSak.path + '*'}
-                                    element={<WithDocTitle title="Saksbehandling" Page={Saksoversikt} />}
-                                />
-                                <Route
-                                    path={routes.saksoversiktIndex.path}
-                                    element={<WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />}
-                                />
-                                <Route
-                                    path={routes.attestering.path + '*'}
-                                    element={<WithDocTitle title="Attestering" Page={Attestering} />}
-                                />
-                                <Route path={routes.drift.path} element={<WithDocTitle title="Drift" Page={Drift} />} />
-                                <Route path="*" element={<>404</>} />
-                            </Routes>
+                            <AppRoutes />
                         </Suspense>
                     </ContentWrapper>
                 </BrowserRouter>
             </FeatureToggleProvider>
         </ErrorBoundary>
     </Provider>
+);
+
+const AppRoutes = () => (
+    <Routes>
+        <Route path={routes.home.path} element={<WithDocTitle title="Hjem" Page={HomePage} />} />
+        <Route path={routes.soknad.path + '*'} element={<WithDocTitle title="Søknad" Page={Soknad} />} />
+        <Route
+            path={routes.saksoversiktValgtSak.path + '*'}
+            element={<WithDocTitle title="Saksbehandling" Page={Saksoversikt} />}
+        />
+        <Route
+            path={routes.saksoversiktIndex.path}
+            element={<WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />}
+        />
+        <Route path={routes.attestering.path + '*'} element={<WithDocTitle title="Attestering" Page={Attestering} />}>
+            <Route path={routes.attesterSøknadsbehandling.path} element={<AttesterSøknadsbehandling />} />
+            <Route path={routes.attesterRevurdering.path} element={<AttesterRevurdering />} />
+            <Route path={routes.attesterKlage.path} element={<AttesterKlage />} />
+        </Route>
+        <Route path={routes.drift.path} element={<WithDocTitle title="Drift" Page={Drift} />} />
+        <Route path="*" element={<>404</>} />
+    </Routes>
 );
 
 const ContentWrapper: React.FC = (props) => {

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -5,6 +5,15 @@ import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 import { FeatureToggleProvider } from '~src/lib/featureToggles';
+import Vilkår from '~src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår';
+
+import ErrorBoundary from './components/errorBoundary/ErrorBoundary';
+import WithDocTitle from './components/WithDocTitle';
+import * as routes from './lib/routes';
+import Store from './redux/Store';
+import './externalStyles';
+import { ContentWrapper } from './utils/router/ContentWrapper';
+
 const Attestering = React.lazy(() => import('~src/pages/saksbehandling/attestering/Attestering'));
 const AttesterKlage = React.lazy(() => import('~src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage'));
 const AttesterRevurdering = React.lazy(
@@ -17,17 +26,6 @@ const Kvittering = React.lazy(() => import('~src/pages/søknad/kvittering/Kvitte
 const Infoside = React.lazy(() => import('~src/pages/søknad/steg/infoside/Infoside'));
 const Inngang = React.lazy(() => import('~src/pages/søknad/steg/inngang/Inngang'));
 const StartUtfylling = React.lazy(() => import('~src/pages/søknad/steg/start-utfylling/StartUtfylling'));
-
-import ErrorBoundary from './components/errorBoundary/ErrorBoundary';
-import WithDocTitle from './components/WithDocTitle';
-import * as routes from './lib/routes';
-import Store from './redux/Store';
-
-import './externalStyles';
-import { ContentWrapper } from './utils/router/ContentWrapper';
-
-import Vilkår from '~src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår';
-
 const Drift = React.lazy(() => import('~/src/pages/drift'));
 const HomePage = React.lazy(() => import('~/src/pages/HomePage'));
 const Saksoversikt = React.lazy(() => import('~/src/pages/saksbehandling/Saksoversikt'));

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -26,6 +26,8 @@ import Store from './redux/Store';
 import './externalStyles';
 import { ContentWrapper } from './utils/router/ContentWrapper';
 
+import Vilkår from '~src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår';
+
 const Drift = React.lazy(() => import('~/src/pages/drift'));
 const HomePage = React.lazy(() => import('~/src/pages/HomePage'));
 const Saksoversikt = React.lazy(() => import('~/src/pages/saksbehandling/Saksoversikt'));
@@ -35,7 +37,6 @@ const Behandlingsoversikt = React.lazy(
 const Soknad = React.lazy(() => import('~/src/pages/søknad'));
 const Gjenoppta = React.lazy(() => import('~/src/pages/saksbehandling/stans/gjenoppta/gjenoppta'));
 const StansOppsummering = React.lazy(() => import('~src/pages/saksbehandling/stans/stansOppsummering'));
-const Vilkår = React.lazy(() => import('~/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår'));
 const SendTilAttesteringPage = React.lazy(
     () => import('~/src/pages/saksbehandling/søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage')
 );
@@ -90,7 +91,7 @@ const AppRoutes = () => {
         <Routes>
             <Route path={routes.home.path} element={<WithDocTitle title="Hjem" Page={HomePage} />} />
             <Route path={routes.soknad.path} element={<WithDocTitle title="Søknad" Page={Soknad} />}>
-                <Route path={''} element={<Infoside isPapirsøknad={isPapirsøknad} />} />
+                <Route index element={<Infoside isPapirsøknad={isPapirsøknad} />} />
                 <Route path={routes.soknadPersonSøk.path} element={<Inngang isPapirsøknad={isPapirsøknad} />} />
                 <Route path={routes.soknadsutfylling.path} element={<StartUtfylling />} />
                 <Route path={routes.søkandskvittering.path} element={<Kvittering />} />
@@ -99,12 +100,13 @@ const AppRoutes = () => {
                 path={routes.saksoversiktValgtSak.path}
                 element={<WithDocTitle title="Saksbehandling" Page={Saksoversikt} />}
             >
-                <Route path="" element={<Sakintro />} />
+                <Route index element={<Sakintro />} />
                 <Route path={routes.klageRoot.path}>
                     <Route path={routes.klageOpprett.path} element={<OpprettKlage />} />
                     <Route path={routes.klage.path} element={<Klage />} />
                 </Route>
                 <Route path={routes.stansRoot.path}>
+                    <Route index element={<StansPage />} />
                     <Route path={routes.stansRoute.path} element={<StansPage />} />
                     <Route path={routes.stansOppsummeringRoute.path} element={<StansOppsummering />} />
                 </Route>

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -5,10 +5,18 @@ import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 import { FeatureToggleProvider } from '~src/lib/featureToggles';
-import Attestering from '~src/pages/saksbehandling/attestering/Attestering';
-import AttesterKlage from '~src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage';
-import AttesterRevurdering from '~src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering';
-import AttesterSøknadsbehandling from '~src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling';
+const Attestering = React.lazy(() => import('~src/pages/saksbehandling/attestering/Attestering'));
+const AttesterKlage = React.lazy(() => import('~src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage'));
+const AttesterRevurdering = React.lazy(
+    () => import('~src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering')
+);
+const AttesterSøknadsbehandling = React.lazy(
+    () => import('~src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling')
+);
+const Kvittering = React.lazy(() => import('~src/pages/søknad/kvittering/Kvittering'));
+const Infoside = React.lazy(() => import('~src/pages/søknad/steg/infoside/Infoside'));
+const Inngang = React.lazy(() => import('~src/pages/søknad/steg/inngang/Inngang'));
+const StartUtfylling = React.lazy(() => import('~src/pages/søknad/steg/start-utfylling/StartUtfylling'));
 
 import ErrorBoundary from './components/errorBoundary/ErrorBoundary';
 import WithDocTitle from './components/WithDocTitle';
@@ -74,48 +82,58 @@ const Root = () => (
     </Provider>
 );
 
-const AppRoutes = () => (
-    <Routes>
-        <Route path={routes.home.path} element={<WithDocTitle title="Hjem" Page={HomePage} />} />
-        <Route path={routes.soknad.path + '*'} element={<WithDocTitle title="Søknad" Page={Soknad} />} />
-        <Route
-            path={routes.saksoversiktValgtSak.path + '*'}
-            element={<WithDocTitle title="Saksbehandling" Page={Saksoversikt} />}
-        >
-            <Route path="" element={<Sakintro />} />
-            <Route path={routes.klageRoot.path}>
-                <Route path={routes.klageOpprett.path} element={<OpprettKlage />} />
-                <Route path={routes.klage.path} element={<Klage />} />
+const AppRoutes = () => {
+    const location = useLocation();
+    const isPapirsøknad = location.search.includes('papirsoknad');
+
+    return (
+        <Routes>
+            <Route path={routes.home.path} element={<WithDocTitle title="Hjem" Page={HomePage} />} />
+            <Route path={routes.soknad.path} element={<WithDocTitle title="Søknad" Page={Soknad} />}>
+                <Route path={''} element={<Infoside isPapirsøknad={isPapirsøknad} />} />
+                <Route path={routes.soknadPersonSøk.path} element={<Inngang isPapirsøknad={isPapirsøknad} />} />
+                <Route path={routes.soknadsutfylling.path} element={<StartUtfylling />} />
+                <Route path={routes.søkandskvittering.path} element={<Kvittering />} />
             </Route>
-            <Route path={routes.stansRoot.path}>
-                <Route path={routes.stansRoute.path} element={<StansPage />} />
-                <Route path={routes.stansOppsummeringRoute.path} element={<StansOppsummering />} />
+            <Route
+                path={routes.saksoversiktValgtSak.path}
+                element={<WithDocTitle title="Saksbehandling" Page={Saksoversikt} />}
+            >
+                <Route path="" element={<Sakintro />} />
+                <Route path={routes.klageRoot.path}>
+                    <Route path={routes.klageOpprett.path} element={<OpprettKlage />} />
+                    <Route path={routes.klage.path} element={<Klage />} />
+                </Route>
+                <Route path={routes.stansRoot.path}>
+                    <Route path={routes.stansRoute.path} element={<StansPage />} />
+                    <Route path={routes.stansOppsummeringRoute.path} element={<StansOppsummering />} />
+                </Route>
+                <Route path={routes.gjenopptaStansRoot.path} element={<Gjenoppta />}>
+                    <Route path={routes.gjenopptaStansOppsummeringRoute.path} element={<GjenopptaOppsummering />} />
+                </Route>
+                <Route path={routes.avsluttBehandling.path} element={<AvsluttBehandling />} />
+                <Route path={routes.revurderValgtSak.path} element={<RevurderingIntroPage />} />
+                <Route path={routes.revurderValgtRevurdering.path} element={<Revurdering />} />
+                <Route path={routes.vedtaksoppsummering.path} element={<Vedtaksoppsummering />} />
+                <Route path={routes.saksbehandlingSendTilAttestering.path} element={<SendTilAttesteringPage />} />
+                <Route path={routes.saksbehandlingVilkårsvurdering.path} element={<Vilkår />} />
+                <Route path={routes.alleDokumenterForSak.path} element={<DokumenterPage />} />
+                <Route path={routes.kontrollsamtale.path} element={<NyDatoForKontrollsamtale />} />
             </Route>
-            <Route path={routes.gjenopptaStansRoot.path} element={<Gjenoppta />}>
-                <Route path={routes.gjenopptaStansOppsummeringRoute.path} element={<GjenopptaOppsummering />} />
+            <Route
+                path={routes.saksoversiktIndex.path}
+                element={<WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />}
+            />
+            <Route path={routes.attestering.path} element={<WithDocTitle title="Attestering" Page={Attestering} />}>
+                <Route path={routes.attesterSøknadsbehandling.path} element={<AttesterSøknadsbehandling />} />
+                <Route path={routes.attesterRevurdering.path} element={<AttesterRevurdering />} />
+                <Route path={routes.attesterKlage.path} element={<AttesterKlage />} />
             </Route>
-            <Route path={routes.avsluttBehandling.path} element={<AvsluttBehandling />} />
-            <Route path={routes.revurderValgtSak.path} element={<RevurderingIntroPage />} />
-            <Route path={routes.revurderValgtRevurdering.path} element={<Revurdering />} />
-            <Route path={routes.vedtaksoppsummering.path} element={<Vedtaksoppsummering />} />
-            <Route path={routes.saksbehandlingSendTilAttestering.path} element={<SendTilAttesteringPage />} />
-            <Route path={routes.saksbehandlingVilkårsvurdering.path} element={<Vilkår />} />
-            <Route path={routes.alleDokumenterForSak.path} element={<DokumenterPage />} />
-            <Route path={routes.kontrollsamtale.path} element={<NyDatoForKontrollsamtale />} />
-        </Route>
-        <Route
-            path={routes.saksoversiktIndex.path}
-            element={<WithDocTitle title="Behandlingsoversikt" Page={Behandlingsoversikt} />}
-        />
-        <Route path={routes.attestering.path + '*'} element={<WithDocTitle title="Attestering" Page={Attestering} />}>
-            <Route path={routes.attesterSøknadsbehandling.path} element={<AttesterSøknadsbehandling />} />
-            <Route path={routes.attesterRevurdering.path} element={<AttesterRevurdering />} />
-            <Route path={routes.attesterKlage.path} element={<AttesterKlage />} />
-        </Route>
-        <Route path={routes.drift.path} element={<WithDocTitle title="Drift" Page={Drift} />} />
-        <Route path="*" element={<>404</>} />
-    </Routes>
-);
+            <Route path={routes.drift.path} element={<WithDocTitle title="Drift" Page={Drift} />} />
+            <Route path="*" element={<>404</>} />
+        </Routes>
+    );
+};
 
 /* eslint-disable-next-line no-undef */
 export default Root;

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,32 +1,22 @@
 // eslint-disable-next-line
-import * as RemoteData from '@devexperts/remote-data-ts';
-import { Heading, Link, Loader } from '@navikt/ds-react';
-import React, { useEffect, Suspense } from 'react';
+import { Loader } from '@navikt/ds-react';
+import React, { Suspense, useEffect } from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, useLocation, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 
-import { ErrorCode } from '~src/api/apiClient';
-import { LOGIN_URL } from '~src/api/authUrl';
-import { FeatureToggle } from '~src/api/featureToggleApi';
-import { UserProvider } from '~src/context/userContext';
-import { FeatureToggleProvider, useFeatureToggle } from '~src/lib/featureToggles';
-import { pipe } from '~src/lib/fp';
-import enableHotjar from '~src/lib/tracking/hotjar';
+import { FeatureToggleProvider } from '~src/lib/featureToggles';
 import Attestering from '~src/pages/saksbehandling/attestering/Attestering';
 import AttesterKlage from '~src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage';
 import AttesterRevurdering from '~src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering';
 import AttesterSøknadsbehandling from '~src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling';
-import { LoggedInUser } from '~src/types/LoggedInUser';
 
 import ErrorBoundary from './components/errorBoundary/ErrorBoundary';
-import Header from './components/header/Header';
 import WithDocTitle from './components/WithDocTitle';
-import * as meSlice from './features/me/me.slice';
 import * as routes from './lib/routes';
-import Store, { useAppDispatch, useAppSelector } from './redux/Store';
-import * as styles from './root.module.less';
+import Store from './redux/Store';
 
 import './externalStyles';
+import { ContentWrapper } from './utils/router/ContentWrapper';
 
 const Drift = React.lazy(() => import('~/src/pages/drift'));
 const HomePage = React.lazy(() => import('~/src/pages/HomePage'));
@@ -84,62 +74,6 @@ const AppRoutes = () => (
         <Route path="*" element={<>404</>} />
     </Routes>
 );
-
-const ContentWrapper: React.FC = (props) => {
-    const loggedInUser = useAppSelector((s) => s.me.me);
-
-    const dispatch = useAppDispatch();
-
-    useEffect(() => {
-        if (RemoteData.isInitial(loggedInUser)) {
-            dispatch(meSlice.fetchMe());
-        }
-    }, [loggedInUser._tag]);
-
-    const hotjarToggle = useFeatureToggle(FeatureToggle.Hotjar);
-    useEffect(() => {
-        hotjarToggle && enableHotjar();
-    }, [hotjarToggle]);
-
-    return (
-        <div>
-            <a href="#main-content" className="sr-only sr-only-focusable">
-                Hopp til innhold
-            </a>
-            <Header
-                user={pipe(
-                    loggedInUser,
-                    RemoteData.getOrElse<unknown, LoggedInUser | null>(() => null)
-                )}
-            />
-            <main className={styles.contentContainer} id="main-content" tabIndex={-1}>
-                {pipe(
-                    loggedInUser,
-                    RemoteData.fold(
-                        () => <Loader />,
-                        () => <Loader />,
-                        (err) => {
-                            return (
-                                <div className={styles.ikkeTilgangContainer}>
-                                    <Heading level="1" size="medium" className={styles.overskrift}>
-                                        {err.statusCode === ErrorCode.NotAuthenticated ||
-                                        err.statusCode === ErrorCode.Unauthorized
-                                            ? 'Ikke tilgang'
-                                            : 'En feil oppstod'}
-                                    </Heading>
-                                    <Link href={`${LOGIN_URL}?redirectTo=${window.location.pathname}`}>
-                                        Logg inn på nytt
-                                    </Link>
-                                </div>
-                            );
-                        },
-                        (u) => <UserProvider user={u}>{props.children}</UserProvider>
-                    )
-                )}
-            </main>
-        </div>
-    );
-};
 
 /* eslint-disable-next-line no-undef */
 export default Root;

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -162,7 +162,7 @@ export const attesterKlage: Route<{ sakId: string; klageId: string }> = {
 
 //---------------Stans------------------------------
 export const stansRoot: Route<{ sakId: string }> = {
-    path: 'stans',
+    path: 'stans/*',
     absPath: '/saksoversikt/:sakId/stans',
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/stans`,
 };

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -31,25 +31,25 @@ export const drift: Route<never> = {
 
 //-------------Søknad--------------------------------
 export const soknad: Route<never> = {
-    path: '/soknad/',
+    path: '/soknad/*',
     absPath: '/soknad/',
     createURL: () => '/soknad/',
 };
 
 export const soknadPersonSøk: Route<{ papirsøknad?: boolean }> = {
-    path: '/personsok',
+    path: 'personsok',
     absPath: '/soknad/personsok',
     createURL: (args) => '/soknad/personsok' + (args.papirsøknad ? '?papirsoknad=true' : ''),
 };
 
 export const soknadsutfylling: Route<{ step: Søknadsteg; papirsøknad?: boolean }> = {
-    path: '/utfylling/:step',
+    path: 'utfylling/:step',
     absPath: '/soknad/utfylling/:step',
     createURL: (args) => `/soknad/utfylling/${args.step}`,
 };
 
 export const søkandskvittering: Route<never> = {
-    path: '/kvittering',
+    path: 'kvittering',
     absPath: '/soknad/kvittering',
     createURL: () => `/soknad/kvittering`,
 };
@@ -64,7 +64,7 @@ export const saksoversiktIndex: Route<never> = {
 export const saksoversiktValgtSak: Route<{
     sakId: string;
 }> = {
-    path: '/saksoversikt/:sakId/',
+    path: '/saksoversikt/:sakId/*',
     absPath: '/saksoversikt/:sakId/',
     createURL: (args) => `/saksoversikt/${args.sakId}`,
 };
@@ -137,7 +137,7 @@ export const alleDokumenterForSak: Route<{ sakId: string }> = {
 
 //---------------Attestering-------------------------
 export const attestering: Route<{ sakId: string }> = {
-    path: '/attestering/:sakId/',
+    path: '/attestering/:sakId/*',
     absPath: '/attestering/:sakId/',
     createURL: (args) => `/attestering/${args.sakId}`,
 };

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -111,6 +111,7 @@ export const saksbehandlingSendTilAttestering: Route<{
 }> = {
     path: `/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
     absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
+    absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
     createURL: (args) => `/saksoversikt/${args.sakId}/${args.behandlingId}/${SaksbehandlingMenyvalg.Vedtak}/`,
 };
 

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -111,7 +111,6 @@ export const saksbehandlingSendTilAttestering: Route<{
 }> = {
     path: `/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
     absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
-    absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
     createURL: (args) => `/saksoversikt/${args.sakId}/${args.behandlingId}/${SaksbehandlingMenyvalg.Vedtak}/`,
 };
 
@@ -153,19 +152,19 @@ export const attestering: Route<{ sakId: string }> = {
 };
 
 export const attesterSøknadsbehandling: Route<{ sakId: string; behandlingId: string }> = {
-    path: '/behandling/:behandlingId/',
+    path: 'behandling/:behandlingId/',
     absPath: '/attestering/:sakId/behandling/:behandlingId/',
     createURL: (args) => `/attestering/${args.sakId}/behandling/${args.behandlingId}`,
 };
 
 export const attesterRevurdering: Route<{ sakId: string; revurderingId: string }> = {
-    path: '/revurdering/:revurderingId/',
+    path: 'revurdering/:revurderingId/',
     absPath: '/attestering/:sakId/revurdering/:revurderingId/',
     createURL: (args) => `/attestering/${args.sakId}/revurdering/${args.revurderingId}`,
 };
 
 export const attesterKlage: Route<{ sakId: string; klageId: string }> = {
-    path: '/klage/:klageId/',
+    path: 'klage/:klageId/',
     absPath: '/attestering/:sakId/klage/:klageId/',
     createURL: (args) => `/attestering/${args.sakId}/klage/${args.klageId}`,
 };

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -71,7 +71,7 @@ export const saksoversiktValgtSak: Route<{
 
 //---------------Vedtak--------------------------------
 export const vedtaksoppsummering: Route<{ sakId: string; vedtakId: string }> = {
-    path: '/vedtak/:vedtakId/',
+    path: 'vedtak/:vedtakId/',
     absPath: '/saksoversikt/:sakId/vedtak/:vedtakId/',
     createURL: ({ sakId, vedtakId }) => `/saksoversikt/${sakId}/vedtak/${vedtakId}/`,
 };
@@ -81,7 +81,7 @@ export const avsluttBehandling: Route<{
     sakId: string;
     id: string;
 }> = {
-    path: '/:id/avsluttBehandling/',
+    path: ':id/avsluttBehandling/',
     absPath: '/saksoversikt/:sakId/:id/avsluttBehandling/',
     createURL: (args) => `/saksoversikt/${args.sakId}/${args.id}/avsluttBehandling`,
 };
@@ -96,20 +96,11 @@ export const saksoversiktValgtBehandling: Route<{
     createURL: (args) => `/saksoversikt/${args.sakId}/${args.behandlingId}/${args.meny}/`,
 };
 
-export const saksbehandlingBeregning: Route<{
-    sakId: string;
-    behandlingId: string;
-}> = {
-    path: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Beregning}/`,
-    absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Beregning}/`,
-    createURL: (args) => `/saksoversikt/${args.sakId}/${args.behandlingId}/${SaksbehandlingMenyvalg.Beregning}/`,
-};
-
 export const saksbehandlingSendTilAttestering: Route<{
     sakId: string;
     behandlingId: string;
 }> = {
-    path: `/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
+    path: `:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
     absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vedtak}/`,
     createURL: (args) => `/saksoversikt/${args.sakId}/${args.behandlingId}/${SaksbehandlingMenyvalg.Vedtak}/`,
 };
@@ -119,27 +110,27 @@ export const saksbehandlingVilkårsvurdering: Route<{
     behandlingId: string;
     vilkar: Vilkårtype;
 }> = {
-    path: `/:behandlingId/${SaksbehandlingMenyvalg.Vilkår}/:vilkar`,
+    path: `:behandlingId/${SaksbehandlingMenyvalg.Vilkår}/:vilkar`,
     absPath: `/saksoversikt/:sakId/:behandlingId/${SaksbehandlingMenyvalg.Vilkår}/:vilkar`,
     createURL: ({ vilkar = Vilkårtype.Virkningstidspunkt, ...args }) =>
         `/saksoversikt/${args.sakId}/${args.behandlingId}/${SaksbehandlingMenyvalg.Vilkår}/${vilkar}`,
 };
 
 export const revurderValgtSak: Route<{ sakId: string }> = {
-    path: `/revurder/`,
+    path: `revurder/`,
     absPath: `/saksoversikt/:sakId/revurder/`,
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/revurder`,
 };
 
 export const revurderValgtRevurdering: Route<{ sakId: string; steg: RevurderingSteg; revurderingId: string }> = {
-    path: `/revurdering/:revurderingId/:steg/`,
+    path: `revurdering/:revurderingId/:steg/`,
     absPath: `/saksoversikt/:sakId/revurdering/:revurderingId/:steg/`,
     createURL: ({ sakId, steg, revurderingId }) => `/saksoversikt/${sakId}/revurdering/${revurderingId}/${steg}`,
 };
 
 //---------------Dokumenter-------------------------
 export const alleDokumenterForSak: Route<{ sakId: string }> = {
-    path: `/dokumenter/`,
+    path: `dokumenter/`,
     absPath: `/saksoversikt/:sakId/dokumenter/`,
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/dokumenter`,
 };
@@ -171,25 +162,25 @@ export const attesterKlage: Route<{ sakId: string; klageId: string }> = {
 
 //---------------Stans------------------------------
 export const stansRoot: Route<{ sakId: string }> = {
-    path: '/stans',
+    path: 'stans',
     absPath: '/saksoversikt/:sakId/stans',
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/stans`,
 };
 
 export const stansRoute: Route<{ sakId: string; revurderingId: string }> = {
-    path: '/stans/:revurderingId',
+    path: ':revurderingId',
     absPath: '/saksoversikt/:sakId/stans/:revurderingId',
     createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/stans/${revurderingId}`,
 };
 
 export const stansOppsummeringRoute: Route<{ sakId: string; revurderingId: string }> = {
-    path: '/stans/:revurderingId/oppsummering',
+    path: ':revurderingId/oppsummering',
     absPath: '/saksoversikt/:sakId/stans/:revurderingId/oppsummering',
     createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/stans/${revurderingId}/oppsummering`,
 };
 
 export const gjenopptaStansRoot: Route<{ sakId: string }> = {
-    path: '/gjenoppta/',
+    path: 'gjenoppta/',
     absPath: '/saksoversikt/:sakId/gjenoppta/',
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/gjenoppta/`,
 };
@@ -201,26 +192,35 @@ export const gjenopptaStansRoute: Route<{ sakId: string; revurderingId: string }
 };
 
 export const gjenopptaStansOppsummeringRoute: Route<{ sakId: string; revurderingId: string }> = {
-    path: '/gjenoppta/:revurderingId/oppsummering',
+    path: ':revurderingId/oppsummering',
     absPath: '/saksoversikt/:sakId/gjenoppta/:revurderingId/oppsummering',
     createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/gjenoppta/${revurderingId}/oppsummering`,
 };
 //---------------Klage------------------------------
-export const klageOpprett: Route<{
+export const klageRoot: Route<{
     sakId: string;
 }> = {
-    path: '/klage/opprett',
-    absPath: 'saksoversikt/:sakId/klage/opprett',
+    path: 'klage',
+    absPath: 'saksoversikt/:sakId/klage',
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/klage/opprett`,
 };
+
 export const klage: Route<{
     sakId: string;
     klageId: string;
     steg: KlageSteg;
 }> = {
-    path: '/klage/:klageId/:steg/',
+    path: ':klageId/:steg/',
     absPath: '/saksoversikt/:sakId/klage/:klageId/:steg/',
     createURL: (args) => `/saksoversikt/${args.sakId}/klage/${args.klageId}/${args.steg}/`,
+};
+
+export const klageOpprett: Route<{
+    sakId: string;
+}> = {
+    path: 'opprett',
+    absPath: 'saksoversikt/:sakId/klage/opprett',
+    createURL: ({ sakId }) => `/saksoversikt/${sakId}/klage/opprett`,
 };
 
 export interface SuccessNotificationState {
@@ -241,7 +241,7 @@ export const createSakIntroLocation = (
 export const kontrollsamtale: Route<{
     sakId: string;
 }> = {
-    path: '/kontrollsamtale/',
+    path: 'kontrollsamtale/',
     absPath: '/saksoversikt/:sakId/kontrollsamtale/',
     createURL: (args) => `/saksoversikt/${args.sakId}/kontrollsamtale/`,
 };

--- a/src/pages/klage/Klage.tsx
+++ b/src/pages/klage/Klage.tsx
@@ -1,17 +1,18 @@
 import { Heading } from '@navikt/ds-react';
 import React from 'react';
 
+import { useOutletContext } from '~node_modules/react-router-dom';
 import Framdriftsindikator from '~src/components/framdriftsindikator/Framdriftsindikator';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { KlageSteg } from '~src/pages/saksbehandling/types';
-import { Sak } from '~src/types/Sak';
 import {
     erKlageVilkårsvurdertUtfyltEllerSenere,
     getDefaultFramdriftsindikatorLinjer,
     getFramdriftsindikatorLinjer,
     getPartialFramdriftsindikatorLinjeInfo,
 } from '~src/utils/klage/klageUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import AvvistKlage from './avvistKlage/AvvistKlage';
 import messages from './klage-nb';
@@ -20,7 +21,8 @@ import SendKlageTilAttestering from './sendKlageTilAttestering/SendKlageTilAttes
 import VurderFormkrav from './vurderFormkrav/VurderFormkrav';
 import VurderingAvKlage from './vurderingAvKlage/VurderingAvKlage';
 
-const Klage = (props: { sak: Sak }) => {
+const Klage = () => {
+    const props = useOutletContext<AttesteringContext>();
     const urlParams = Routes.useRouteParams<typeof Routes.klage>();
     const klage = props.sak.klager.find((k) => k.id === urlParams.klageId);
     const { formatMessage } = useI18n({ messages });

--- a/src/pages/klage/opprettKlage/OpprettKlage.tsx
+++ b/src/pages/klage/opprettKlage/OpprettKlage.tsx
@@ -4,7 +4,7 @@ import { Button, Heading, HelpText, Loader, TextField } from '@navikt/ds-react';
 import * as DateFns from 'date-fns';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import DatePicker from '~src/components/datePicker/DatePicker';
@@ -16,7 +16,7 @@ import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import yup from '~src/lib/validering';
 import { KlageSteg } from '~src/pages/saksbehandling/types';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from '../klage-nb';
 
@@ -41,7 +41,8 @@ const schema = yup.object<FormData>({
         .max(DateFns.endOfDay(new Date())),
 });
 
-const OpprettKlage = (props: { sak: Sak }) => {
+const OpprettKlage = () => {
+    const props = useOutletContext<AttesteringContext>();
     const [opprettKlageStatus, opprettKlage] = useAsyncActionCreator(klageActions.opprettKlage);
     const { handleSubmit, register, control, formState } = useForm<FormData>({
         resolver: yupResolver(schema),

--- a/src/pages/kontrollsamtale/KontrollsamtalePage.tsx
+++ b/src/pages/kontrollsamtale/KontrollsamtalePage.tsx
@@ -4,8 +4,9 @@ import { Alert, BodyLong, Button, Heading, Loader } from '@navikt/ds-react';
 import startOfTomorrow from 'date-fns/startOfTomorrow';
 import * as React from 'react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
+import { isEmpty } from '~node_modules/fp-ts/lib/Array';
 import { ApiError } from '~src/api/apiClient';
 import * as kontrollsamtaleApi from '~src/api/kontrollsamtaleApi';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
@@ -16,16 +17,15 @@ import { useI18n } from '~src/lib/i18n';
 import { Nullable } from '~src/lib/types';
 import { Kontrollsamtale } from '~src/types/Kontrollsamtale';
 import { formatDate, toDateOrNull } from '~src/utils/date/dateUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import * as styles from './kontrollsamtalePage.module.less';
 import messages from './message-nb';
 
-interface Props {
-    sakId: string;
-    kanKalleInn: boolean;
-}
-
-const KontrollsamtalePage = (props: Props) => {
+const KontrollsamtalePage = () => {
+    const props = useOutletContext<AttesteringContext>();
+    const sakId = props.sak.id;
+    const kanKalleInn = !isEmpty(props.sak.utbetalinger);
     const [nyDatoStatus, settNyDatoPost] = useApiCall(kontrollsamtaleApi.settNyDatoForKontrollsamtale);
     const [nesteKontrollsamtale, fetchNesteKontrollsamtale] = useApiCall(kontrollsamtaleApi.fetchNesteKontrollsamtale);
     const [nyDato, settNyDato] = useState<Nullable<Date>>(null);
@@ -34,12 +34,12 @@ const KontrollsamtalePage = (props: Props) => {
     const { formatMessage } = useI18n({ messages });
 
     const handleNyDatoForKontrollsamtaleClick = (nyDato: Date) => {
-        settNyDatoPost({ sakId: props.sakId, nyDato: nyDato }, () => fetchNesteKontrollsamtale(props.sakId));
+        settNyDatoPost({ sakId: sakId, nyDato: nyDato }, () => fetchNesteKontrollsamtale(sakId));
     };
 
     React.useEffect(() => {
-        fetchNesteKontrollsamtale(props.sakId);
-    }, [props.sakId]);
+        fetchNesteKontrollsamtale(sakId);
+    }, [sakId]);
 
     return (
         <div className={styles.kontrollsamtalePage}>
@@ -52,7 +52,7 @@ const KontrollsamtalePage = (props: Props) => {
                         <Heading level="1" size="large">
                             {formatMessage('kontrollsamtale')}
                         </Heading>
-                        {!props.kanKalleInn ? (
+                        {!kanKalleInn ? (
                             <SkjemaelementFeilmelding>
                                 {formatMessage('ingenUtbetalingsperioder')}
                             </SkjemaelementFeilmelding>

--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -1,11 +1,9 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { Loader } from '@navikt/ds-react';
-import { isEmpty } from 'fp-ts/lib/Array';
 import React, { useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
-import { useNavigate, Routes, Route } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
-import { Person } from '~src/api/personApi';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import Personlinje from '~src/components/personlinje/Personlinje';
 import * as personSlice from '~src/features/person/person.slice';
@@ -14,33 +12,9 @@ import { pipe } from '~src/lib/fp';
 import { Languages } from '~src/lib/i18n';
 import * as routes from '~src/lib/routes';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
-import { Sak } from '~src/types/Sak';
-import { erInformasjonsRevurdering } from '~src/utils/revurdering/revurderingUtils';
 
 import messages from './saksoversikt-nb';
 import * as styles from './saksoversikt.module.less';
-
-const Gjenoppta = React.lazy(() => import('./stans/gjenoppta/gjenoppta'));
-const StansOppsummering = React.lazy(() => import('~src/pages/saksbehandling/stans/stansOppsummering'));
-const Vilkår = React.lazy(() => import('./søknadsbehandling/vilkår/Vilkår'));
-const SendTilAttesteringPage = React.lazy(
-    () => import('./søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage')
-);
-const Vedtaksoppsummering = React.lazy(() => import('~src/pages/saksbehandling/vedtak/Vedtaksoppsummering'));
-const AvsluttBehandling = React.lazy(() => import('./avsluttBehandling/AvsluttBehandling'));
-const Revurdering = React.lazy(() => import('./revurdering/Revurdering'));
-const Sakintro = React.lazy(() => import('./sakintro/Sakintro'));
-const DokumenterPage = React.lazy(() => import('~src/pages/saksbehandling/dokumenter/DokumenterPage'));
-const StansPage = React.lazy(() => import('./stans/Stans'));
-const OpprettKlage = React.lazy(() => import('~src/pages/klage/opprettKlage/OpprettKlage'));
-const Klage = React.lazy(() => import('~src/pages/klage/Klage'));
-const NyDatoForKontrollsamtale = React.lazy(() => import('~src/pages/kontrollsamtale/KontrollsamtalePage'));
-const RevurderingIntroPage = React.lazy(
-    () => import('~src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroPage')
-);
-const GjenopptaOppsummering = React.lazy(
-    () => import('~src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering')
-);
 
 const Saksoversikt = () => {
     const urlParams = routes.useRouteParams<typeof routes.saksoversiktValgtSak>();
@@ -83,7 +57,7 @@ const Saksoversikt = () => {
                             <Personlinje søker={søker} sakInfo={{ sakId: sak.id, saksnummer: sak.saksnummer }} />
                             <div className={styles.container}>
                                 <div className={styles.mainContent}>
-                                    <SakRoutes sak={sak} søker={søker} />
+                                    <Outlet context={{ sak, søker }} />
                                 </div>
                             </div>
                         </>
@@ -93,46 +67,5 @@ const Saksoversikt = () => {
         </IntlProvider>
     );
 };
-
-const SakRoutes = ({ sak, søker }: { sak: Sak; søker: Person }) => (
-    <Routes>
-        <Route path={'/'} element={<Sakintro sak={sak} />} />
-        <Route path={routes.klageOpprett.path} element={<OpprettKlage sak={sak} />} />
-        <Route path={routes.klage.path} element={<Klage sak={sak} />} />
-        <Route path={routes.stansOppsummeringRoute.path} element={<StansOppsummering sak={sak} />} />
-        <Route path={routes.stansRoot.path} element={<StansPage sak={sak} />} />
-        <Route path={routes.gjenopptaStansOppsummeringRoute.path} element={<GjenopptaOppsummering sak={sak} />} />
-        <Route path={routes.gjenopptaStansRoot.path} element={<Gjenoppta sak={sak} />} />
-        <Route path={routes.avsluttBehandling.path} element={<AvsluttBehandling sak={sak} />} />
-        <Route
-            path={routes.revurderValgtSak.path}
-            element={
-                <RevurderingIntroPage
-                    sakId={sak.id}
-                    utbetalinger={sak.utbetalinger}
-                    informasjonsRevurdering={undefined}
-                />
-            }
-        />
-        <Route
-            path={routes.revurderValgtRevurdering.path + '*'}
-            element={
-                <Revurdering
-                    sakId={sak.id}
-                    utbetalinger={sak.utbetalinger}
-                    informasjonsRevurderinger={sak.revurderinger.filter(erInformasjonsRevurdering)}
-                />
-            }
-        />
-        <Route path={routes.vedtaksoppsummering.path} element={<Vedtaksoppsummering sak={sak} />} />
-        <Route path={routes.saksbehandlingSendTilAttestering.path} element={<SendTilAttesteringPage sak={sak} />} />
-        <Route path={routes.saksbehandlingVilkårsvurdering.path} element={<Vilkår sak={sak} søker={søker} />} />
-        <Route path={routes.alleDokumenterForSak.path} element={<DokumenterPage sak={sak} />} />
-        <Route
-            path={routes.kontrollsamtale.path}
-            element={<NyDatoForKontrollsamtale sakId={sak.id} kanKalleInn={!isEmpty(sak.utbetalinger)} />}
-        />
-    </Routes>
-);
 
 export default Saksoversikt;

--- a/src/pages/saksbehandling/Saksoversikt.tsx
+++ b/src/pages/saksbehandling/Saksoversikt.tsx
@@ -5,15 +5,16 @@ import React, { useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import { useNavigate, Routes, Route } from 'react-router-dom';
 
+import { Person } from '~src/api/personApi';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import Personlinje from '~src/components/personlinje/Personlinje';
-import { SøknadsbehandlingDraftProvider } from '~src/context/søknadsbehandlingDraftContext';
 import * as personSlice from '~src/features/person/person.slice';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
 import { pipe } from '~src/lib/fp';
 import { Languages } from '~src/lib/i18n';
 import * as routes from '~src/lib/routes';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
+import { Sak } from '~src/types/Sak';
 import { erInformasjonsRevurdering } from '~src/utils/revurdering/revurderingUtils';
 
 import messages from './saksoversikt-nb';
@@ -59,12 +60,10 @@ const Saksoversikt = () => {
             if (RemoteData.isInitial(søker)) {
                 dispatch(personSlice.fetchPerson({ fnr: sak.value.fnr }));
             } else if (RemoteData.isSuccess(søker) && !urlParams.sakId) {
-                rerouteToSak(sak.value.id);
+                navigate(routes.saksoversiktValgtSak.createURL({ sakId: sak.value.id }));
             }
         }
     }, [sak._tag, søker._tag]);
-
-    const rerouteToSak = (id: string) => navigate(routes.saksoversiktValgtSak.createURL({ sakId: id }));
 
     return (
         <IntlProvider locale={Languages.nb} messages={messages}>
@@ -83,145 +82,9 @@ const Saksoversikt = () => {
                         <>
                             <Personlinje søker={søker} sakInfo={{ sakId: sak.id, saksnummer: sak.saksnummer }} />
                             <div className={styles.container}>
-                                <Routes>
-                                    <Route
-                                        path={routes.klageOpprett.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <OpprettKlage sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.klage.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <Klage sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.stansOppsummeringRoute.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <StansOppsummering sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.stansRoot.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <StansPage sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.gjenopptaStansOppsummeringRoute.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <GjenopptaOppsummering sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.gjenopptaStansRoot.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <Gjenoppta sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.avsluttBehandling.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <AvsluttBehandling sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.revurderValgtSak.path}
-                                        element={
-                                            <RevurderingIntroPage
-                                                sakId={sak.id}
-                                                utbetalinger={sak.utbetalinger}
-                                                informasjonsRevurdering={undefined}
-                                            />
-                                        }
-                                    />
-                                    <Route
-                                        path={routes.revurderValgtRevurdering.path + '*'}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <Revurdering
-                                                    sakId={sak.id}
-                                                    utbetalinger={sak.utbetalinger}
-                                                    informasjonsRevurderinger={sak.revurderinger.filter(
-                                                        erInformasjonsRevurdering
-                                                    )}
-                                                />
-                                            </div>
-                                        }
-                                    />
-                                    <Route
-                                        path={routes.vedtaksoppsummering.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <Vedtaksoppsummering sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.saksbehandlingSendTilAttestering.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <SendTilAttesteringPage sak={sak} />
-                                            </div>
-                                        }
-                                    />
-                                    <Route
-                                        path={routes.saksbehandlingVilkårsvurdering.path}
-                                        element={
-                                            <SøknadsbehandlingDraftProvider>
-                                                <div className={styles.mainContent}>
-                                                    <Vilkår sak={sak} søker={søker} />
-                                                </div>
-                                            </SøknadsbehandlingDraftProvider>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.alleDokumenterForSak.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <DokumenterPage sak={sak} />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route
-                                        path={routes.kontrollsamtale.path}
-                                        element={
-                                            <div className={styles.mainContent}>
-                                                <NyDatoForKontrollsamtale
-                                                    sakId={sak.id}
-                                                    kanKalleInn={!isEmpty(sak.utbetalinger)}
-                                                />
-                                            </div>
-                                        }
-                                    />
-
-                                    <Route path={'/'} element={<Sakintro sak={sak} />} />
-                                </Routes>
+                                <div className={styles.mainContent}>
+                                    <SakRoutes sak={sak} søker={søker} />
+                                </div>
                             </div>
                         </>
                     )
@@ -230,5 +93,46 @@ const Saksoversikt = () => {
         </IntlProvider>
     );
 };
+
+const SakRoutes = ({ sak, søker }: { sak: Sak; søker: Person }) => (
+    <Routes>
+        <Route path={'/'} element={<Sakintro sak={sak} />} />
+        <Route path={routes.klageOpprett.path} element={<OpprettKlage sak={sak} />} />
+        <Route path={routes.klage.path} element={<Klage sak={sak} />} />
+        <Route path={routes.stansOppsummeringRoute.path} element={<StansOppsummering sak={sak} />} />
+        <Route path={routes.stansRoot.path} element={<StansPage sak={sak} />} />
+        <Route path={routes.gjenopptaStansOppsummeringRoute.path} element={<GjenopptaOppsummering sak={sak} />} />
+        <Route path={routes.gjenopptaStansRoot.path} element={<Gjenoppta sak={sak} />} />
+        <Route path={routes.avsluttBehandling.path} element={<AvsluttBehandling sak={sak} />} />
+        <Route
+            path={routes.revurderValgtSak.path}
+            element={
+                <RevurderingIntroPage
+                    sakId={sak.id}
+                    utbetalinger={sak.utbetalinger}
+                    informasjonsRevurdering={undefined}
+                />
+            }
+        />
+        <Route
+            path={routes.revurderValgtRevurdering.path + '*'}
+            element={
+                <Revurdering
+                    sakId={sak.id}
+                    utbetalinger={sak.utbetalinger}
+                    informasjonsRevurderinger={sak.revurderinger.filter(erInformasjonsRevurdering)}
+                />
+            }
+        />
+        <Route path={routes.vedtaksoppsummering.path} element={<Vedtaksoppsummering sak={sak} />} />
+        <Route path={routes.saksbehandlingSendTilAttestering.path} element={<SendTilAttesteringPage sak={sak} />} />
+        <Route path={routes.saksbehandlingVilkårsvurdering.path} element={<Vilkår sak={sak} søker={søker} />} />
+        <Route path={routes.alleDokumenterForSak.path} element={<DokumenterPage sak={sak} />} />
+        <Route
+            path={routes.kontrollsamtale.path}
+            element={<NyDatoForKontrollsamtale sakId={sak.id} kanKalleInn={!isEmpty(sak.utbetalinger)} />}
+        />
+    </Routes>
+);
 
 export default Saksoversikt;

--- a/src/pages/saksbehandling/attestering/Attestering.tsx
+++ b/src/pages/saksbehandling/attestering/Attestering.tsx
@@ -1,9 +1,8 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { Alert, Loader } from '@navikt/ds-react';
 import React, { useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
-import { Person } from '~src/api/personApi';
 import Personlinje from '~src/components/personlinje/Personlinje';
 import * as personSlice from '~src/features/person/person.slice';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
@@ -11,14 +10,9 @@ import { pipe } from '~src/lib/fp';
 import { useI18n } from '~src/lib/i18n';
 import * as routes from '~src/lib/routes';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
-import { Sak } from '~src/types/Sak';
-import { erInformasjonsRevurdering } from '~src/utils/revurdering/revurderingUtils';
 
 import messages from './attestering-nb';
 import * as styles from './attestering.module.less';
-import AttesterKlage from './attesterKlage/AttesterKlage';
-import AttesterRevurdering from './attesterRevurdering/AttesterRevurdering';
-import AttesterSøknadsbehandling from './attesterSøknadsbehandling/AttesterSøknadsbehandling';
 
 const Attestering = () => {
     const dispatch = useAppDispatch();
@@ -54,34 +48,12 @@ const Attestering = () => {
                         }}
                     />
                     <div className={styles.attesteringsKomponentContainer}>
-                        <AttesteringRoutes sak={sakValue} søker={søkerValue} />
+                        <Outlet context={{ sak: sakValue, søker: søkerValue }} />
                     </div>
                 </div>
             )
         )
     );
 };
-
-const AttesteringRoutes = ({ sak, søker }: { sak: Sak; søker: Person }) => (
-    <Routes>
-        <Route
-            path={routes.attesterSøknadsbehandling.path}
-            element={<AttesterSøknadsbehandling sak={sak} søker={søker} />}
-        />
-        <Route
-            path={routes.attesterRevurdering.path}
-            element={
-                <AttesterRevurdering
-                    sakInfo={{ sakId: sak.id, saksnummer: sak.saksnummer }}
-                    informasjonsRevurderinger={sak.revurderinger.filter(erInformasjonsRevurdering)}
-                />
-            }
-        />
-        <Route
-            path={routes.attesterKlage.path}
-            element={<AttesterKlage sakId={sak.id} klager={sak.klager} vedtaker={sak.vedtak} />}
-        />
-    </Routes>
-);
 
 export default Attestering;

--- a/src/pages/saksbehandling/attestering/Attestering.tsx
+++ b/src/pages/saksbehandling/attestering/Attestering.tsx
@@ -3,6 +3,7 @@ import { Alert, Loader } from '@navikt/ds-react';
 import React, { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 
+import { Person } from '~src/api/personApi';
 import Personlinje from '~src/components/personlinje/Personlinje';
 import * as personSlice from '~src/features/person/person.slice';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
@@ -10,6 +11,7 @@ import { pipe } from '~src/lib/fp';
 import { useI18n } from '~src/lib/i18n';
 import * as routes from '~src/lib/routes';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
+import { Sak } from '~src/types/Sak';
 import { erInformasjonsRevurdering } from '~src/utils/revurdering/revurderingUtils';
 
 import messages from './attestering-nb';
@@ -52,38 +54,34 @@ const Attestering = () => {
                         }}
                     />
                     <div className={styles.attesteringsKomponentContainer}>
-                        <Routes>
-                            <Route
-                                path={routes.attesterSøknadsbehandling.path}
-                                element={<AttesterSøknadsbehandling sak={sakValue} søker={søkerValue} />}
-                            />
-                            <Route
-                                path={routes.attesterRevurdering.path}
-                                element={
-                                    <AttesterRevurdering
-                                        sakInfo={{ sakId: sakValue.id, saksnummer: sakValue.saksnummer }}
-                                        informasjonsRevurderinger={sakValue.revurderinger.filter(
-                                            erInformasjonsRevurdering
-                                        )}
-                                    />
-                                }
-                            />
-                            <Route
-                                path={routes.attesterKlage.path}
-                                element={
-                                    <AttesterKlage
-                                        sakId={sakValue.id}
-                                        klager={sakValue.klager}
-                                        vedtaker={sakValue.vedtak}
-                                    />
-                                }
-                            />
-                        </Routes>
+                        <AttesteringRoutes sak={sakValue} søker={søkerValue} />
                     </div>
                 </div>
             )
         )
     );
 };
+
+const AttesteringRoutes = ({ sak, søker }: { sak: Sak; søker: Person }) => (
+    <Routes>
+        <Route
+            path={routes.attesterSøknadsbehandling.path}
+            element={<AttesterSøknadsbehandling sak={sak} søker={søker} />}
+        />
+        <Route
+            path={routes.attesterRevurdering.path}
+            element={
+                <AttesterRevurdering
+                    sakInfo={{ sakId: sak.id, saksnummer: sak.saksnummer }}
+                    informasjonsRevurderinger={sak.revurderinger.filter(erInformasjonsRevurdering)}
+                />
+            }
+        />
+        <Route
+            path={routes.attesterKlage.path}
+            element={<AttesterKlage sakId={sak.id} klager={sak.klager} vedtaker={sak.vedtak} />}
+        />
+    </Routes>
+);
 
 export default Attestering;

--- a/src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage.tsx
+++ b/src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage.tsx
@@ -1,7 +1,8 @@
 import { Alert, Heading } from '@navikt/ds-react';
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useOutletContext } from 'react-router-dom';
 
+import { Person } from '~src/api/personApi';
 import { AttesteringsForm } from '~src/components/attestering/AttesteringsForm';
 import OppsummeringAvKlage from '~src/components/oppsummeringAvKlage/OppsummeringAvKlage';
 import * as klageActions from '~src/features/klage/klageActions';
@@ -9,8 +10,7 @@ import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { UnderkjennelseGrunn } from '~src/types/Behandling';
-import { Klage } from '~src/types/Klage';
-import { Vedtak } from '~src/types/Vedtak';
+import { Sak } from '~src/types/Sak';
 import {
     erKlageINoenFormForAvvist,
     erKlageOpprettholdt,
@@ -23,7 +23,14 @@ import * as sharedStyles from '../sharedStyles.module.less';
 import messages from './attesterKlage-nb';
 import * as styles from './attesterKlage.module.less';
 
-const AttesterKlage = (props: { sakId: string; klager: Klage[]; vedtaker: Vedtak[] }) => {
+interface AttesteringContext {
+    sak: Sak;
+    søker: Person;
+}
+
+const AttesterKlage = () => {
+    const { sak } = useOutletContext<AttesteringContext>();
+    const props = { sakId: sak.id, klager: sak.klager, vedtaker: sak.vedtak };
     const { formatMessage } = useI18n({ messages });
     const navigate = useNavigate();
     const urlParams = Routes.useRouteParams<typeof Routes.attesterKlage>();

--- a/src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage.tsx
+++ b/src/pages/saksbehandling/attestering/attesterKlage/AttesterKlage.tsx
@@ -2,7 +2,6 @@ import { Alert, Heading } from '@navikt/ds-react';
 import React from 'react';
 import { Link, useNavigate, useOutletContext } from 'react-router-dom';
 
-import { Person } from '~src/api/personApi';
 import { AttesteringsForm } from '~src/components/attestering/AttesteringsForm';
 import OppsummeringAvKlage from '~src/components/oppsummeringAvKlage/OppsummeringAvKlage';
 import * as klageActions from '~src/features/klage/klageActions';
@@ -10,23 +9,18 @@ import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { UnderkjennelseGrunn } from '~src/types/Behandling';
-import { Sak } from '~src/types/Sak';
 import {
     erKlageINoenFormForAvvist,
     erKlageOpprettholdt,
     erKlageTilAttestering,
     erKlageTilAttesteringAvvist,
 } from '~src/utils/klage/klageUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import * as sharedStyles from '../sharedStyles.module.less';
 
 import messages from './attesterKlage-nb';
 import * as styles from './attesterKlage.module.less';
-
-interface AttesteringContext {
-    sak: Sak;
-    søker: Person;
-}
 
 const AttesterKlage = () => {
     const { sak } = useOutletContext<AttesteringContext>();

--- a/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
+++ b/src/pages/saksbehandling/attestering/attesterRevurdering/AttesterRevurdering.tsx
@@ -4,7 +4,6 @@ import React, { useEffect } from 'react';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import * as PdfApi from '~src/api/pdfApi';
-import { Person } from '~src/api/personApi';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import { AttesteringsForm } from '~src/components/attestering/AttesteringsForm';
 import Revurderingoppsummering from '~src/components/revurdering/oppsummering/Revurderingoppsummering';
@@ -20,7 +19,6 @@ import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb
 import { useAppDispatch } from '~src/redux/Store';
 import { UnderkjennelseGrunn } from '~src/types/Behandling';
 import { InformasjonsRevurderingStatus, Revurdering } from '~src/types/Revurdering';
-import { Sak } from '~src/types/Sak';
 import {
     erGregulering,
     erInformasjonsRevurdering,
@@ -29,16 +27,12 @@ import {
     hentAvkortingFraRevurdering,
     periodenInneholderTilbakekrevingOgAndreTyper,
 } from '~src/utils/revurdering/revurderingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import * as SharedStyles from '../sharedStyles.module.less';
 
 import messages from './attesterRevurdering-nb';
 import * as styles from './attesterRevurdering.module.less';
-
-interface AttesteringContext {
-    sak: Sak;
-    søker: Person;
-}
 
 const AttesterRevurdering = () => {
     const { sak } = useOutletContext<AttesteringContext>();

--- a/src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling.tsx
+++ b/src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling.tsx
@@ -13,6 +13,7 @@ import * as Routes from '~src/lib/routes';
 import { Behandling, UnderkjennelseGrunn } from '~src/types/Behandling';
 import { Sak } from '~src/types/Sak';
 import { erIverksatt, erTilAttestering } from '~src/utils/behandling/behandlingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from './attesterSøknadsbehandling-nb';
 import * as styles from './attesterSøknadsbehandling.module.less';
@@ -95,11 +96,6 @@ const Attesteringsinnhold = ({
         </div>
     );
 };
-
-interface AttesteringContext {
-    sak: Sak;
-    søker: Person;
-}
 
 const AttesterSøknadsbehandling = () => {
     const props = useOutletContext<AttesteringContext>();

--- a/src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling.tsx
+++ b/src/pages/saksbehandling/attestering/attesterSøknadsbehandling/AttesterSøknadsbehandling.tsx
@@ -1,7 +1,7 @@
 import { Alert } from '@navikt/ds-react';
 import React from 'react';
 import { IntlShape } from 'react-intl';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useOutletContext } from 'react-router-dom';
 
 import { Person } from '~src/api/personApi';
 import { AttesteringsForm } from '~src/components/attestering/AttesteringsForm';
@@ -96,7 +96,13 @@ const Attesteringsinnhold = ({
     );
 };
 
-const AttesterSøknadsbehandling = (props: { sak: Sak; søker: Person }) => {
+interface AttesteringContext {
+    sak: Sak;
+    søker: Person;
+}
+
+const AttesterSøknadsbehandling = () => {
+    const props = useOutletContext<AttesteringContext>();
     const urlParams = Routes.useRouteParams<typeof Routes.attesterSøknadsbehandling>();
     const { intl } = useI18n({ messages });
 

--- a/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling.tsx
+++ b/src/pages/saksbehandling/avsluttBehandling/AvsluttBehandling.tsx
@@ -1,9 +1,10 @@
 import { Alert, Heading, Panel } from '@navikt/ds-react';
 import React from 'react';
 
+import { useOutletContext } from '~node_modules/react-router-dom';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from './avsluttBehandling-nb';
 import * as styles from './avsluttBehandling.module.less';
@@ -11,7 +12,8 @@ import AvsluttKlage from './avsluttKlage/AvsluttKlage';
 import AvsluttRevurdering from './avsluttRevurdering/AvsluttRevurdering';
 import LukkSøknadOgAvsluttBehandling from './lukkSøknad/LukkSøknad';
 
-const AvsluttBehandling = (props: { sak: Sak }) => {
+const AvsluttBehandling = () => {
+    const props = useOutletContext<AttesteringContext>();
     const { formatMessage } = useI18n({ messages });
     const urlParams = Routes.useRouteParams<typeof Routes.avsluttBehandling>();
 

--- a/src/pages/saksbehandling/dokumenter/DokumenterPage.tsx
+++ b/src/pages/saksbehandling/dokumenter/DokumenterPage.tsx
@@ -2,7 +2,7 @@ import * as RemoteData from '@devexperts/remote-data-ts';
 import { Back, FileContent } from '@navikt/ds-icons';
 import { Alert, Button, Heading, Ingress, LinkPanel, Loader, Tag } from '@navikt/ds-react';
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import { ÅpentBrev } from '~src/assets/Illustrations';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
@@ -11,9 +11,9 @@ import { useAsyncActionCreator } from '~src/lib/hooks';
 import { MessageFormatter, useI18n } from '~src/lib/i18n';
 import { saksoversiktValgtSak } from '~src/lib/routes';
 import { Dokument, DokumentIdType } from '~src/types/dokument/Dokument';
-import { Sak } from '~src/types/Sak';
 import * as DateUtils from '~src/utils/date/dateUtils';
 import { getBlob } from '~src/utils/dokumentUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from './dokumenterPage-nb';
 import * as styles from './dokumenterPage.module.less';
@@ -36,7 +36,8 @@ const Header = (props: { saksnummer: number; formatMessage: MessageFormatter<typ
     </div>
 );
 
-const DokumenterPage = (props: { sak: Sak }) => {
+const DokumenterPage = () => {
+    const props = useOutletContext<AttesteringContext>();
     const [dokumenterState, fetchDokumenter] = useAsyncActionCreator(sakSlice.hentDokumenter);
     const navigate = useNavigate();
 

--- a/src/pages/saksbehandling/revurdering/Revurdering.tsx
+++ b/src/pages/saksbehandling/revurdering/Revurdering.tsx
@@ -4,6 +4,7 @@ import * as A from 'fp-ts/Array';
 import * as O from 'fp-ts/Option';
 import React from 'react';
 
+import { useOutletContext } from '~node_modules/react-router-dom';
 import { ApiError } from '~src/api/apiClient';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import Framdriftsindikator, {
@@ -19,11 +20,12 @@ import * as routes from '~src/lib/routes';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~src/types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
 import { InformasjonsRevurdering, Vurderingstatus } from '~src/types/Revurdering';
-import { Utbetalingsperiode } from '~src/types/Utbetalingsperiode';
 import {
+    erInformasjonsRevurdering,
     revurderingstegrekkefølge,
     revurderingstegTilInformasjonSomRevurderes,
 } from '~src/utils/revurdering/revurderingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import SkjemaelementFeilmelding from '../../../components/formElements/SkjemaelementFeilmelding';
 import { RevurderingSteg } from '../types';
@@ -39,11 +41,13 @@ const EndringAvFradrag = React.lazy(() => import('./endringAvFradrag/EndringAvFr
 const RevurderingOppsummeringPage = React.lazy(() => import('./OppsummeringPage/RevurderingOppsummeringPage'));
 const Uførhet = React.lazy(() => import('./uførhet/Uførhet'));
 
-const RevurderingPage = (props: {
-    sakId: string;
-    utbetalinger: Utbetalingsperiode[];
-    informasjonsRevurderinger: InformasjonsRevurdering[];
-}) => {
+const RevurderingPage = () => {
+    const { sak } = useOutletContext<AttesteringContext>();
+    const props = {
+        sakId: sak.id,
+        utbetalinger: sak.utbetalinger,
+        informasjonsRevurderinger: sak.revurderinger.filter(erInformasjonsRevurdering),
+    };
     const { formatMessage } = useI18n({ messages: { ...sharedMessages, ...stegmessages } });
 
     const urlParams = routes.useRouteParams<typeof routes.revurderValgtRevurdering>();
@@ -146,13 +150,7 @@ const RevurderingPage = (props: {
             <Heading level="1" size="large" className={styles.tittel}>
                 {formatMessage('revurdering.tittel')}
             </Heading>
-            {urlParams.steg === RevurderingSteg.Periode && (
-                <RevurderingIntroPage
-                    sakId={props.sakId}
-                    utbetalinger={props.utbetalinger}
-                    informasjonsRevurdering={påbegyntRevurdering}
-                />
-            )}
+            {urlParams.steg === RevurderingSteg.Periode && <RevurderingIntroPage />}
             {urlParams.steg === RevurderingSteg.Oppsummering && (
                 <RevurderingOppsummeringPage
                     sakId={props.sakId}

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroPage.tsx
@@ -1,6 +1,6 @@
 import * as DateFns from 'date-fns';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import {
     oppdaterRevurderingsPeriode as oppdaterRevurdering,
@@ -8,9 +8,10 @@ import {
 } from '~src/features/revurdering/revurderingActions';
 import * as Routes from '~src/lib/routes';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
-import { InformasjonSomRevurderes, InformasjonsRevurdering, OpprettetRevurderingGrunn } from '~src/types/Revurdering';
-import { compareUtbetalingsperiode, Utbetalingsperiode } from '~src/types/Utbetalingsperiode';
-import { finnNesteRevurderingsteg } from '~src/utils/revurdering/revurderingUtils';
+import { InformasjonSomRevurderes, OpprettetRevurderingGrunn } from '~src/types/Revurdering';
+import { compareUtbetalingsperiode } from '~src/types/Utbetalingsperiode';
+import { erInformasjonsRevurdering, finnNesteRevurderingsteg } from '~src/utils/revurdering/revurderingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import RevurderingIntroForm from './RevurderingIntroForm';
 
@@ -21,11 +22,16 @@ export interface FormValues {
     begrunnelse: string;
 }
 
-const RevurderingIntroPage = (props: {
-    sakId: string;
-    utbetalinger: Utbetalingsperiode[];
-    informasjonsRevurdering: InformasjonsRevurdering | undefined;
-}) => {
+const RevurderingIntroPage = () => {
+    const { sak } = useOutletContext<AttesteringContext>();
+    const urlParams = Routes.useRouteParams<typeof Routes.revurderValgtRevurdering>();
+
+    const props = {
+        sakId: sak.id,
+        utbetalinger: sak.utbetalinger,
+        informasjonsRevurderinger: sak.revurderinger.filter(erInformasjonsRevurdering), //TODO: Skal passe for begge
+    };
+    const informasjonsRevurdering = props.informasjonsRevurderinger.find((r) => r.id === urlParams.revurderingId);
     const oppdaterRevurderingStatus = useAppSelector((state) => state.sak.oppdaterRevurderingStatus);
     const opprettRevurderingStatus = useAppSelector((state) => state.sak.opprettRevurderingStatus);
 
@@ -34,10 +40,10 @@ const RevurderingIntroPage = (props: {
 
     const forrigeUrl = Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId });
     const thunk = (arg: FormValues) =>
-        props.informasjonsRevurdering
+        informasjonsRevurdering
             ? oppdaterRevurdering({
                   sakId: props.sakId,
-                  revurderingId: props.informasjonsRevurdering.id,
+                  revurderingId: informasjonsRevurdering.id,
                   ...arg,
               })
             : opprettRevurdering({
@@ -47,7 +53,7 @@ const RevurderingIntroPage = (props: {
 
     const endre = async (arg: FormValues, goTo: 'neste' | 'avbryt') => {
         const response = await dispatch(thunk(arg));
-        if ((props.informasjonsRevurdering ? oppdaterRevurdering : opprettRevurdering).fulfilled.match(response)) {
+        if ((informasjonsRevurdering ? oppdaterRevurdering : opprettRevurdering).fulfilled.match(response)) {
             navigate(
                 goTo === 'avbryt'
                     ? forrigeUrl
@@ -70,7 +76,7 @@ const RevurderingIntroPage = (props: {
         <RevurderingIntroForm
             save={endre}
             tilbakeUrl={forrigeUrl}
-            revurdering={props.informasjonsRevurdering}
+            revurdering={informasjonsRevurdering}
             maxFraOgMed={DateFns.parseISO(sisteUtbetaling.tilOgMed)}
             minFraOgMed={DateFns.parseISO(førsteUtbetaling.fraOgMed)}
             opprettRevurderingStatus={opprettRevurderingStatus}

--- a/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroPage.tsx
+++ b/src/pages/saksbehandling/revurdering/revurderingIntro/RevurderingIntroPage.tsx
@@ -29,7 +29,7 @@ const RevurderingIntroPage = () => {
     const props = {
         sakId: sak.id,
         utbetalinger: sak.utbetalinger,
-        informasjonsRevurderinger: sak.revurderinger.filter(erInformasjonsRevurdering), //TODO: Skal passe for begge
+        informasjonsRevurderinger: sak.revurderinger.filter(erInformasjonsRevurdering),
     };
     const informasjonsRevurdering = props.informasjonsRevurderinger.find((r) => r.id === urlParams.revurderingId);
     const oppdaterRevurderingStatus = useAppSelector((state) => state.sak.oppdaterRevurderingStatus);

--- a/src/pages/saksbehandling/sakintro/Sakintro.tsx
+++ b/src/pages/saksbehandling/sakintro/Sakintro.tsx
@@ -4,7 +4,7 @@ import { Alert, Button, LinkPanel, Loader, Popover } from '@navikt/ds-react';
 import { isEmpty } from 'fp-ts/lib/Array';
 import React, { useState } from 'react';
 import { IntlShape } from 'react-intl';
-import { Link } from 'react-router-dom';
+import { Link, useOutletContext } from 'react-router-dom';
 
 import { FeatureToggle } from '~src/api/featureToggleApi';
 import { ÅpentBrev } from '~src/assets/Illustrations';
@@ -16,10 +16,10 @@ import * as Routes from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
 import Utbetalinger from '~src/pages/saksbehandling/sakintro/Utbetalinger';
 import { Behandling } from '~src/types/Behandling';
-import { Sak } from '~src/types/Sak';
 import { Søknad } from '~src/types/Søknad';
 import { erIverksatt } from '~src/utils/behandling/behandlingUtils';
 import { splittAvsluttedeOgÅpneRevurderinger } from '~src/utils/revurdering/revurderingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 import { getIverksatteInnvilgedeSøknader, getIverksatteAvslåtteSøknader } from '~src/utils/søknad/søknadUtils';
 
 import KlageLister from './KlageLister';
@@ -42,7 +42,8 @@ enum NyBehandling {
     KLAGE = 'KLAGE',
 }
 
-const Sakintro = (props: { sak: Sak }) => {
+const Sakintro = () => {
+    const props = useOutletContext<AttesteringContext>();
     const { intl } = useI18n({ messages });
     const locationState = useNotificationFromLocation();
 

--- a/src/pages/saksbehandling/stans/Stans.tsx
+++ b/src/pages/saksbehandling/stans/Stans.tsx
@@ -3,7 +3,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Heading, Loader, Select, Textarea } from '@navikt/ds-react';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import DatePicker from '~src/components/datePicker/DatePicker';
@@ -15,14 +15,10 @@ import { Nullable } from '~src/lib/types';
 import yup, { getDateErrorMessage } from '~src/lib/validering';
 import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb';
 import { Revurdering, OpprettetRevurderingGrunn, StansAvYtelse } from '~src/types/Revurdering';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from './stans-nb';
 import * as styles from './stans.module.less';
-
-interface Props {
-    sak: Sak;
-}
 
 interface FormData {
     årsak: Nullable<OpprettetRevurderingGrunn>;
@@ -46,7 +42,8 @@ function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
     };
 }
 
-const Stans = (props: Props) => {
+const Stans = () => {
+    const props = useOutletContext<AttesteringContext>();
     const navigate = useNavigate();
     const urlParams = Routes.useRouteParams<typeof Routes.stansRoute>();
     const revurdering = props.sak.revurderinger.find((r) => r.id === urlParams.revurderingId) ?? null;

--- a/src/pages/saksbehandling/stans/Stans.tsx
+++ b/src/pages/saksbehandling/stans/Stans.tsx
@@ -159,7 +159,7 @@ const Stans = () => {
                         variant="secondary"
                         onClick={() => {
                             if (urlParams.revurderingId) {
-                                return navigate(Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id }));
+                                navigate(Routes.saksoversiktValgtSak.createURL({ sakId: props.sak.id }));
                             }
                             navigate(-1);
                         }}

--- a/src/pages/saksbehandling/stans/components/StansOppsummeringskomponent.tsx
+++ b/src/pages/saksbehandling/stans/components/StansOppsummeringskomponent.tsx
@@ -48,7 +48,12 @@ const StansOppsummeringskomponent = (props: Props) => {
                 </div>
             )}
             <div className={styles.iverksett}>
-                <Button variant="secondary" onClick={() => knapper?.tilbake?.onClick() ?? navigate(-1)}>
+                <Button
+                    variant="secondary"
+                    onClick={() => {
+                        knapper?.tilbake?.onClick ? knapper.tilbake.onClick() : navigate(-1);
+                    }}
+                >
                     {knapper?.tilbake?.tekst ?? intl.formatMessage({ id: 'stans.bunnknapper.tilbake' })}
                     {knapper?.tilbake?.spinner && <Loader />}
                 </Button>

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -13,7 +13,7 @@ import * as Routes from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
 import yup from '~src/lib/validering';
 import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb';
-import { Gjenopptak, OpprettetRevurderingGrunn, Revurdering } from '~src/types/Revurdering';
+import { OpprettetRevurderingGrunn, Revurdering } from '~src/types/Revurdering';
 import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from './gjenoppta-nb';
@@ -77,11 +77,10 @@ const Gjenoppta = () => {
             årsak: values.årsak,
             begrunnelse: values.begrunnelse,
         };
-        const onSuccess = (gjenopptak: Gjenopptak) => {
+        const onSuccess = () => {
             navigate(
-                Routes.gjenopptaStansOppsummeringRoute.createURL({
+                Routes.saksoversiktValgtSak.createURL({
                     sakId: urlParams.sakId ?? '',
-                    revurderingId: gjenopptak.id,
                 })
             );
         };

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -3,7 +3,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Heading, Loader, Select, Textarea } from '@navikt/ds-react';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
 import * as revurderingActions from '~src/features/revurdering/revurderingActions';
@@ -14,14 +14,10 @@ import { Nullable } from '~src/lib/types';
 import yup from '~src/lib/validering';
 import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb';
 import { Gjenopptak, OpprettetRevurderingGrunn, Revurdering } from '~src/types/Revurdering';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import messages from './gjenoppta-nb';
 import * as styles from './gjenoppta.module.less';
-
-interface Props {
-    sak: Sak;
-}
 
 interface FormData {
     årsak: Nullable<OpprettetRevurderingGrunn>;
@@ -42,7 +38,8 @@ function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
     };
 }
 
-const Gjenoppta = (props: Props) => {
+const Gjenoppta = () => {
+    const props = useOutletContext<AttesteringContext>();
     const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansOppsummeringRoute>();
     const { formatMessage } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const navigate = useNavigate();

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenopptaOppsummering.tsx
@@ -1,7 +1,7 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { Alert, Heading } from '@navikt/ds-react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import * as revurderingApi from '~src/api/revurderingApi';
 import LinkAsButton from '~src/components/linkAsButton/LinkAsButton';
@@ -13,17 +13,14 @@ import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb
 import * as styles from '~src/pages/saksbehandling/stans/gjenoppta/gjenoppta.module.less';
 import { useAppDispatch } from '~src/redux/Store';
 import { UtbetalingsRevurderingStatus } from '~src/types/Revurdering';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import StansOppsummeringskomponent from '../components/StansOppsummeringskomponent';
 
 import messages from './gjenoppta-nb';
 
-interface Props {
-    sak: Sak;
-}
-
-const GjenopptaOppsummering = ({ sak }: Props) => {
+const GjenopptaOppsummering = () => {
+    const { sak } = useOutletContext<AttesteringContext>();
     const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansOppsummeringRoute>();
     const { formatMessage } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const navigate = useNavigate();

--- a/src/pages/saksbehandling/stans/stansOppsummering.tsx
+++ b/src/pages/saksbehandling/stans/stansOppsummering.tsx
@@ -1,7 +1,7 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { Alert, Heading } from '@navikt/ds-react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import * as revurderingApi from '~src/api/revurderingApi';
 import LinkAsButton from '~src/components/linkAsButton/LinkAsButton';
@@ -12,17 +12,14 @@ import * as Routes from '~src/lib/routes';
 import sharedMessages from '~src/pages/saksbehandling/revurdering/revurdering-nb';
 import { useAppDispatch } from '~src/redux/Store';
 import { UtbetalingsRevurderingStatus } from '~src/types/Revurdering';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import StansOppsummeringskomponent from './components/StansOppsummeringskomponent';
 import messages from './stans-nb';
 import * as styles from './stans.module.less';
 
-interface Props {
-    sak: Sak;
-}
-
-const StansOppsummering = (props: Props) => {
+const StansOppsummering = () => {
+    const props = useOutletContext<AttesteringContext>();
     const urlParams = Routes.useRouteParams<typeof Routes.stansOppsummeringRoute>();
     const navigate = useNavigate();
     const dispatch = useAppDispatch();

--- a/src/pages/saksbehandling/søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/sendTilAttesteringPage/SendTilAttesteringPage.tsx
@@ -2,7 +2,7 @@ import * as RemoteData from '@devexperts/remote-data-ts';
 import { Alert, Button, Loader, Textarea } from '@navikt/ds-react';
 import React, { useMemo } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import * as PdfApi from '~src/api/pdfApi';
 import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
@@ -13,7 +13,6 @@ import * as sakSlice from '~src/features/saksoversikt/sak.slice';
 import { useAsyncActionCreator, useBrevForhåndsvisning } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
-import { Sak } from '~src/types/Sak';
 import { Vilkårtype, VilkårVurderingStatus } from '~src/types/Vilkårsvurdering';
 import {
     erAvslått,
@@ -22,6 +21,7 @@ import {
     erBeregnetAvslag,
     erVilkårsvurderingerVurdertAvslag,
 } from '~src/utils/behandling/behandlingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 import { createVilkårUrl, mapToVilkårsinformasjon } from '~src/utils/søknadsbehandling/vilkår/vilkårUtils';
 
 import messages from './sendTilAttesteringPage-nb';
@@ -31,7 +31,8 @@ interface FormData {
     fritekst: string;
 }
 
-const SendTilAttesteringPage = (props: { sak: Sak }) => {
+const SendTilAttesteringPage = () => {
+    const props = useOutletContext<AttesteringContext>();
     const { formatMessage } = useI18n({ messages });
 
     const navigate = useNavigate();

--- a/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { Person } from '~src/api/personApi';
+import { useOutletContext } from '~node_modules/react-router-dom';
 import Beregning from '~src/components/beregningOgSimulering/beregning/Beregning';
 import { SøknadsbehandlingDraftProvider } from '~src/context/søknadsbehandlingDraftContext';
 import * as Routes from '~src/lib/routes';
-import { Sak } from '~src/types/Sak';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 import { erVilkårsvurderingerVurdertAvslag } from '~src/utils/behandling/behandlingUtils';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 import { createVilkårUrl } from '~src/utils/søknadsbehandling/vilkår/vilkårUtils';
 
 import FastOppholdINorge from '../fast-opphold-i-norge/FastOppholdINorge';
@@ -23,7 +23,8 @@ import Virkningstidspunkt from '../virkningstidspunkt/Virkningstidspunkt';
 
 import * as styles from './vilkår.module.less';
 
-const Vilkår = (props: { sak: Sak; søker: Person }) => {
+const Vilkår = () => {
+    const props = useOutletContext<AttesteringContext>();
     const {
         vilkar = Vilkårtype.Virkningstidspunkt,
         sakId,

--- a/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Person } from '~src/api/personApi';
 import Beregning from '~src/components/beregningOgSimulering/beregning/Beregning';
+import { SøknadsbehandlingDraftProvider } from '~src/context/søknadsbehandlingDraftContext';
 import * as Routes from '~src/lib/routes';
 import { Sak } from '~src/types/Sak';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
@@ -51,102 +52,106 @@ const Vilkår = (props: { sak: Sak; søker: Person }) => {
     });
 
     return (
-        <div className={styles.container}>
-            <SaksbehandlingFramdriftsindikator sakId={props.sak.id} behandling={behandling} vilkår={vilkar} />
-            <div className={styles.content}>
-                {vilkar === Vilkårtype.Virkningstidspunkt && (
-                    <Virkningstidspunkt
-                        behandling={behandling}
-                        forrigeUrl={saksoversiktUrl}
-                        nesteUrl={vilkårUrl(Vilkårtype.Uførhet)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.Uførhet && (
-                    <Uførhet
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.Virkningstidspunkt)}
-                        nesteUrl={vilkårUrl(Vilkårtype.Flyktning)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.Flyktning && (
-                    <Flyktning
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.Uførhet)}
-                        nesteUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.LovligOpphold && (
-                    <LovligOppholdINorge
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.Flyktning)}
-                        nesteUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.FastOppholdINorge && (
-                    <FastOppholdINorge
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
-                        nesteUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.Institusjonsopphold && (
-                    <Institusjonsopphold
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
-                        nesteUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.OppholdIUtlandet && (
-                    <OppholdIUtlandet
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
-                        nesteUrl={vilkårUrl(Vilkårtype.Formue)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.Formue && (
-                    <Formue
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
-                        søker={props.søker}
-                        nesteUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.PersonligOppmøte && (
-                    <PersonligOppmøte
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.Formue)}
-                        nesteUrl={vilkårUrl(Vilkårtype.Sats)}
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.Sats && (
-                    <Sats
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
-                        nesteUrl={
-                            erVilkårsvurderingerVurdertAvslag(behandling) ? vedtakUrl : vilkårUrl(Vilkårtype.Beregning)
-                        }
-                        sakId={sakId}
-                    />
-                )}
-                {vilkar === Vilkårtype.Beregning && (
-                    <Beregning
-                        behandling={behandling}
-                        forrigeUrl={vilkårUrl(Vilkårtype.Sats)}
-                        nesteUrl={vedtakUrl}
-                        sakId={sakId}
-                    />
-                )}
+        <SøknadsbehandlingDraftProvider>
+            <div className={styles.container}>
+                <SaksbehandlingFramdriftsindikator sakId={props.sak.id} behandling={behandling} vilkår={vilkar} />
+                <div className={styles.content}>
+                    {vilkar === Vilkårtype.Virkningstidspunkt && (
+                        <Virkningstidspunkt
+                            behandling={behandling}
+                            forrigeUrl={saksoversiktUrl}
+                            nesteUrl={vilkårUrl(Vilkårtype.Uførhet)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.Uførhet && (
+                        <Uførhet
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Virkningstidspunkt)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Flyktning)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.Flyktning && (
+                        <Flyktning
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Uførhet)}
+                            nesteUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.LovligOpphold && (
+                        <LovligOppholdINorge
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Flyktning)}
+                            nesteUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.FastOppholdINorge && (
+                        <FastOppholdINorge
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.LovligOpphold)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.Institusjonsopphold && (
+                        <Institusjonsopphold
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.FastOppholdINorge)}
+                            nesteUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.OppholdIUtlandet && (
+                        <OppholdIUtlandet
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Institusjonsopphold)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Formue)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.Formue && (
+                        <Formue
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.OppholdIUtlandet)}
+                            søker={props.søker}
+                            nesteUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.PersonligOppmøte && (
+                        <PersonligOppmøte
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Formue)}
+                            nesteUrl={vilkårUrl(Vilkårtype.Sats)}
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.Sats && (
+                        <Sats
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.PersonligOppmøte)}
+                            nesteUrl={
+                                erVilkårsvurderingerVurdertAvslag(behandling)
+                                    ? vedtakUrl
+                                    : vilkårUrl(Vilkårtype.Beregning)
+                            }
+                            sakId={sakId}
+                        />
+                    )}
+                    {vilkar === Vilkårtype.Beregning && (
+                        <Beregning
+                            behandling={behandling}
+                            forrigeUrl={vilkårUrl(Vilkårtype.Sats)}
+                            nesteUrl={vedtakUrl}
+                            sakId={sakId}
+                        />
+                    )}
+                </div>
             </div>
-        </div>
+        </SøknadsbehandlingDraftProvider>
     );
 };
 

--- a/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/vilkår/Vilkår.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { useOutletContext } from 'react-router-dom';
 
-import { useOutletContext } from '~node_modules/react-router-dom';
 import Beregning from '~src/components/beregningOgSimulering/beregning/Beregning';
 import { SøknadsbehandlingDraftProvider } from '~src/context/søknadsbehandlingDraftContext';
 import * as Routes from '~src/lib/routes';

--- a/src/pages/saksbehandling/vedtak/Vedtaksoppsummering.tsx
+++ b/src/pages/saksbehandling/vedtak/Vedtaksoppsummering.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@navikt/ds-react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 
 import Søknadsbehandlingoppsummering from '~src/components/søknadsbehandlingoppsummering/Søknadsbehandlingoppsummering';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
-import { Sak } from '~src/types/Sak';
+import { AttesteringContext } from '~src/utils/router/routerUtils';
 
 import Klagevedtaksoppsummering from './klagevedtaksoppsummering/klagevedtaksoppsummering';
 import ReguleringVedtaksoppsummering from './reguleringsvedtaksoppsummering/reguleringVedtaksoppsummering';
@@ -14,11 +14,8 @@ import { hentInformasjonKnyttetTilVedtak, hentKlagevedtakFraKlageinstans } from 
 import messages from './vedtaksoppsummering-nb';
 import * as styles from './vedtaksoppsummering.module.less';
 
-interface Props {
-    sak: Sak;
-}
-
-const Vedtaksoppsummering = (props: Props) => {
+const Vedtaksoppsummering = () => {
+    const props = useOutletContext<AttesteringContext>();
     const urlParams = Routes.useRouteParams<typeof Routes.vedtaksoppsummering>();
     const { formatMessage } = useI18n({ messages });
     const navigate = useNavigate();

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -7,12 +7,6 @@ import { useI18n } from '~src/lib/i18n';
 import * as styles from './index.module.less';
 import messages from './nb';
 
-const SøknadInfoWrapper = ({ children }: { children: React.ReactNode }) => (
-    <div className={styles.content}>
-        <div className={styles.infoContainer}>{children}</div>
-    </div>
-);
-
 const index = () => {
     const { formatMessage } = useI18n({ messages });
 
@@ -24,9 +18,11 @@ const index = () => {
                 </Heading>
             </div>
             <div className={styles.contentContainer}>
-                <SøknadInfoWrapper>
-                    <Outlet />
-                </SøknadInfoWrapper>
+                <div className={styles.content}>
+                    <div className={styles.infoContainer}>
+                        <Outlet />
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -32,45 +32,40 @@ const index = () => {
                 </Heading>
             </div>
             <div className={styles.contentContainer}>
-                <Routes>
-                    <Route path={routes.soknadsutfylling.path} element={<StartUtfylling />} />
-                    <Route
-                        path={'/'}
-                        element={
-                            <SøknadInfoWrapper>
-                                <Infoside
-                                    nesteUrl={routes.soknadPersonSøk.createURL({
-                                        papirsøknad: isPapirsøknad,
-                                    })}
-                                />
-                            </SøknadInfoWrapper>
-                        }
-                    />
-                    <Route
-                        path={routes.soknadPersonSøk.path}
-                        element={
-                            <SøknadInfoWrapper>
-                                <Inngang
-                                    nesteUrl={routes.soknadsutfylling.createURL({
-                                        step: Søknadsteg.Uførevedtak,
-                                        papirsøknad: isPapirsøknad,
-                                    })}
-                                />
-                            </SøknadInfoWrapper>
-                        }
-                    />
-                    <Route
-                        path={routes.søkandskvittering.path}
-                        element={
-                            <SøknadInfoWrapper>
-                                <Kvittering />
-                            </SøknadInfoWrapper>
-                        }
-                    />
-                </Routes>
+                <SøknadInfoWrapper>
+                    <SøknadRoutes isPapirsøknad={isPapirsøknad} />
+                </SøknadInfoWrapper>
             </div>
         </div>
     );
 };
+
+const SøknadRoutes = ({ isPapirsøknad }: { isPapirsøknad: boolean }) => (
+    <Routes>
+        <Route
+            path={'/'}
+            element={
+                <Infoside
+                    nesteUrl={routes.soknadPersonSøk.createURL({
+                        papirsøknad: isPapirsøknad,
+                    })}
+                />
+            }
+        />
+        <Route
+            path={routes.soknadPersonSøk.path}
+            element={
+                <Inngang
+                    nesteUrl={routes.soknadsutfylling.createURL({
+                        step: Søknadsteg.Uførevedtak,
+                        papirsøknad: isPapirsøknad,
+                    })}
+                />
+            }
+        />
+        <Route path={routes.soknadsutfylling.path} element={<StartUtfylling />} />
+        <Route path={routes.søkandskvittering.path} element={<Kvittering />} />
+    </Routes>
+);
 
 export default index;

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -1,17 +1,11 @@
 import { Heading } from '@navikt/ds-react';
 import * as React from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
 import { useI18n } from '~src/lib/i18n';
-import * as routes from '~src/lib/routes';
-import { StartUtfylling } from '~src/pages/søknad/steg/start-utfylling/StartUtfylling';
 
 import * as styles from './index.module.less';
-import Kvittering from './kvittering/Kvittering';
 import messages from './nb';
-import Infoside from './steg/infoside/Infoside';
-import Inngang from './steg/inngang/Inngang';
-import { Søknadsteg } from './types';
 
 const SøknadInfoWrapper = ({ children }: { children: React.ReactNode }) => (
     <div className={styles.content}>
@@ -20,8 +14,6 @@ const SøknadInfoWrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 const index = () => {
-    const location = useLocation();
-    const isPapirsøknad = location.search.includes('papirsoknad');
     const { formatMessage } = useI18n({ messages });
 
     return (
@@ -33,39 +25,11 @@ const index = () => {
             </div>
             <div className={styles.contentContainer}>
                 <SøknadInfoWrapper>
-                    <SøknadRoutes isPapirsøknad={isPapirsøknad} />
+                    <Outlet />
                 </SøknadInfoWrapper>
             </div>
         </div>
     );
 };
-
-const SøknadRoutes = ({ isPapirsøknad }: { isPapirsøknad: boolean }) => (
-    <Routes>
-        <Route
-            path={'/'}
-            element={
-                <Infoside
-                    nesteUrl={routes.soknadPersonSøk.createURL({
-                        papirsøknad: isPapirsøknad,
-                    })}
-                />
-            }
-        />
-        <Route
-            path={routes.soknadPersonSøk.path}
-            element={
-                <Inngang
-                    nesteUrl={routes.soknadsutfylling.createURL({
-                        step: Søknadsteg.Uførevedtak,
-                        papirsøknad: isPapirsøknad,
-                    })}
-                />
-            }
-        />
-        <Route path={routes.soknadsutfylling.path} element={<StartUtfylling />} />
-        <Route path={routes.søkandskvittering.path} element={<Kvittering />} />
-    </Routes>
-);
 
 export default index;

--- a/src/pages/søknad/steg/infoside/Infoside.tsx
+++ b/src/pages/søknad/steg/infoside/Infoside.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 
 import LinkAsButton from '~src/components/linkAsButton/LinkAsButton';
 import { useI18n } from '~src/lib/i18n';
+import { soknadPersonSøk } from '~src/lib/routes';
 
 import messages from './infoside-nb';
 import * as styles from './infoside.module.less';
 
-const Infoside = (props: { nesteUrl: string }) => {
+const Infoside = (props: { isPapirsøknad?: boolean }) => {
+    const nesteUrl = soknadPersonSøk.createURL({
+        papirsøknad: props.isPapirsøknad,
+    });
     const suUførFlyktningLink = 'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-ufor-flyktning';
     const merOmSuForUføreLink =
         'https://www.nav.no/no/person/pensjon/andre-pensjonsordninger/supplerende-stonad-for-ufore-flyktninger';
@@ -74,7 +78,7 @@ const Infoside = (props: { nesteUrl: string }) => {
                 </BodyLong>
             </section>
 
-            <LinkAsButton variant="primary" href={props.nesteUrl} className={styles.knapp}>
+            <LinkAsButton variant="primary" href={nesteUrl} className={styles.knapp}>
                 {formatMessage('knapp.neste')}
             </LinkAsButton>
         </div>

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -17,7 +17,9 @@ import { pipe } from '~src/lib/fp';
 import { useApiCall, useAsyncActionCreator } from '~src/lib/hooks';
 import { MessageFormatter, useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
+import { soknadsutfylling } from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
+import { Søknadsteg } from '~src/pages/søknad/types';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { Periode } from '~src/types/Periode';
 import { Søknadstype } from '~src/types/Søknad';
@@ -96,7 +98,11 @@ const SakinfoAlert = ({
     );
 };
 
-const index = (props: { nesteUrl: string }) => {
+const index = (props: { isPapirsøknad?: boolean }) => {
+    const nesteUrl = soknadsutfylling.createURL({
+        step: Søknadsteg.Uførevedtak,
+        papirsøknad: props.isPapirsøknad,
+    });
     const { søker } = useAppSelector((s) => s.søker);
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
@@ -121,7 +127,7 @@ const index = (props: { nesteUrl: string }) => {
             dispatch(
                 søknadSlice.actions.startSøknad(isPapirsøknad ? Søknadstype.Papirsøknad : Søknadstype.DigitalSøknad)
             );
-            navigate(props.nesteUrl);
+            navigate(nesteUrl);
         }
     };
 

--- a/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
+++ b/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
@@ -21,7 +21,7 @@ import { useAppSelector } from '~src/redux/Store';
 import { Rolle } from '~src/types/LoggedInUser';
 import { Søknadstype } from '~src/types/Søknad';
 
-export const StartUtfylling = () => {
+const StartUtfylling = () => {
     const { søker: søkerFraStore } = useAppSelector((s) => s.søker);
     const søknad = useAppSelector((s) => s.soknad);
     const { step } = useParams<{ step: Søknadsteg }>();
@@ -152,3 +152,5 @@ export const StartUtfylling = () => {
         </div>
     );
 };
+
+export default StartUtfylling;

--- a/src/utils/router/ContentWrapper.tsx
+++ b/src/utils/router/ContentWrapper.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from 'react';
+
+import * as RemoteData from '~node_modules/@devexperts/remote-data-ts';
+import { Heading, Link, Loader } from '~node_modules/@navikt/ds-react';
+import { ErrorCode } from '~src/api/apiClient';
+import { LOGIN_URL } from '~src/api/authUrl';
+import { FeatureToggle } from '~src/api/featureToggleApi';
+import Header from '~src/components/header/Header';
+import { UserProvider } from '~src/context/userContext';
+import * as meSlice from '~src/features/me/me.slice';
+import { useFeatureToggle } from '~src/lib/featureToggles';
+import { pipe } from '~src/lib/fp';
+import enableHotjar from '~src/lib/tracking/hotjar';
+import { useAppDispatch, useAppSelector } from '~src/redux/Store';
+import * as styles from '~src/root.module.less';
+import { LoggedInUser } from '~src/types/LoggedInUser';
+
+export const ContentWrapper: React.FC = (props) => {
+    const loggedInUser = useAppSelector((s) => s.me.me);
+
+    const dispatch = useAppDispatch();
+
+    useEffect(() => {
+        if (RemoteData.isInitial(loggedInUser)) {
+            dispatch(meSlice.fetchMe());
+        }
+    }, [loggedInUser._tag]);
+
+    const hotjarToggle = useFeatureToggle(FeatureToggle.Hotjar);
+    useEffect(() => {
+        hotjarToggle && enableHotjar();
+    }, [hotjarToggle]);
+
+    return (
+        <div>
+            <a href="#main-content" className="sr-only sr-only-focusable">
+                Hopp til innhold
+            </a>
+            <Header
+                user={pipe(
+                    loggedInUser,
+                    RemoteData.getOrElse<unknown, LoggedInUser | null>(() => null)
+                )}
+            />
+            <main className={styles.contentContainer} id="main-content" tabIndex={-1}>
+                {pipe(
+                    loggedInUser,
+                    RemoteData.fold(
+                        () => <Loader />,
+                        () => <Loader />,
+                        (err) => {
+                            return (
+                                <div className={styles.ikkeTilgangContainer}>
+                                    <Heading level="1" size="medium" className={styles.overskrift}>
+                                        {err.statusCode === ErrorCode.NotAuthenticated ||
+                                        err.statusCode === ErrorCode.Unauthorized
+                                            ? 'Ikke tilgang'
+                                            : 'En feil oppstod'}
+                                    </Heading>
+                                    <Link href={`${LOGIN_URL}?redirectTo=${window.location.pathname}`}>
+                                        Logg inn på nytt
+                                    </Link>
+                                </div>
+                            );
+                        },
+                        (u) => <UserProvider user={u}>{props.children}</UserProvider>
+                    )
+                )}
+            </main>
+        </div>
+    );
+};

--- a/src/utils/router/routerUtils.ts
+++ b/src/utils/router/routerUtils.ts
@@ -1,0 +1,7 @@
+import { Person } from '~src/api/personApi';
+import { Sak } from '~src/types/Sak';
+
+export interface AttesteringContext {
+    sak: Sak;
+    søker: Person;
+}


### PR DESCRIPTION
Dro alle Routes ut til Root. Nå har vi også et lesbart hierarki hvor vi ser hva som ligger innenfor hver subroute

En stor endring her er bruk av `<Outlet />`. Denne kan sammenlignes litt med `children` da denne rendrer det som returneres av en Route. [Her](https://reactrouter.com/docs/en/v6/api#outlet) kan man lese mer om den, evt spørre meg 🤓 