### PR TITLE
Infoside for SU alder

### DIFF
--- a/src/pages/søknad/steg/infoside/Infoside.tsx
+++ b/src/pages/søknad/steg/infoside/Infoside.tsx
@@ -18,6 +18,11 @@ const Infoside = () => {
         soknadstema,
         papirsøknad: isPapirsøknad,
     });
+
+    const merOmSuAlderLink =
+        'https://www.nav.no/no/person/pensjon/andre-pensjonsordninger/supplerende-stonad-for-personer-med-kort-botid-i-norge';
+    const suAlderLink =
+        'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-personer-over-sekstisyv-ar';
     const suUførFlyktningLink = 'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-ufor-flyktning';
     const merOmSuForUføreLink =
         'https://www.nav.no/no/person/pensjon/andre-pensjonsordninger/supplerende-stonad-for-ufore-flyktninger';
@@ -29,9 +34,15 @@ const Infoside = () => {
         <div className={styles.pageContainer}>
             <GuidePanel className={styles.guide}>
                 <BodyLong>
-                    {formatMessage('suppstønadInfo.kanFåSupp', {
-                        b: (text) => <b>{text}</b>,
-                    })}
+                    {formatMessage(
+                        getSøknadstematekst(soknadstema, {
+                            [Søknadstema.Uføre]: 'suppstønadInfo.kanFåSupp.ufør',
+                            [Søknadstema.Alder]: 'suppstønadInfo.kanFåSupp.alder',
+                        }),
+                        {
+                            strong: (text) => <strong>{text}</strong>,
+                        }
+                    )}
                 </BodyLong>
             </GuidePanel>
 
@@ -43,10 +54,24 @@ const Infoside = () => {
             </Heading>
 
             <section className={styles.section}>
-                <Ingress spacing>{formatMessage('suppstønadInfo.ingress')}</Ingress>
+                <Ingress spacing>
+                    {getSøknadstematekst(soknadstema, {
+                        [Søknadstema.Uføre]: formatMessage('suppstønadInfo.ingress.ufør'),
+                        [Søknadstema.Alder]: formatMessage('suppstønadInfo.ingress.alder'),
+                    })}
+                </Ingress>
                 <BodyLong>
-                    <Link target="_blank" href={merOmSuForUføreLink}>
-                        {formatMessage('suppstønad.merOmSuForUføre')}
+                    <Link
+                        target="_blank"
+                        href={getSøknadstematekst(soknadstema, {
+                            [Søknadstema.Uføre]: merOmSuForUføreLink,
+                            [Søknadstema.Alder]: merOmSuAlderLink,
+                        })}
+                    >
+                        {getSøknadstematekst(soknadstema, {
+                            [Søknadstema.Uføre]: formatMessage('suppstønad.merOmSuForUføre'),
+                            [Søknadstema.Alder]: formatMessage('suppstønad.merOmSuAlder'),
+                        })}
                     </Link>
                 </BodyLong>
             </section>
@@ -59,7 +84,14 @@ const Infoside = () => {
                 <BodyLong spacing as="ul" className={styles.list}>
                     <li className={styles.listItem}>{formatMessage('henterInnInfo.viHenter.personinfo')}</li>
                     <li className={styles.listItem}>{formatMessage('henterInnInfo.viHenter.arbeidsforhold')}</li>
-                    <li className={styles.listItem}>{formatMessage('henterInnInfo.viHenter.flyktningsstatus')}</li>
+                    <li className={styles.listItem}>
+                        {formatMessage(
+                            getSøknadstematekst(soknadstema, {
+                                [Søknadstema.Uføre]: 'henterInnInfo.viHenter.flyktningsstatus',
+                                [Søknadstema.Alder]: 'henterInnInfo.viHenter.oppholdstillatelse',
+                            })
+                        )}
+                    </li>
                 </BodyLong>
                 <BodyLong spacing>{formatMessage('henterInnInfo.brukerTidligereOpplysninger')}</BodyLong>
 
@@ -77,9 +109,14 @@ const Infoside = () => {
                 <BodyLong spacing>{formatMessage('viktigÅVite.blirIkkeLagret')}</BodyLong>
                 <BodyLong spacing>
                     {formatMessage('viktigÅVite.manglerDuDokumentasjon', {
-                        //eslint-disable-next-line react/display-name
                         navLink: (tekst) => (
-                            <Link target="_blank" href={suUførFlyktningLink}>
+                            <Link
+                                target="_blank"
+                                href={getSøknadstematekst(soknadstema, {
+                                    [Søknadstema.Uføre]: suUførFlyktningLink,
+                                    [Søknadstema.Alder]: suAlderLink,
+                                })}
+                            >
                                 {tekst}
                             </Link>
                         ),

--- a/src/pages/søknad/steg/infoside/infoside-nb.ts
+++ b/src/pages/søknad/steg/infoside/infoside-nb.ts
@@ -10,7 +10,7 @@ export default {
     'suppstønad.merOmSuForUføre': 'Mer om supplerende stønad for uføre flyktninger',
     'suppstønad.merOmSuAlder': 'Mer om supplerende stønad for personer som har fylt 67 år',
 
-    'henterInnInfo.ingress': 'Vi vil hente informasjon om deg',
+    'henterInnInfo.ingress': 'Vi vil hente informasjon om deg og ektefellen eller samboeren din',
     'henterInnInfo.viHenterInfo':
         'I tillegg til det du selv opplyser i søknaden, vil vi hente inn denne informasjonen: ',
     'henterInnInfo.viHenter.personinfo': 'personinformasjon om deg og ektefellen eller samboeren din',

--- a/src/pages/søknad/steg/infoside/infoside-nb.ts
+++ b/src/pages/søknad/steg/infoside/infoside-nb.ts
@@ -10,7 +10,7 @@ export default {
     'suppstønad.merOmSuForUføre': 'Mer om supplerende stønad for uføre flyktninger',
     'suppstønad.merOmSuAlder': 'Mer om supplerende stønad for personer som har fylt 67 år',
 
-    'henterInnInfo.ingress': 'Vi vil hente informasjon om deg og ektefellen eller samboeren din',
+    'henterInnInfo.ingress': 'Vi vil hente informasjon om deg',
     'henterInnInfo.viHenterInfo':
         'I tillegg til det du selv opplyser i søknaden, vil vi hente inn denne informasjonen: ',
     'henterInnInfo.viHenter.personinfo': 'personinformasjon om deg og ektefellen eller samboeren din',
@@ -31,5 +31,5 @@ export default {
         'Mangler du dokumentasjon, kan du sende den inn på et senere tidspunkt. Du finner mer om dette på <navLink>nav.no.</navLink>',
 
     'page.tittel.uføre': 'Start en ny søknad om supplerende stønad for uføre flyktninger',
-    'page.tittel.alder': 'Start en ny søknad om supplerende stønad for alder',
+    'page.tittel.alder': 'Start en ny søknad om supplerende stønad for personer som har fylt 67 år',
 };

--- a/src/pages/søknad/steg/infoside/infoside-nb.ts
+++ b/src/pages/søknad/steg/infoside/infoside-nb.ts
@@ -1,10 +1,14 @@
 export default {
-    'suppstønadInfo.kanFåSupp':
-        'Du kan få supplerende stønad hvis du er <b>flyktning</b>, <b>ufør</b> og har <b>bodd kort tid i Norge</b>.',
-    'suppstønadInfo.ingress':
+    'suppstønadInfo.kanFåSupp.ufør':
+        'Du kan få supplerende stønad hvis du er <strong>flyktning</strong>, <strong>ufør</strong> og har <strong>bodd kort tid i Norge</strong>.',
+    'suppstønadInfo.kanFåSupp.alder':
+        'Du kan få supplerende stønad hvis du har <strong>fylt 67 år og bodd kort tid i Norge</strong>.',
+    'suppstønadInfo.ingress.ufør':
         'Stønaden vil sikre deg en inntekt som er det minste du kan få i uføretrygd. Inntekten din og inntekten til samboeren eller ektefellen din, avgjør hvor mye penger du har rett til. Om du bor alene eller sammen med andre avgjør også hvor mye du har rett til.',
-
+    'suppstønadInfo.ingress.alder':
+        'Stønaden vil sikre deg en inntekt som svarer til folketrygdens garantipensjon for alderspensjonister. Inntekten din og inntekten til samboeren eller ektefellen din, avgjør hvor mye penger du har rett til. Om du bor alene eller sammen med andre avgjør også hvor mye du har rett til.',
     'suppstønad.merOmSuForUføre': 'Mer om supplerende stønad for uføre flyktninger',
+    'suppstønad.merOmSuAlder': 'Mer om supplerende stønad for personer som har fylt 67 år',
 
     'henterInnInfo.ingress': 'Vi vil hente informasjon om deg',
     'henterInnInfo.viHenterInfo':
@@ -13,6 +17,7 @@ export default {
     'henterInnInfo.viHenter.arbeidsforhold':
         'opplysninger om arbeidsforholdet ditt fra arbeidsgiver- og arbeidstakerregisteret',
     'henterInnInfo.viHenter.flyktningsstatus': 'flyktningstatus og oppholdstillatelse fra UDI',
+    'henterInnInfo.viHenter.oppholdstillatelse': 'oppholdstillatelse fra UDI',
     'henterInnInfo.brukerTidligereOpplysninger':
         'Hvis det er nødvendig kan vi bruke opplysninger du har gitt oss før, eller som du har gitt oss i andre sammenhenger.',
     'henterInnInfo.personvernLinkTekst': 'Mer om hvordan NAV håndterer dine personopplysninger',

--- a/src/pages/søknad/steg/inngang/inngang-nb.ts
+++ b/src/pages/søknad/steg/inngang/inngang-nb.ts
@@ -30,7 +30,8 @@ export default {
     'sendeInnDokumentasjon.måLeggesVed': 'Du må legge ved dette:',
     'sendeInnDokumentasjon.måLeggesVed.punkt1': 'Kopi av pass',
     'sendeInnDokumentasjon.måLeggesVed.punkt2': 'Kopi av grunnlaget for skatt og den siste skattemeldingen',
-    'sendeInnDokumentasjon.ogsåLeggesVed': 'Du må også legge ved dette:',
+    'sendeInnDokumentasjon.ogsåLeggesVed':
+        'Har du eller ektefelle/samboer formue eller pensjon må du også legge ved dette:',
     'sendeInnDokumentasjon.ogsåLeggesVed.punkt1': 'Dokumentasjon som viser at du har formue i utlandet',
     'sendeInnDokumentasjon.ogsåLeggesVed.punkt2': 'Dokumentasjon som viser at du har pensjon i utlandet',
 

--- a/src/pages/søknad/utils.ts
+++ b/src/pages/søknad/utils.ts
@@ -1,13 +1,13 @@
 import { Søknadstema } from '~src/types/Søknad';
 
-export const getSøknadstematekst = (
+export function getSøknadstematekst<AlderTekst extends string, UføreTekst extends string>(
     søknadstema: Søknadstema,
-    text: { [Søknadstema.Uføre]: string; [Søknadstema.Alder]: string }
-): string => {
+    text: { [Søknadstema.Uføre]: UføreTekst; [Søknadstema.Alder]: AlderTekst }
+): AlderTekst | UføreTekst {
     switch (søknadstema) {
         case Søknadstema.Alder:
             return text[Søknadstema.Alder];
         case Søknadstema.Uføre:
             return text[Søknadstema.Uføre];
     }
-};
+}


### PR DESCRIPTION
Gjenbruker i hovedsak infosiden for SU ufør, og bytter til spesialiserte tekster der det er forskjeller. Det er også en liten endring med på dokumentasjon-siden (Inngang), som skal være for både alder og ufør.
![Screenshot 2022-05-20 at 12 32 44](https://user-images.githubusercontent.com/4296255/169510366-ff45ff26-4052-4069-9868-276c332a24bf.png)

<img width="620" alt="Screenshot 2022-05-20 at 12 26 07" src="https://user-images.githubusercontent.com/4296255/169509013-5628790f-5597-4b92-9eee-178db94905b1.png">

