### PR TITLE
Fikset hot reloading

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -25,6 +25,9 @@ function setup() {
             serveOptions: {
                 port: 1234,
             },
+            hmrOptions: {
+                port: 1234,
+            },
             defaultTargetOptions: {
                 shouldScopeHoist: false,
                 shouldOptimize: false,


### PR DESCRIPTION
Trengte bara å sette vilken port hot reloaden skulle connecte seg mot.

Noter att når endringer gjøres i `/server` så restartes servern av nodemon og hot reloading-websocketen stenges ned, da må man refresha for å få det å funka igjen. Men skal gå fint så länge man bara fikser øvrige frontend filer.