### PR TITLE
Forskjellige advarsler basert på allerede åpne søknader

### DIFF
--- a/src/api/sakApi.ts
+++ b/src/api/sakApi.ts
@@ -1,15 +1,18 @@
 import { GrunnlagsdataOgVilkårsvurderinger } from '~src/types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
 import { Restans } from '~src/types/Restans';
-import { BegrensetSakinfo, Sak } from '~src/types/Sak';
+import { AlleredeÅpenSak, Sak, Sakstype } from '~src/types/Sak';
 
 import apiClient, { ApiClientResult } from './apiClient';
 
-export async function fetchSakByFnr(fnr: string): Promise<ApiClientResult<Sak>> {
+export async function fetchSakByFnr(fnr: string, type: Sakstype = Sakstype.UFØRE): Promise<ApiClientResult<Sak>> {
+    console.log(type);
+
     return apiClient({
         url: `/saker/søk`,
         method: 'POST',
         body: {
             fnr: fnr,
+            type: type.toString(),
         },
     });
 }
@@ -36,7 +39,7 @@ export async function hentFerdigeBehandlinger(): Promise<ApiClientResult<Restans
     return apiClient({ url: `/saker/behandlinger/ferdige`, method: 'GET' });
 }
 
-export async function hentBegrensetSakinfo(fnr: string): Promise<ApiClientResult<BegrensetSakinfo>> {
+export async function hentBegrensetSakinfo(fnr: string): Promise<ApiClientResult<AlleredeÅpenSak>> {
     return apiClient({ url: `/saker/info/${fnr}`, method: 'GET' });
 }
 

--- a/src/api/sakApi.ts
+++ b/src/api/sakApi.ts
@@ -1,10 +1,11 @@
 import { GrunnlagsdataOgVilkårsvurderinger } from '~src/types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
 import { Restans } from '~src/types/Restans';
-import { AlleredeÅpenSak, Sak, Sakstype } from '~src/types/Sak';
+import { AlleredeGjeldendeSakForBruker, Sak } from '~src/types/Sak';
+import { Sakstype } from '~src/types/Søknad';
 
 import apiClient, { ApiClientResult } from './apiClient';
 
-export async function fetchSakByFnr(fnr: string, type: Sakstype = Sakstype.UFØRE): Promise<ApiClientResult<Sak>> {
+export async function fetchSakByFnr(fnr: string, type: Sakstype = Sakstype.Uføre): Promise<ApiClientResult<Sak>> {
     return apiClient({
         url: `/saker/søk`,
         method: 'POST',
@@ -37,7 +38,7 @@ export async function hentFerdigeBehandlinger(): Promise<ApiClientResult<Restans
     return apiClient({ url: `/saker/behandlinger/ferdige`, method: 'GET' });
 }
 
-export async function hentBegrensetSakinfo(fnr: string): Promise<ApiClientResult<AlleredeÅpenSak>> {
+export async function hentBegrensetSakinfo(fnr: string): Promise<ApiClientResult<AlleredeGjeldendeSakForBruker>> {
     return apiClient({ url: `/saker/info/${fnr}`, method: 'GET' });
 }
 

--- a/src/api/sakApi.ts
+++ b/src/api/sakApi.ts
@@ -5,8 +5,6 @@ import { AlleredeÅpenSak, Sak, Sakstype } from '~src/types/Sak';
 import apiClient, { ApiClientResult } from './apiClient';
 
 export async function fetchSakByFnr(fnr: string, type: Sakstype = Sakstype.UFØRE): Promise<ApiClientResult<Sak>> {
-    console.log(type);
-
     return apiClient({
         url: `/saker/søk`,
         method: 'POST',

--- a/src/api/sakApi.ts
+++ b/src/api/sakApi.ts
@@ -1,7 +1,6 @@
 import { GrunnlagsdataOgVilkårsvurderinger } from '~src/types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
 import { Restans } from '~src/types/Restans';
-import { AlleredeGjeldendeSakForBruker, Sak } from '~src/types/Sak';
-import { Sakstype } from '~src/types/Søknad';
+import { AlleredeGjeldendeSakForBruker, Sak, Sakstype } from '~src/types/Sak';
 
 import apiClient, { ApiClientResult } from './apiClient';
 

--- a/src/components/personadvarsel/personAdvarsel.module.less
+++ b/src/components/personadvarsel/personAdvarsel.module.less
@@ -10,7 +10,8 @@
     color: red;
 }
 
-.black {
+.black,
+.etikett.black {
     color: white;
     background-color: #262626;
 }

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import * as Routes from '~src/lib/routes';
 import { KlageSteg, RevurderingSteg, SaksbehandlingMenyvalg } from '~src/pages/saksbehandling/types';
 import { Søknadssteg } from '~src/pages/søknad/types';
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 
 interface Route<T> {
@@ -37,26 +37,31 @@ export const soknad: Route<never> = {
     createURL: () => '/soknad/',
 };
 
-export const soknadtema: Route<{ soknadstema?: Søknadstema; papirsøknad?: boolean }> = {
+export const URL_TEMA_UFØRE = 'ufore' as const;
+export const URL_TEMA_ALDER = 'alder' as const;
+
+export type TemaFraUrl = typeof URL_TEMA_UFØRE | typeof URL_TEMA_ALDER;
+
+export const soknadtema: Route<{ soknadstema?: TemaFraUrl; papirsøknad?: boolean }> = {
     path: ':soknadstema/*',
     absPath: '/soknad/:soknadstema/',
     createURL: (args) =>
         `/soknad${args?.soknadstema ? '/' + args.soknadstema : ''}${args.papirsøknad ? '?papirsoknad=true' : ''}`,
 };
 
-export const soknadPersonSøk: Route<{ papirsøknad?: boolean; soknadstema: Søknadstema }> = {
+export const soknadPersonSøk: Route<{ papirsøknad?: boolean; soknadstema: Sakstype }> = {
     path: 'personsok',
     absPath: '/soknad/:soknadstema/personsok',
     createURL: (args) => `/soknad/${args.soknadstema}/personsok${args.papirsøknad ? '?papirsoknad=true' : ''}`,
 };
 
-export const soknadsutfylling: Route<{ step: Søknadssteg; soknadstema: Søknadstema; papirsøknad?: boolean }> = {
+export const soknadsutfylling: Route<{ step: Søknadssteg; soknadstema: Sakstype; papirsøknad?: boolean }> = {
     path: 'utfylling/:step',
     absPath: '/soknad/:soknadstema/utfylling/:step',
     createURL: (args) => `/soknad/${args.soknadstema}/utfylling/${args.step}`,
 };
 
-export const søknadskvittering: Route<{ soknadstema: Søknadstema }> = {
+export const søknadskvittering: Route<{ soknadstema: Sakstype }> = {
     path: 'kvittering',
     absPath: '/soknad/:soknadstema/kvittering',
     createURL: (args) => `/soknad/${args.soknadstema}/kvittering`,

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -42,6 +42,19 @@ export const URL_TEMA_ALDER = 'alder' as const;
 
 export type TemaFraUrl = typeof URL_TEMA_UFØRE | typeof URL_TEMA_ALDER;
 
+export function urlForSakstype(sakstype: Sakstype): TemaFraUrl {
+    switch (sakstype) {
+        case Sakstype.Alder:
+            return URL_TEMA_ALDER;
+        case Sakstype.Uføre:
+            return URL_TEMA_UFØRE;
+    }
+}
+
+export function sakstypeFraTemaIUrl(temaIUrl?: TemaFraUrl): Sakstype {
+    return temaIUrl === Routes.URL_TEMA_ALDER ? Sakstype.Alder : Sakstype.Uføre;
+}
+
 export const soknadtema: Route<{ soknadstema?: TemaFraUrl; papirsøknad?: boolean }> = {
     path: ':soknadstema/*',
     absPath: '/soknad/:soknadstema/',
@@ -49,19 +62,20 @@ export const soknadtema: Route<{ soknadstema?: TemaFraUrl; papirsøknad?: boolea
         `/soknad${args?.soknadstema ? '/' + args.soknadstema : ''}${args.papirsøknad ? '?papirsoknad=true' : ''}`,
 };
 
-export const soknadPersonSøk: Route<{ papirsøknad?: boolean; soknadstema: Sakstype }> = {
+export const soknadPersonSøk: Route<{ papirsøknad?: boolean; soknadstema: TemaFraUrl }> = {
     path: 'personsok',
     absPath: '/soknad/:soknadstema/personsok',
-    createURL: (args) => `/soknad/${args.soknadstema}/personsok${args.papirsøknad ? '?papirsoknad=true' : ''}`,
+    createURL: ({ soknadstema, papirsøknad }) =>
+        `/soknad/${soknadstema}/personsok${papirsøknad ? '?papirsoknad=true' : ''}`,
 };
 
-export const soknadsutfylling: Route<{ step: Søknadssteg; soknadstema: Sakstype; papirsøknad?: boolean }> = {
+export const soknadsutfylling: Route<{ step: Søknadssteg; soknadstema: TemaFraUrl; papirsøknad?: boolean }> = {
     path: 'utfylling/:step',
     absPath: '/soknad/:soknadstema/utfylling/:step',
     createURL: (args) => `/soknad/${args.soknadstema}/utfylling/${args.step}`,
 };
 
-export const søknadskvittering: Route<{ soknadstema: Sakstype }> = {
+export const søknadskvittering: Route<{ soknadstema: TemaFraUrl }> = {
     path: 'kvittering',
     absPath: '/soknad/:soknadstema/kvittering',
     createURL: (args) => `/soknad/${args.soknadstema}/kvittering`,

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import * as Routes from '~src/lib/routes';
 import { KlageSteg, RevurderingSteg, SaksbehandlingMenyvalg } from '~src/pages/saksbehandling/types';
 import { Søknadssteg } from '~src/pages/søknad/types';
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 
 interface Route<T> {

--- a/src/pages/søknad/Søknadsvelger.tsx
+++ b/src/pages/søknad/Søknadsvelger.tsx
@@ -8,7 +8,7 @@ import { useFeatureToggle } from '~src/lib/featureToggles';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { SøknadContext } from '~src/pages/søknad/index';
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 
 import messages from './nb';
 import * as styles from './søknadsvelger.module.less';
@@ -21,7 +21,7 @@ const Søknadsvelger = () => {
         return (
             <Navigate
                 replace
-                to={Routes.soknadtema.createURL({ papirsøknad: isPapirsøknad, soknadstema: Søknadstema.Uføre })}
+                to={Routes.soknadtema.createURL({ papirsøknad: isPapirsøknad, soknadstema: Routes.URL_TEMA_UFØRE })}
             />
         );
     }
@@ -53,7 +53,7 @@ const Søknadsvelger = () => {
                         variant="secondary"
                         href={Routes.soknadtema.createURL({
                             papirsøknad: isPapirsøknad,
-                            soknadstema: Søknadstema.Alder,
+                            soknadstema: Sakstype.Alder,
                         })}
                     >
                         {formatMessage('alder-lenke')}
@@ -68,7 +68,7 @@ const Søknadsvelger = () => {
                         variant="secondary"
                         href={Routes.soknadtema.createURL({
                             papirsøknad: isPapirsøknad,
-                            soknadstema: Søknadstema.Uføre,
+                            soknadstema: Routes.URL_TEMA_UFØRE,
                         })}
                     >
                         {formatMessage('ufør-lenke')}

--- a/src/pages/søknad/Søknadsvelger.tsx
+++ b/src/pages/søknad/Søknadsvelger.tsx
@@ -8,7 +8,6 @@ import { useFeatureToggle } from '~src/lib/featureToggles';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { SøknadContext } from '~src/pages/søknad/index';
-import { Sakstype } from '~src/types/Søknad';
 
 import messages from './nb';
 import * as styles from './søknadsvelger.module.less';
@@ -53,7 +52,7 @@ const Søknadsvelger = () => {
                         variant="secondary"
                         href={Routes.soknadtema.createURL({
                             papirsøknad: isPapirsøknad,
-                            soknadstema: Sakstype.Alder,
+                            soknadstema: Routes.URL_TEMA_ALDER,
                         })}
                     >
                         {formatMessage('alder-lenke')}

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -8,7 +8,7 @@ import { useFeatureToggle } from '~src/lib/featureToggles';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 
 import * as styles from './index.module.less';
 import messages from './nb';

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -8,37 +8,40 @@ import { useFeatureToggle } from '~src/lib/featureToggles';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 
 import * as styles from './index.module.less';
 import messages from './nb';
 
 export interface SøknadContext {
-    soknadstema: Søknadstema;
+    sakstype: Sakstype;
     isPapirsøknad: boolean;
+}
+
+function sakstypeFraTemaIUrl(temaIUrl?: Routes.TemaFraUrl): Sakstype {
+    return temaIUrl === Routes.URL_TEMA_ALDER ? Sakstype.Alder : Sakstype.Uføre;
 }
 
 const index = () => {
     const { formatMessage } = useI18n({ messages });
     const location = useLocation();
     const isPapirsøknad = location.search.includes('papirsoknad');
-    const soknadstema = useFeatureToggle(FeatureToggle.Alder)
-        ? Routes.useRouteParams<typeof Routes.soknadtema>().soknadstema
-        : Søknadstema.Uføre;
+    const temaIUrl = Routes.useRouteParams<typeof Routes.soknadtema>().soknadstema;
+    const sakstype = useFeatureToggle(FeatureToggle.Alder) ? sakstypeFraTemaIUrl(temaIUrl) : Sakstype.Uføre;
 
     return (
         <div className={styles.container}>
             <div
                 className={classNames(styles.infostripe, {
-                    [styles.ufore]: soknadstema === Søknadstema.Uføre,
-                    [styles.alder]: soknadstema === Søknadstema.Alder,
+                    [styles.ufore]: sakstype === Sakstype.Uføre,
+                    [styles.alder]: sakstype === Sakstype.Alder,
                 })}
             >
-                {soknadstema && (
+                {sakstype && (
                     <Heading level="2" size="small">
-                        {getSøknadstematekst(soknadstema, {
-                            [Søknadstema.Uføre]: formatMessage('infolinjeUføre'),
-                            [Søknadstema.Alder]: formatMessage('infolinjeAlder'),
+                        {getSøknadstematekst(sakstype, {
+                            [Sakstype.Uføre]: formatMessage('infolinjeUføre'),
+                            [Sakstype.Alder]: formatMessage('infolinjeAlder'),
                         })}
                     </Heading>
                 )}
@@ -46,7 +49,7 @@ const index = () => {
             <div className={styles.contentContainer}>
                 <div className={styles.content}>
                     <div className={styles.infoContainer}>
-                        <Outlet context={{ soknadstema, isPapirsøknad }} />
+                        <Outlet context={{ sakstype, isPapirsøknad }} />
                     </div>
                 </div>
             </div>

--- a/src/pages/søknad/index.tsx
+++ b/src/pages/søknad/index.tsx
@@ -18,16 +18,12 @@ export interface SøknadContext {
     isPapirsøknad: boolean;
 }
 
-function sakstypeFraTemaIUrl(temaIUrl?: Routes.TemaFraUrl): Sakstype {
-    return temaIUrl === Routes.URL_TEMA_ALDER ? Sakstype.Alder : Sakstype.Uføre;
-}
-
 const index = () => {
     const { formatMessage } = useI18n({ messages });
     const location = useLocation();
     const isPapirsøknad = location.search.includes('papirsoknad');
     const temaIUrl = Routes.useRouteParams<typeof Routes.soknadtema>().soknadstema;
-    const sakstype = useFeatureToggle(FeatureToggle.Alder) ? sakstypeFraTemaIUrl(temaIUrl) : Sakstype.Uføre;
+    const sakstype = useFeatureToggle(FeatureToggle.Alder) ? Routes.sakstypeFraTemaIUrl(temaIUrl) : Sakstype.Uføre;
 
     return (
         <div className={styles.container}>

--- a/src/pages/søknad/steg/Steg.tsx
+++ b/src/pages/søknad/steg/Steg.tsx
@@ -26,7 +26,7 @@ import { Sakstype, Søknadstype } from '~src/types/Søknad';
 export const Steg = (props: {
     title: string;
     step: Søknadssteg;
-    soknadstema: Sakstype;
+    sakstype: Sakstype;
     søknad: SøknadState;
     søker: Person;
     erSaksbehandler: boolean;
@@ -50,7 +50,7 @@ export const Steg = (props: {
             </div>
             <ShowSteg
                 step={props.step}
-                soknadstema={props.soknadstema}
+                sakstype={props.sakstype}
                 søknad={props.søknad}
                 søker={props.søker}
                 erSaksbehandler={props.erSaksbehandler}
@@ -61,19 +61,19 @@ export const Steg = (props: {
 
 const ShowSteg = (props: {
     step: Søknadssteg;
-    soknadstema: Sakstype;
+    sakstype: Sakstype;
     søknad: SøknadState;
     søker: Person;
     erSaksbehandler: boolean;
 }) => {
     const avbrytUrl = routes.soknadPersonSøk.createURL({
         papirsøknad: props.erSaksbehandler && props.søknad.forVeileder.type === Søknadstype.Papirsøknad,
-        soknadstema: props.soknadstema,
+        soknadstema: routes.urlForSakstype(props.sakstype),
     });
     const stegUrl = (steg: Søknadssteg) =>
         routes.soknadsutfylling.createURL({
             step: steg,
-            soknadstema: props.soknadstema,
+            soknadstema: routes.urlForSakstype(props.sakstype),
         });
 
     switch (props.step) {
@@ -113,7 +113,7 @@ const ShowSteg = (props: {
             return (
                 <BoOgOppholdINorge
                     forrigeUrl={stegUrl(
-                        props.soknadstema === Sakstype.Uføre
+                        props.sakstype === Sakstype.Uføre
                             ? Uføresteg.FlyktningstatusOppholdstillatelse
                             : Alderssteg.Oppholdstillatelse
                     )}
@@ -166,7 +166,7 @@ const ShowSteg = (props: {
                             : stegUrl(Fellessteg.DinInntekt)
                     }
                     nesteUrl={routes.soknadsutfylling.createURL({
-                        soknadstema: props.soknadstema,
+                        soknadstema: routes.urlForSakstype(props.sakstype),
                         step:
                             props.søknad.forVeileder.type === Søknadstype.DigitalSøknad
                                 ? Fellessteg.ForVeileder
@@ -200,7 +200,9 @@ const ShowSteg = (props: {
                             ? Fellessteg.ForVeileder
                             : Fellessteg.InformasjonOmPapirsøknad
                     )}
-                    nesteUrl={routes.søknadskvittering.createURL({ soknadstema: props.soknadstema })}
+                    nesteUrl={routes.søknadskvittering.createURL({
+                        soknadstema: routes.urlForSakstype(props.sakstype),
+                    })}
                     avbrytUrl={avbrytUrl}
                     søker={props.søker}
                 />

--- a/src/pages/søknad/steg/Steg.tsx
+++ b/src/pages/søknad/steg/Steg.tsx
@@ -21,7 +21,8 @@ import Oppsummering from '~src/pages/søknad/steg/oppsummering/Oppsummering';
 import Uførevedtak from '~src/pages/søknad/steg/uførevedtak/Uførevedtak';
 import Utenlandsopphold from '~src/pages/søknad/steg/utenlandsopphold/Utenlandsopphold';
 import { Alderssteg, Fellessteg, Søknadssteg, Uføresteg } from '~src/pages/søknad/types';
-import { Sakstype, Søknadstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
+import { Søknadstype } from '~src/types/Søknad';
 
 export const Steg = (props: {
     title: string;

--- a/src/pages/søknad/steg/Steg.tsx
+++ b/src/pages/søknad/steg/Steg.tsx
@@ -21,12 +21,12 @@ import Oppsummering from '~src/pages/søknad/steg/oppsummering/Oppsummering';
 import Uførevedtak from '~src/pages/søknad/steg/uførevedtak/Uførevedtak';
 import Utenlandsopphold from '~src/pages/søknad/steg/utenlandsopphold/Utenlandsopphold';
 import { Alderssteg, Fellessteg, Søknadssteg, Uføresteg } from '~src/pages/søknad/types';
-import { Søknadstema, Søknadstype } from '~src/types/Søknad';
+import { Sakstype, Søknadstype } from '~src/types/Søknad';
 
 export const Steg = (props: {
     title: string;
     step: Søknadssteg;
-    soknadstema: Søknadstema;
+    soknadstema: Sakstype;
     søknad: SøknadState;
     søker: Person;
     erSaksbehandler: boolean;
@@ -61,7 +61,7 @@ export const Steg = (props: {
 
 const ShowSteg = (props: {
     step: Søknadssteg;
-    soknadstema: Søknadstema;
+    soknadstema: Sakstype;
     søknad: SøknadState;
     søker: Person;
     erSaksbehandler: boolean;
@@ -113,7 +113,7 @@ const ShowSteg = (props: {
             return (
                 <BoOgOppholdINorge
                     forrigeUrl={stegUrl(
-                        props.soknadstema === Søknadstema.Uføre
+                        props.soknadstema === Sakstype.Uføre
                             ? Uføresteg.FlyktningstatusOppholdstillatelse
                             : Alderssteg.Oppholdstillatelse
                     )}

--- a/src/pages/søknad/steg/infoside/Infoside.tsx
+++ b/src/pages/søknad/steg/infoside/Infoside.tsx
@@ -7,13 +7,13 @@ import { useI18n } from '~src/lib/i18n';
 import { soknadPersonSøk } from '~src/lib/routes';
 import { SøknadContext } from '~src/pages/søknad';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 
 import messages from './infoside-nb';
 import * as styles from './infoside.module.less';
 
 const Infoside = () => {
-    const { isPapirsøknad, soknadstema } = useOutletContext<SøknadContext>();
+    const { isPapirsøknad, sakstype: soknadstema } = useOutletContext<SøknadContext>();
     const nesteUrl = soknadPersonSøk.createURL({
         soknadstema,
         papirsøknad: isPapirsøknad,
@@ -36,8 +36,8 @@ const Infoside = () => {
                 <BodyLong>
                     {formatMessage(
                         getSøknadstematekst(soknadstema, {
-                            [Søknadstema.Uføre]: 'suppstønadInfo.kanFåSupp.ufør',
-                            [Søknadstema.Alder]: 'suppstønadInfo.kanFåSupp.alder',
+                            [Sakstype.Uføre]: 'suppstønadInfo.kanFåSupp.ufør',
+                            [Sakstype.Alder]: 'suppstønadInfo.kanFåSupp.alder',
                         }),
                         {
                             strong: (text) => <strong>{text}</strong>,
@@ -48,29 +48,29 @@ const Infoside = () => {
 
             <Heading level="1" size="xlarge" spacing>
                 {getSøknadstematekst(soknadstema, {
-                    [Søknadstema.Uføre]: formatMessage('page.tittel.uføre'),
-                    [Søknadstema.Alder]: formatMessage('page.tittel.alder'),
+                    [Sakstype.Uføre]: formatMessage('page.tittel.uføre'),
+                    [Sakstype.Alder]: formatMessage('page.tittel.alder'),
                 })}
             </Heading>
 
             <section className={styles.section}>
                 <Ingress spacing>
                     {getSøknadstematekst(soknadstema, {
-                        [Søknadstema.Uføre]: formatMessage('suppstønadInfo.ingress.ufør'),
-                        [Søknadstema.Alder]: formatMessage('suppstønadInfo.ingress.alder'),
+                        [Sakstype.Uføre]: formatMessage('suppstønadInfo.ingress.ufør'),
+                        [Sakstype.Alder]: formatMessage('suppstønadInfo.ingress.alder'),
                     })}
                 </Ingress>
                 <BodyLong>
                     <Link
                         target="_blank"
                         href={getSøknadstematekst(soknadstema, {
-                            [Søknadstema.Uføre]: merOmSuForUføreLink,
-                            [Søknadstema.Alder]: merOmSuAlderLink,
+                            [Sakstype.Uføre]: merOmSuForUføreLink,
+                            [Sakstype.Alder]: merOmSuAlderLink,
                         })}
                     >
                         {getSøknadstematekst(soknadstema, {
-                            [Søknadstema.Uføre]: formatMessage('suppstønad.merOmSuForUføre'),
-                            [Søknadstema.Alder]: formatMessage('suppstønad.merOmSuAlder'),
+                            [Sakstype.Uføre]: formatMessage('suppstønad.merOmSuForUføre'),
+                            [Sakstype.Alder]: formatMessage('suppstønad.merOmSuAlder'),
                         })}
                     </Link>
                 </BodyLong>
@@ -87,8 +87,8 @@ const Infoside = () => {
                     <li className={styles.listItem}>
                         {formatMessage(
                             getSøknadstematekst(soknadstema, {
-                                [Søknadstema.Uføre]: 'henterInnInfo.viHenter.flyktningsstatus',
-                                [Søknadstema.Alder]: 'henterInnInfo.viHenter.oppholdstillatelse',
+                                [Sakstype.Uføre]: 'henterInnInfo.viHenter.flyktningsstatus',
+                                [Sakstype.Alder]: 'henterInnInfo.viHenter.oppholdstillatelse',
                             })
                         )}
                     </li>
@@ -113,8 +113,8 @@ const Infoside = () => {
                             <Link
                                 target="_blank"
                                 href={getSøknadstematekst(soknadstema, {
-                                    [Søknadstema.Uføre]: suUførFlyktningLink,
-                                    [Søknadstema.Alder]: suAlderLink,
+                                    [Sakstype.Uføre]: suUførFlyktningLink,
+                                    [Sakstype.Alder]: suAlderLink,
                                 })}
                             >
                                 {tekst}

--- a/src/pages/søknad/steg/infoside/Infoside.tsx
+++ b/src/pages/søknad/steg/infoside/Infoside.tsx
@@ -7,7 +7,7 @@ import { useI18n } from '~src/lib/i18n';
 import { soknadPersonSøk, urlForSakstype } from '~src/lib/routes';
 import { SøknadContext } from '~src/pages/søknad';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 
 import messages from './infoside-nb';
 import * as styles from './infoside.module.less';

--- a/src/pages/søknad/steg/infoside/Infoside.tsx
+++ b/src/pages/søknad/steg/infoside/Infoside.tsx
@@ -4,7 +4,7 @@ import { useOutletContext } from 'react-router-dom';
 
 import LinkAsButton from '~src/components/linkAsButton/LinkAsButton';
 import { useI18n } from '~src/lib/i18n';
-import { soknadPersonSøk } from '~src/lib/routes';
+import { soknadPersonSøk, urlForSakstype } from '~src/lib/routes';
 import { SøknadContext } from '~src/pages/søknad';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
 import { Sakstype } from '~src/types/Søknad';
@@ -13,9 +13,9 @@ import messages from './infoside-nb';
 import * as styles from './infoside.module.less';
 
 const Infoside = () => {
-    const { isPapirsøknad, sakstype: soknadstema } = useOutletContext<SøknadContext>();
+    const { isPapirsøknad, sakstype } = useOutletContext<SøknadContext>();
     const nesteUrl = soknadPersonSøk.createURL({
-        soknadstema,
+        soknadstema: urlForSakstype(sakstype),
         papirsøknad: isPapirsøknad,
     });
 
@@ -35,7 +35,7 @@ const Infoside = () => {
             <GuidePanel className={styles.guide}>
                 <BodyLong>
                     {formatMessage(
-                        getSøknadstematekst(soknadstema, {
+                        getSøknadstematekst(sakstype, {
                             [Sakstype.Uføre]: 'suppstønadInfo.kanFåSupp.ufør',
                             [Sakstype.Alder]: 'suppstønadInfo.kanFåSupp.alder',
                         }),
@@ -47,7 +47,7 @@ const Infoside = () => {
             </GuidePanel>
 
             <Heading level="1" size="xlarge" spacing>
-                {getSøknadstematekst(soknadstema, {
+                {getSøknadstematekst(sakstype, {
                     [Sakstype.Uføre]: formatMessage('page.tittel.uføre'),
                     [Sakstype.Alder]: formatMessage('page.tittel.alder'),
                 })}
@@ -55,7 +55,7 @@ const Infoside = () => {
 
             <section className={styles.section}>
                 <Ingress spacing>
-                    {getSøknadstematekst(soknadstema, {
+                    {getSøknadstematekst(sakstype, {
                         [Sakstype.Uføre]: formatMessage('suppstønadInfo.ingress.ufør'),
                         [Sakstype.Alder]: formatMessage('suppstønadInfo.ingress.alder'),
                     })}
@@ -63,12 +63,12 @@ const Infoside = () => {
                 <BodyLong>
                     <Link
                         target="_blank"
-                        href={getSøknadstematekst(soknadstema, {
+                        href={getSøknadstematekst(sakstype, {
                             [Sakstype.Uføre]: merOmSuForUføreLink,
                             [Sakstype.Alder]: merOmSuAlderLink,
                         })}
                     >
-                        {getSøknadstematekst(soknadstema, {
+                        {getSøknadstematekst(sakstype, {
                             [Sakstype.Uføre]: formatMessage('suppstønad.merOmSuForUføre'),
                             [Sakstype.Alder]: formatMessage('suppstønad.merOmSuAlder'),
                         })}
@@ -86,7 +86,7 @@ const Infoside = () => {
                     <li className={styles.listItem}>{formatMessage('henterInnInfo.viHenter.arbeidsforhold')}</li>
                     <li className={styles.listItem}>
                         {formatMessage(
-                            getSøknadstematekst(soknadstema, {
+                            getSøknadstematekst(sakstype, {
                                 [Sakstype.Uføre]: 'henterInnInfo.viHenter.flyktningsstatus',
                                 [Sakstype.Alder]: 'henterInnInfo.viHenter.oppholdstillatelse',
                             })
@@ -112,7 +112,7 @@ const Infoside = () => {
                         navLink: (tekst) => (
                             <Link
                                 target="_blank"
-                                href={getSøknadstematekst(soknadstema, {
+                                href={getSøknadstematekst(sakstype, {
                                     [Sakstype.Uføre]: suUførFlyktningLink,
                                     [Sakstype.Alder]: suAlderLink,
                                 })}

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -15,13 +15,15 @@ import * as personSlice from '~src/features/person/person.slice';
 import søknadSlice from '~src/features/søknad/søknad.slice';
 import { pipe } from '~src/lib/fp';
 import { useApiCall, useAsyncActionCreator } from '~src/lib/hooks';
-import { MessageFormatter, useI18n } from '~src/lib/i18n';
+import { useI18n } from '~src/lib/i18n';
 import { soknadsutfylling } from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
 import { SøknadContext } from '~src/pages/søknad';
 import { Alderssteg, Uføresteg } from '~src/pages/søknad/types';
+import { getSøknadstematekst } from '~src/pages/søknad/utils';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { Periode } from '~src/types/Periode';
+import { AlleredeÅpenSak, Sakstype } from '~src/types/Sak';
 import { Søknadstema, Søknadstype } from '~src/types/Søknad';
 import { formatDate } from '~src/utils/date/dateUtils';
 import { er67EllerEldre } from '~src/utils/person/personUtils';
@@ -29,76 +31,183 @@ import { er67EllerEldre } from '~src/utils/person/personUtils';
 import nb from './inngang-nb';
 import * as styles from './inngang.module.less';
 
-const SakinfoAlert = ({
-    harÅpenSøknad,
+const Aldersvarsel = ({ søkerAlder }: { søkerAlder: Nullable<number> }) => {
+    const { formatMessage } = useI18n({ messages: nb });
+    const { soknadstema } = useOutletContext<SøknadContext>();
+
+    if (!skalViseAldersvarsel(søkerAlder, soknadstema)) {
+        return null;
+    }
+
+    const suAndreSkjemaLenke = lenkeTilMotsattSkjema(soknadstema);
+    return (
+        <div>
+            <Heading level="2" size="small" spacing>
+                {formatMessage('heading.advarsel.alder')}
+            </Heading>
+            <BodyLong>
+                {formatMessage(
+                    getSøknadstematekst(soknadstema, {
+                        [Søknadstema.Uføre]: 'advarsel.alder.uføre',
+                        [Søknadstema.Alder]: 'advarsel.alder.alder',
+                    }),
+                    {
+                        navLink: (tekst) => (
+                            <Link target="_blank" href={suAndreSkjemaLenke}>
+                                {tekst}
+                            </Link>
+                        ),
+                    }
+                )}
+            </BodyLong>
+        </div>
+    );
+};
+
+const IverksattInnvilgetStønadsperiodeAlert = ({
     iverksattInnvilgetStønadsperiode,
-    aldervarsel,
-    formatMessage,
+    type,
 }: {
-    harÅpenSøknad: boolean;
     iverksattInnvilgetStønadsperiode: Nullable<Periode<string>>;
-    aldervarsel: boolean;
-    formatMessage: MessageFormatter<typeof nb>;
+    type: Sakstype;
 }) => {
-    const visTittel = [harÅpenSøknad, iverksattInnvilgetStønadsperiode, aldervarsel].filter(Boolean).length > 1;
-    const suAlderUrl =
-        'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-personer-over-sekstisyv-ar';
+    const { formatMessage } = useI18n({ messages: nb });
+    const { soknadstema } = useOutletContext<SøknadContext>();
+    if (iverksattInnvilgetStønadsperiode == null) {
+        return null;
+    }
+
+    const typeErSammeSomTema =
+        (soknadstema === Søknadstema.Alder && type === Sakstype.ALDER) ||
+        (soknadstema === Søknadstema.Uføre && type === Sakstype.ALDER);
+
+    return (
+        <div>
+            <Heading level="2" size="small" spacing>
+                {formatMessage(`heading.løpendeYtelse.${type}`)}
+            </Heading>
+            <BodyLong>
+                {formatMessage(`åpenSøknad.løpendeYtelse${typeErSammeSomTema ? '' : '.kort'}`, {
+                    løpendePeriode: `${formatDate(iverksattInnvilgetStønadsperiode.fraOgMed)} - ${formatDate(
+                        iverksattInnvilgetStønadsperiode.tilOgMed
+                    )}`,
+                    tidligestNyPeriode: formatDate(
+                        DateFns.startOfMonth(new Date(iverksattInnvilgetStønadsperiode.tilOgMed)).toString()
+                    ),
+                    type: formatMessage(type),
+                })}
+            </BodyLong>
+        </div>
+    );
+};
+
+const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: AlleredeÅpenSak }) => {
+    const { alder, uføre } = alleredeÅpenSakInfo;
+    const { formatMessage } = useI18n({ messages: nb });
+    const { soknadstema } = useOutletContext<SøknadContext>();
+
+    const suAndreSkjemaLenke = lenkeTilMotsattSkjema(soknadstema);
+
+    if (!alder.harÅpenSøknad && !uføre.harÅpenSøknad) {
+        return null;
+    }
+
+    return (
+        <>
+            {alder.harÅpenSøknad && (
+                <div>
+                    <Heading level="2" size="small" spacing>
+                        {formatMessage(
+                            getSøknadstematekst(soknadstema, {
+                                [Søknadstema.Alder]: 'heading.åpenSøknad',
+                                [Søknadstema.Uføre]: 'heading.åpenSøknad.uføre',
+                            })
+                        )}
+                    </Heading>
+                    <BodyLong>
+                        {formatMessage(
+                            getSøknadstematekst(soknadstema, {
+                                [Søknadstema.Uføre]: 'feil.harÅpenSøknad.motsatt-uføre',
+                                [Søknadstema.Alder]: 'feil.harÅpenSøknad',
+                            }),
+                            {
+                                navLink: (tekst) => (
+                                    <Link target="_blank" href={suAndreSkjemaLenke}>
+                                        {tekst}
+                                    </Link>
+                                ),
+                            }
+                        )}
+                    </BodyLong>
+                </div>
+            )}
+            {uføre.harÅpenSøknad && (
+                <div>
+                    <Heading level="2" size="small" spacing>
+                        {formatMessage(
+                            getSøknadstematekst(soknadstema, {
+                                [Søknadstema.Alder]: 'heading.åpenSøknad.alder',
+                                [Søknadstema.Uføre]: 'heading.åpenSøknad',
+                            })
+                        )}
+                    </Heading>
+                    <BodyLong>
+                        {formatMessage(
+                            getSøknadstematekst(soknadstema, {
+                                [Søknadstema.Uføre]: 'feil.harÅpenSøknad',
+                                [Søknadstema.Alder]: 'feil.harÅpenSøknad.motsatt-alder',
+                            }),
+                            {
+                                navLink: (tekst) => (
+                                    <Link target="_blank" href={suAndreSkjemaLenke}>
+                                        {tekst}
+                                    </Link>
+                                ),
+                            }
+                        )}
+                    </BodyLong>
+                </div>
+            )}
+            <IverksattInnvilgetStønadsperiodeAlert
+                type={Sakstype.UFØRE}
+                iverksattInnvilgetStønadsperiode={uføre.iverksattInnvilgetStønadsperiode}
+            />
+            <IverksattInnvilgetStønadsperiodeAlert
+                type={Sakstype.ALDER}
+                iverksattInnvilgetStønadsperiode={alder.iverksattInnvilgetStønadsperiode}
+            />
+        </>
+    );
+};
+
+const SakinfoAlertContainer = ({
+    alleredeÅpenSakInfo,
+    søkerAlder,
+}: {
+    alleredeÅpenSakInfo: AlleredeÅpenSak;
+    søkerAlder: Nullable<number>;
+}) => {
+    const { soknadstema } = useOutletContext<SøknadContext>();
+    const visAldersvarsel = skalViseAldersvarsel(søkerAlder, soknadstema);
+
+    if (
+        !visAldersvarsel &&
+        !alleredeÅpenSakInfo.alder.harÅpenSøknad &&
+        !alleredeÅpenSakInfo.uføre.harÅpenSøknad &&
+        alleredeÅpenSakInfo.alder.iverksattInnvilgetStønadsperiode === null &&
+        alleredeÅpenSakInfo.uføre.iverksattInnvilgetStønadsperiode === null
+    ) {
+        return null;
+    }
     return (
         <Alert className={styles.åpenSøknadContainer} variant="warning">
-            {harÅpenSøknad && (
-                <div>
-                    {visTittel && (
-                        <Heading level="2" size="small" spacing>
-                            {formatMessage('heading.åpenSøknad')}
-                        </Heading>
-                    )}
-                    <BodyLong spacing={iverksattInnvilgetStønadsperiode !== null}>
-                        {formatMessage('feil.harÅpenSøknad')}
-                    </BodyLong>
-                </div>
-            )}
-            {iverksattInnvilgetStønadsperiode && (
-                <div>
-                    {visTittel && (
-                        <Heading level="2" size="small" spacing>
-                            {formatMessage('heading.løpendeYtelse')}
-                        </Heading>
-                    )}
-                    <BodyLong>
-                        {formatMessage('åpenSøknad.løpendeYtelse', {
-                            løpendePeriode: `${formatDate(iverksattInnvilgetStønadsperiode.fraOgMed)} - ${formatDate(
-                                iverksattInnvilgetStønadsperiode.tilOgMed
-                            )}`,
-                            tidligestNyPeriode: formatDate(
-                                DateFns.startOfMonth(new Date(iverksattInnvilgetStønadsperiode.tilOgMed)).toString()
-                            ),
-                        })}
-                    </BodyLong>
-                </div>
-            )}
-            {aldervarsel && (
-                <div>
-                    {visTittel && (
-                        <Heading level="2" size="small" spacing>
-                            {formatMessage('heading.advarsel.alder')}
-                        </Heading>
-                    )}
-                    <BodyLong>
-                        {formatMessage('advarsel.alder', {
-                            navLink: (tekst) => (
-                                <Link target="_blank" href={suAlderUrl}>
-                                    {tekst}
-                                </Link>
-                            ),
-                        })}
-                    </BodyLong>
-                </div>
-            )}
+            <ÅpenSøknadVarsel alleredeÅpenSakInfo={alleredeÅpenSakInfo} />
+            <Aldersvarsel søkerAlder={søkerAlder} />
         </Alert>
     );
 };
 
-const index = () => {
+const Inngang = () => {
     const { isPapirsøknad, soknadstema } = useOutletContext<SøknadContext>();
     const startstegUrl = soknadsutfylling.createURL({
         step: soknadstema === Søknadstema.Uføre ? Uføresteg.Uførevedtak : Alderssteg.Alderspensjon,
@@ -207,17 +316,13 @@ const index = () => {
                     />
                     {pipe(
                         RemoteData.combine(sakinfo, hentPersonStatus),
-                        RemoteData.map(
-                            ([{ harÅpenSøknad, iverksattInnvilgetStønadsperiode }, { alder }]) =>
-                                (harÅpenSøknad || iverksattInnvilgetStønadsperiode || er67EllerEldre(alder)) && (
-                                    <SakinfoAlert
-                                        harÅpenSøknad={harÅpenSøknad}
-                                        iverksattInnvilgetStønadsperiode={iverksattInnvilgetStønadsperiode}
-                                        aldervarsel={er67EllerEldre(alder)}
-                                        formatMessage={formatMessage}
-                                    />
-                                )
-                        ),
+                        RemoteData.map(([begrensetSakInfo, { alder }]) => (
+                            <SakinfoAlertContainer
+                                key={alder}
+                                alleredeÅpenSakInfo={begrensetSakInfo}
+                                søkerAlder={alder}
+                            />
+                        )),
                         RemoteData.getOrElse(() => null as React.ReactNode)
                     )}
                     {/* Vi ønsker ikke å vise en feil dersom personkallet ikke er 2xx eller sakskallet ga 404  */}
@@ -247,4 +352,27 @@ const index = () => {
     );
 };
 
-export default index;
+function skalViseAldersvarsel(alder: Nullable<number>, soknadstema: Søknadstema): boolean {
+    if (alder == null) {
+        return false;
+    }
+    const erOver67år = er67EllerEldre(alder);
+    if (soknadstema === Søknadstema.Uføre) {
+        return erOver67år;
+    } else {
+        return !erOver67år;
+    }
+}
+const SU_ALDER_URL = 'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-personer-over-sekstisyv-ar';
+const SU_UFØRE_URL = 'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-ufor-flyktning';
+
+function lenkeTilMotsattSkjema(skjema: Søknadstema): string {
+    switch (skjema) {
+        case Søknadstema.Alder:
+            return SU_UFØRE_URL;
+        case Søknadstema.Uføre:
+            return SU_ALDER_URL;
+    }
+}
+
+export default Inngang;

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -16,7 +16,7 @@ import søknadSlice from '~src/features/søknad/søknad.slice';
 import { pipe } from '~src/lib/fp';
 import { useApiCall, useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
-import { soknadsutfylling } from '~src/lib/routes';
+import { soknadsutfylling, urlForSakstype } from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
 import { SøknadContext } from '~src/pages/søknad';
 import { Alderssteg, Uføresteg } from '~src/pages/søknad/types';
@@ -208,7 +208,7 @@ const Inngang = () => {
     const { isPapirsøknad, sakstype } = useOutletContext<SøknadContext>();
     const startstegUrl = soknadsutfylling.createURL({
         step: sakstype === Sakstype.Uføre ? Uføresteg.Uførevedtak : Alderssteg.Alderspensjon,
-        soknadstema: sakstype,
+        soknadstema: urlForSakstype(sakstype),
         papirsøknad: isPapirsøknad,
     });
     const { søker } = useAppSelector((s) => s.søker);

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -23,8 +23,8 @@ import { Alderssteg, Uføresteg } from '~src/pages/søknad/types';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { Periode } from '~src/types/Periode';
-import { AlleredeÅpenSak, Sakstype } from '~src/types/Sak';
-import { Søknadstema, Søknadstype } from '~src/types/Søknad';
+import { AlleredeGjeldendeSakForBruker } from '~src/types/Sak';
+import { Sakstype, Søknadstype } from '~src/types/Søknad';
 import { formatDate } from '~src/utils/date/dateUtils';
 import { er67EllerEldre } from '~src/utils/person/personUtils';
 
@@ -33,13 +33,13 @@ import * as styles from './inngang.module.less';
 
 const Aldersvarsel = ({ søkerAlder }: { søkerAlder: Nullable<number> }) => {
     const { formatMessage } = useI18n({ messages: nb });
-    const { soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype } = useOutletContext<SøknadContext>();
 
-    if (!skalViseAldersvarsel(søkerAlder, soknadstema)) {
+    if (!skalViseAldersvarsel(søkerAlder, sakstype)) {
         return null;
     }
 
-    const suAndreSkjemaLenke = lenkeTilMotsattSkjema(soknadstema);
+    const suAndreSkjemaLenke = lenkeTilMotsattSkjema(sakstype);
     return (
         <div>
             <Heading level="2" size="small" spacing>
@@ -47,9 +47,9 @@ const Aldersvarsel = ({ søkerAlder }: { søkerAlder: Nullable<number> }) => {
             </Heading>
             <BodyLong>
                 {formatMessage(
-                    getSøknadstematekst(soknadstema, {
-                        [Søknadstema.Uføre]: 'advarsel.alder.uføre',
-                        [Søknadstema.Alder]: 'advarsel.alder.alder',
+                    getSøknadstematekst(sakstype, {
+                        [Sakstype.Uføre]: 'advarsel.alder.uføre',
+                        [Sakstype.Alder]: 'advarsel.alder.alder',
                     }),
                     {
                         navLink: (tekst) => (
@@ -72,15 +72,12 @@ const IverksattInnvilgetStønadsperiodeAlert = ({
     type: Sakstype;
 }) => {
     const { formatMessage } = useI18n({ messages: nb });
-    const { soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype } = useOutletContext<SøknadContext>();
     if (iverksattInnvilgetStønadsperiode == null) {
         return null;
     }
 
-    const typeErSammeSomTema =
-        (soknadstema === Søknadstema.Alder && type === Sakstype.ALDER) ||
-        (soknadstema === Søknadstema.Uføre && type === Sakstype.ALDER);
-
+    const typeErSammeSomTema = sakstype === type;
     return (
         <div>
             <Heading level="2" size="small" spacing>
@@ -101,12 +98,12 @@ const IverksattInnvilgetStønadsperiodeAlert = ({
     );
 };
 
-const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: AlleredeÅpenSak }) => {
+const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: AlleredeGjeldendeSakForBruker }) => {
     const { alder, uføre } = alleredeÅpenSakInfo;
     const { formatMessage } = useI18n({ messages: nb });
-    const { soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype } = useOutletContext<SøknadContext>();
 
-    const suAndreSkjemaLenke = lenkeTilMotsattSkjema(soknadstema);
+    const suAndreSkjemaLenke = lenkeTilMotsattSkjema(sakstype);
 
     if (!alder.harÅpenSøknad && !uføre.harÅpenSøknad) {
         return null;
@@ -118,17 +115,17 @@ const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: Al
                 <div>
                     <Heading level="2" size="small" spacing>
                         {formatMessage(
-                            getSøknadstematekst(soknadstema, {
-                                [Søknadstema.Alder]: 'heading.åpenSøknad',
-                                [Søknadstema.Uføre]: 'heading.åpenSøknad.uføre',
+                            getSøknadstematekst(sakstype, {
+                                [Sakstype.Alder]: 'heading.åpenSøknad',
+                                [Sakstype.Uføre]: 'heading.åpenSøknad.uføre',
                             })
                         )}
                     </Heading>
                     <BodyLong>
                         {formatMessage(
-                            getSøknadstematekst(soknadstema, {
-                                [Søknadstema.Uføre]: 'feil.harÅpenSøknad.motsatt-uføre',
-                                [Søknadstema.Alder]: 'feil.harÅpenSøknad',
+                            getSøknadstematekst(sakstype, {
+                                [Sakstype.Uføre]: 'feil.harÅpenSøknad.motsatt-uføre',
+                                [Sakstype.Alder]: 'feil.harÅpenSøknad',
                             }),
                             {
                                 navLink: (tekst) => (
@@ -145,17 +142,17 @@ const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: Al
                 <div>
                     <Heading level="2" size="small" spacing>
                         {formatMessage(
-                            getSøknadstematekst(soknadstema, {
-                                [Søknadstema.Alder]: 'heading.åpenSøknad.alder',
-                                [Søknadstema.Uføre]: 'heading.åpenSøknad',
+                            getSøknadstematekst(sakstype, {
+                                [Sakstype.Alder]: 'heading.åpenSøknad.alder',
+                                [Sakstype.Uføre]: 'heading.åpenSøknad',
                             })
                         )}
                     </Heading>
                     <BodyLong>
                         {formatMessage(
-                            getSøknadstematekst(soknadstema, {
-                                [Søknadstema.Uføre]: 'feil.harÅpenSøknad',
-                                [Søknadstema.Alder]: 'feil.harÅpenSøknad.motsatt-alder',
+                            getSøknadstematekst(sakstype, {
+                                [Sakstype.Uføre]: 'feil.harÅpenSøknad',
+                                [Sakstype.Alder]: 'feil.harÅpenSøknad.motsatt-alder',
                             }),
                             {
                                 navLink: (tekst) => (
@@ -169,11 +166,11 @@ const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: Al
                 </div>
             )}
             <IverksattInnvilgetStønadsperiodeAlert
-                type={Sakstype.UFØRE}
+                type={Sakstype.Uføre}
                 iverksattInnvilgetStønadsperiode={uføre.iverksattInnvilgetStønadsperiode}
             />
             <IverksattInnvilgetStønadsperiodeAlert
-                type={Sakstype.ALDER}
+                type={Sakstype.Alder}
                 iverksattInnvilgetStønadsperiode={alder.iverksattInnvilgetStønadsperiode}
             />
         </>
@@ -184,11 +181,11 @@ const SakinfoAlertContainer = ({
     alleredeÅpenSakInfo,
     søkerAlder,
 }: {
-    alleredeÅpenSakInfo: AlleredeÅpenSak;
+    alleredeÅpenSakInfo: AlleredeGjeldendeSakForBruker;
     søkerAlder: Nullable<number>;
 }) => {
-    const { soknadstema } = useOutletContext<SøknadContext>();
-    const visAldersvarsel = skalViseAldersvarsel(søkerAlder, soknadstema);
+    const { sakstype } = useOutletContext<SøknadContext>();
+    const visAldersvarsel = skalViseAldersvarsel(søkerAlder, sakstype);
 
     if (
         !visAldersvarsel &&
@@ -208,10 +205,10 @@ const SakinfoAlertContainer = ({
 };
 
 const Inngang = () => {
-    const { isPapirsøknad, soknadstema } = useOutletContext<SøknadContext>();
+    const { isPapirsøknad, sakstype } = useOutletContext<SøknadContext>();
     const startstegUrl = soknadsutfylling.createURL({
-        step: soknadstema === Søknadstema.Uføre ? Uføresteg.Uførevedtak : Alderssteg.Alderspensjon,
-        soknadstema: soknadstema,
+        step: sakstype === Sakstype.Uføre ? Uføresteg.Uførevedtak : Alderssteg.Alderspensjon,
+        soknadstema: sakstype,
         papirsøknad: isPapirsøknad,
     });
     const { søker } = useAppSelector((s) => s.søker);
@@ -352,12 +349,12 @@ const Inngang = () => {
     );
 };
 
-function skalViseAldersvarsel(alder: Nullable<number>, soknadstema: Søknadstema): boolean {
+function skalViseAldersvarsel(alder: Nullable<number>, sakstype: Sakstype): boolean {
     if (alder == null) {
         return false;
     }
     const erOver67år = er67EllerEldre(alder);
-    if (soknadstema === Søknadstema.Uføre) {
+    if (sakstype === Sakstype.Uføre) {
         return erOver67år;
     } else {
         return !erOver67år;
@@ -366,11 +363,11 @@ function skalViseAldersvarsel(alder: Nullable<number>, soknadstema: Søknadstema
 const SU_ALDER_URL = 'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-personer-over-sekstisyv-ar';
 const SU_UFØRE_URL = 'https://www.nav.no/soknader/nb/person/pensjon/supplerende-stonad-til-ufor-flyktning';
 
-function lenkeTilMotsattSkjema(skjema: Søknadstema): string {
+function lenkeTilMotsattSkjema(skjema: Sakstype): string {
     switch (skjema) {
-        case Søknadstema.Alder:
+        case Sakstype.Alder:
             return SU_UFØRE_URL;
-        case Søknadstema.Uføre:
+        case Sakstype.Uføre:
             return SU_ALDER_URL;
     }
 }

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -23,8 +23,8 @@ import { Alderssteg, Uføresteg } from '~src/pages/søknad/types';
 import { getSøknadstematekst } from '~src/pages/søknad/utils';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
 import { Periode } from '~src/types/Periode';
-import { AlleredeGjeldendeSakForBruker } from '~src/types/Sak';
-import { Sakstype, Søknadstype } from '~src/types/Søknad';
+import { AlleredeGjeldendeSakForBruker, Sakstype } from '~src/types/Sak';
+import { Søknadstype } from '~src/types/Søknad';
 import { formatDate } from '~src/utils/date/dateUtils';
 import { er67EllerEldre } from '~src/utils/person/personUtils';
 

--- a/src/pages/søknad/steg/inngang/inngang-nb.ts
+++ b/src/pages/søknad/steg/inngang/inngang-nb.ts
@@ -1,4 +1,14 @@
+import { Sakstype } from '~src/types/Sak';
+
 export default {
+    [Sakstype.ALDER]: 'Supplerende stønad for personer over 67 år med kort botid i Norge',
+    [Sakstype.UFØRE]: 'Supplerende stønad for uføre flyktninger',
+
+    'advarsel.alder.uføre':
+        'Du kan få supplerende stønad for uføre flyktninger hvis du er under 67 år. Er du over 67 år kan du søke <navLink>Supplerende stønad for personer med kort botid i Norge</navLink>. Har du akkurat fylt 67 år kan du ha rett på etterbetaling for supplerende stønad for uføre flyktninger. Da må du fylle ut to søknader, en som ufør flyktning under 67 år og en som person med kort botid i Norge.',
+    'advarsel.alder.alder':
+        'Du kan få supplerende stønad for personer med kort botid i Norge hvis du er over 67 år. Er du under 67 år og ufør flyktning kan du søke <navLink>Supplerende stønad for uføre flyktninger</navLink>.',
+
     'bekreftelsesboks.tekst.p1':
         'Veilederen har fortalt søkeren om hvilken informasjon vi henter og hvilken informasjon som søkeren selv må levere.',
     'bekreftelsesboks.tekst.p2':
@@ -8,16 +18,22 @@ export default {
     'feil.påkrevdFelt': 'Feltet er påkrevd',
     'feil.harÅpenSøknad':
         'Bruker har allerede en åpen søknad som er til behandling. Dersom bruker ønsker å komme med ytterligere dokumentasjon kan denne sendes til skanning. Skulle bruker ønske å endre på opplysningene i søknaden kan dette gjøres ved å sende en oppgave via MODIA personoversikt.',
-
-    'heading.åpenSøknad': 'Åpen søknad',
-    'heading.løpendeYtelse': 'Løpende ytelse',
-
-    'åpenSøknad.løpendeYtelse':
-        'Bruker har allerede en løpende ytelse, supplerende stønad er innvilget for perioden {løpendePeriode}. Bruker kan tidligst søke om ny periode {tidligestNyPeriode}.',
+    'feil.harÅpenSøknad.motsatt-alder':
+        'Bruker har allerede en åpen søknad for supplerende stønad for uføre flyktninger som er til behandling. Dersom bruker ønsker å oppdatere den søknaden <navLink>følg instruksjonene her</navLink>.',
+    'feil.harÅpenSøknad.motsatt-uføre':
+        'Bruker har allerede en åpen søknad for supplerende stønad forpersoner over 67 år med kort botid i Norge som er til behandling. Dersom bruker ønsker å oppdatere den søknaden <navLink>følg instruksjonene her</navLink>.',
 
     'heading.advarsel.alder': 'Alder',
-    'advarsel.alder':
-        'Du kan få supplerende stønad for uføre flyktninger hvis du er under 67 år. Er du over 67 år kan du søke <navLink>Supplerende stønad for personer med kort botid i Norge</navLink>. Har du akkurat fylt 67 år kan du ha rett på etterbetaling for supplerende stønad for uføre flyktninger. Da må du fylle ut to søknader, en som ufør flyktning under 67 år og en som person med kort botid i Norge.',
+    'heading.åpenSøknad': 'Åpen søknad',
+    'heading.åpenSøknad.alder': 'Åpen søknad for personer over 67 år med kort botid',
+    'heading.åpenSøknad.uføre': 'Åpen søknad for uføre flyktninger',
+    'heading.løpendeYtelse.uføre': 'Løpende ytelse uføre flyktninger',
+    'heading.løpendeYtelse.alder': 'Løpende ytelse personer over 67 år med kort botid',
+
+    'åpenSøknad.løpendeYtelse':
+        'Bruker har allerede en løpende ytelse, supplerende stønad {type} er innvilget for perioden {løpendePeriode}. Bruker kan tidligst søke om ny periode {tidligestNyPeriode}.',
+    'åpenSøknad.løpendeYtelse.kort':
+        'Bruker har allerede en løpende ytelse, supplerende stønad {type} er innvilget for perioden {løpendePeriode}.',
 
     'finnSøker.tittel': 'Finn søker',
     'finnSøker.tekst': 'For å starte søknaden, må du skrive inn fødselsnummeret til søkeren',

--- a/src/pages/søknad/steg/inngang/inngang-nb.ts
+++ b/src/pages/søknad/steg/inngang/inngang-nb.ts
@@ -1,4 +1,4 @@
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 
 export default {
     [Sakstype.Alder]: 'Supplerende stønad for personer over 67 år med kort botid i Norge',

--- a/src/pages/søknad/steg/inngang/inngang-nb.ts
+++ b/src/pages/søknad/steg/inngang/inngang-nb.ts
@@ -1,8 +1,8 @@
-import { Sakstype } from '~src/types/Sak';
+import { Sakstype } from '~src/types/Søknad';
 
 export default {
-    [Sakstype.ALDER]: 'Supplerende stønad for personer over 67 år med kort botid i Norge',
-    [Sakstype.UFØRE]: 'Supplerende stønad for uføre flyktninger',
+    [Sakstype.Alder]: 'Supplerende stønad for personer over 67 år med kort botid i Norge',
+    [Sakstype.Uføre]: 'Supplerende stønad for uføre flyktninger',
 
     'advarsel.alder.uføre':
         'Du kan få supplerende stønad for uføre flyktninger hvis du er under 67 år. Er du over 67 år kan du søke <navLink>Supplerende stønad for personer med kort botid i Norge</navLink>. Har du akkurat fylt 67 år kan du ha rett på etterbetaling for supplerende stønad for uføre flyktninger. Da må du fylle ut to søknader, en som ufør flyktning under 67 år og en som person med kort botid i Norge.',

--- a/src/pages/søknad/steg/inngang/inngang.module.less
+++ b/src/pages/søknad/steg/inngang/inngang.module.less
@@ -43,6 +43,13 @@
 .åpenSøknadContainer {
     margin-top: @spacing-l;
 
+    > div div:only-child {
+        // Hvis det kun er 1 advarsel
+        h2 {
+            display: none;
+        }
+    }
+
     > div {
         display: flex;
         flex-direction: column;

--- a/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
@@ -9,7 +9,7 @@ import * as innsendingSlice from '~src/features/søknad/innsending.slice';
 import { useI18n } from '~src/lib/i18n';
 import { SøknadContext } from '~src/pages/søknad';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 
 import Bunnknapper from '../../bunnknapper/Bunnknapper';
 import * as sharedStyles from '../../steg-shared.module.less';
@@ -20,13 +20,13 @@ import Søknadoppsummering from './Søknadoppsummering/Søknadoppsummering';
 
 const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: string; søker: Person }) => {
     const navigate = useNavigate();
-    const { soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype: soknadstema } = useOutletContext<SøknadContext>();
     const [søknadFraStore, innsending] = useAppSelector((s) => [s.soknad, s.innsending.søknad]);
     const { formatMessage } = useI18n({ messages });
     const dispatch = useAppDispatch();
 
     const handleSubmit = async () => {
-        if (soknadstema === Søknadstema.Uføre) {
+        if (soknadstema === Sakstype.Uføre) {
             const res = await dispatch(
                 innsendingSlice.sendUføresøknad({
                     søknad: søknadFraStore,
@@ -38,7 +38,7 @@ const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: 
             }
         }
 
-        if (soknadstema === Søknadstema.Alder) {
+        if (soknadstema === Sakstype.Alder) {
             const res = await dispatch(
                 innsendingSlice.sendAldersøknad({
                     søknad: søknadFraStore,

--- a/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
@@ -59,7 +59,7 @@ const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: 
                     handleSubmit();
                 }}
             >
-                <Søknadoppsummering søknad={søknadFraStore} søknadstema={soknadstema} />
+                <Søknadoppsummering søknad={søknadFraStore} sakstype={soknadstema} />
 
                 <Alert variant="info" className={styles.meldFraOmEndringerContainer}>
                     <Heading level="2" size="medium" spacing>

--- a/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Oppsummering.tsx
@@ -9,7 +9,7 @@ import * as innsendingSlice from '~src/features/søknad/innsending.slice';
 import { useI18n } from '~src/lib/i18n';
 import { SøknadContext } from '~src/pages/søknad';
 import { useAppDispatch, useAppSelector } from '~src/redux/Store';
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 
 import Bunnknapper from '../../bunnknapper/Bunnknapper';
 import * as sharedStyles from '../../steg-shared.module.less';
@@ -20,13 +20,13 @@ import Søknadoppsummering from './Søknadoppsummering/Søknadoppsummering';
 
 const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: string; søker: Person }) => {
     const navigate = useNavigate();
-    const { sakstype: soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype } = useOutletContext<SøknadContext>();
     const [søknadFraStore, innsending] = useAppSelector((s) => [s.soknad, s.innsending.søknad]);
     const { formatMessage } = useI18n({ messages });
     const dispatch = useAppDispatch();
 
     const handleSubmit = async () => {
-        if (soknadstema === Sakstype.Uføre) {
+        if (sakstype === Sakstype.Uføre) {
             const res = await dispatch(
                 innsendingSlice.sendUføresøknad({
                     søknad: søknadFraStore,
@@ -38,7 +38,7 @@ const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: 
             }
         }
 
-        if (soknadstema === Sakstype.Alder) {
+        if (sakstype === Sakstype.Alder) {
             const res = await dispatch(
                 innsendingSlice.sendAldersøknad({
                     søknad: søknadFraStore,
@@ -59,7 +59,7 @@ const Oppsummering = (props: { forrigeUrl: string; nesteUrl: string; avbrytUrl: 
                     handleSubmit();
                 }}
             >
-                <Søknadoppsummering søknad={søknadFraStore} sakstype={soknadstema} />
+                <Søknadoppsummering søknad={søknadFraStore} sakstype={sakstype} />
 
                 <Alert variant="info" className={styles.meldFraOmEndringerContainer}>
                     <Heading level="2" size="medium" spacing>

--- a/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
@@ -15,7 +15,7 @@ import oppholdstillatelseMessages from '~src/pages/søknad/steg/oppholdstillatel
 import uførevedtakMessages from '~src/pages/søknad/steg/uførevedtak/uførevedtak-nb';
 import utenlandsoppholdMessages from '~src/pages/søknad/steg/utenlandsopphold/utenlandsopphold-nb';
 import { Alderssteg, Fellessteg, Uføresteg } from '~src/pages/søknad/types';
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 import { formatAdresse } from '~src/utils/format/formatUtils';
 
 import * as sharedStyles from '../../../steg-shared.module.less';
@@ -31,7 +31,7 @@ import * as styles from './søknadsoppsummering.module.less';
 const booleanSvar = (bool: Nullable<boolean>, formatMessage: MessageFormatter<typeof oppsummeringMessages>) =>
     bool ? formatMessage('ja') : bool === false ? formatMessage('nei') : formatMessage('ubesvart');
 
-const Søknadoppsummering = ({ søknad, søknadstema }: { søknad: SøknadState; søknadstema: Søknadstema }) => {
+const Søknadoppsummering = ({ søknad, søknadstema }: { søknad: SøknadState; søknadstema: Sakstype }) => {
     const { intl, formatMessage } = useI18n({
         messages: {
             ...stegMessages,
@@ -48,10 +48,8 @@ const Søknadoppsummering = ({ søknad, søknadstema }: { søknad: SøknadState;
     return (
         <RawIntlProvider value={intl}>
             <Accordion>
-                {søknadstema === Søknadstema.Uføre && (
-                    <UføreOppsummering søknad={søknad} formatMessage={formatMessage} />
-                )}
-                {søknadstema === Søknadstema.Alder && (
+                {søknadstema === Sakstype.Uføre && <UføreOppsummering søknad={søknad} formatMessage={formatMessage} />}
+                {søknadstema === Sakstype.Alder && (
                     <AlderspensjonOppsummering søknad={søknad} formatMessage={formatMessage} />
                 )}
 

--- a/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
@@ -31,7 +31,7 @@ import * as styles from './søknadsoppsummering.module.less';
 const booleanSvar = (bool: Nullable<boolean>, formatMessage: MessageFormatter<typeof oppsummeringMessages>) =>
     bool ? formatMessage('ja') : bool === false ? formatMessage('nei') : formatMessage('ubesvart');
 
-const Søknadoppsummering = ({ søknad, søknadstema }: { søknad: SøknadState; søknadstema: Sakstype }) => {
+const Søknadoppsummering = ({ søknad, sakstype }: { søknad: SøknadState; sakstype: Sakstype }) => {
     const { intl, formatMessage } = useI18n({
         messages: {
             ...stegMessages,
@@ -48,8 +48,8 @@ const Søknadoppsummering = ({ søknad, søknadstema }: { søknad: SøknadState;
     return (
         <RawIntlProvider value={intl}>
             <Accordion>
-                {søknadstema === Sakstype.Uføre && <UføreOppsummering søknad={søknad} formatMessage={formatMessage} />}
-                {søknadstema === Sakstype.Alder && (
+                {sakstype === Sakstype.Uføre && <UføreOppsummering søknad={søknad} formatMessage={formatMessage} />}
+                {sakstype === Sakstype.Alder && (
                     <AlderspensjonOppsummering søknad={søknad} formatMessage={formatMessage} />
                 )}
 

--- a/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
+++ b/src/pages/søknad/steg/oppsummering/Søknadoppsummering/Søknadoppsummering.tsx
@@ -15,7 +15,7 @@ import oppholdstillatelseMessages from '~src/pages/søknad/steg/oppholdstillatel
 import uførevedtakMessages from '~src/pages/søknad/steg/uførevedtak/uførevedtak-nb';
 import utenlandsoppholdMessages from '~src/pages/søknad/steg/utenlandsopphold/utenlandsopphold-nb';
 import { Alderssteg, Fellessteg, Uføresteg } from '~src/pages/søknad/types';
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 import { formatAdresse } from '~src/utils/format/formatUtils';
 
 import * as sharedStyles from '../../../steg-shared.module.less';

--- a/src/pages/søknad/steg/oppsummering/components/EndreSvar.tsx
+++ b/src/pages/søknad/steg/oppsummering/components/EndreSvar.tsx
@@ -11,12 +11,12 @@ import messages from '../Søknadoppsummering/søknadsoppsummering-nb';
 import * as styles from '../Søknadoppsummering/søknadsoppsummering.module.less';
 
 export const EndreSvar = (props: { path: Søknadssteg }) => {
-    const { sakstype: soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype } = useOutletContext<SøknadContext>();
     const { intl } = useI18n({ messages });
     return (
         <Link
             className={styles.endreSvarContainer}
-            to={routes.soknadsutfylling.createURL({ step: props.path, soknadstema })}
+            to={routes.soknadsutfylling.createURL({ step: props.path, soknadstema: routes.urlForSakstype(sakstype) })}
         >
             <span className={styles.marginRight}>
                 <Edit />

--- a/src/pages/søknad/steg/oppsummering/components/EndreSvar.tsx
+++ b/src/pages/søknad/steg/oppsummering/components/EndreSvar.tsx
@@ -11,7 +11,7 @@ import messages from '../Søknadoppsummering/søknadsoppsummering-nb';
 import * as styles from '../Søknadoppsummering/søknadsoppsummering.module.less';
 
 export const EndreSvar = (props: { path: Søknadssteg }) => {
-    const { soknadstema } = useOutletContext<SøknadContext>();
+    const { sakstype: soknadstema } = useOutletContext<SøknadContext>();
     const { intl } = useI18n({ messages });
     return (
         <Link

--- a/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
+++ b/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
@@ -26,6 +26,7 @@ const StartUtfylling = () => {
     const { søker: søkerFraStore } = useAppSelector((s) => s.søker);
     const søknad = useAppSelector((s) => s.soknad);
     const { step, soknadstema } = useRouteParams<typeof soknadsutfylling>();
+    const sakstype = routes.sakstypeFraTemaIUrl(soknadstema);
     const { formatMessage } = useI18n({ messages });
     const user = useUserContext();
     const navigate = useNavigate();
@@ -42,18 +43,18 @@ const StartUtfylling = () => {
     }, [step]);
 
     const steg = [
-        { step: Uføresteg.Uførevedtak, onlyIf: soknadstema === Sakstype.Uføre },
+        { step: Uføresteg.Uførevedtak, onlyIf: sakstype === Sakstype.Uføre },
         {
             step: Uføresteg.FlyktningstatusOppholdstillatelse,
-            onlyIf: soknadstema === Sakstype.Uføre,
+            onlyIf: sakstype === Sakstype.Uføre,
         },
         {
             step: Alderssteg.Alderspensjon,
-            onlyIf: soknadstema === Sakstype.Alder,
+            onlyIf: sakstype === Sakstype.Alder,
         },
         {
             step: Alderssteg.Oppholdstillatelse,
-            onlyIf: soknadstema === Sakstype.Alder,
+            onlyIf: sakstype === Sakstype.Alder,
         },
         { step: Fellessteg.BoOgOppholdINorge },
         { step: Fellessteg.DinFormue },
@@ -96,7 +97,9 @@ const StartUtfylling = () => {
             </Alert>
             <LinkAsButton
                 variant="secondary"
-                href={routes.soknadPersonSøk.createURL({ soknadstema: soknadstema ?? Sakstype.Uføre })}
+                href={routes.soknadPersonSøk.createURL({
+                    soknadstema: routes.urlForSakstype(sakstype ?? Sakstype.Uføre),
+                })}
             >
                 {formatMessage('feilmelding.knapp')}
             </LinkAsButton>
@@ -129,7 +132,7 @@ const StartUtfylling = () => {
                                                 navigate(
                                                     routes.soknadsutfylling.createURL({
                                                         step: nyttSteg.step,
-                                                        soknadstema: soknadstema ?? Sakstype.Uføre,
+                                                        soknadstema: routes.urlForSakstype(sakstype ?? Sakstype.Uføre),
                                                     })
                                                 );
                                             }
@@ -153,7 +156,7 @@ const StartUtfylling = () => {
                                         step={step ?? Uføresteg.Uførevedtak}
                                         søknad={søknad}
                                         søker={søker}
-                                        soknadstema={soknadstema ?? Sakstype.Uføre}
+                                        sakstype={sakstype ?? Sakstype.Uføre}
                                         erSaksbehandler={user.roller.includes(Rolle.Saksbehandler)}
                                         hjelpetekst={aktivtSteg?.hjelpetekst}
                                     />

--- a/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
+++ b/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
@@ -20,7 +20,8 @@ import { Steg } from '~src/pages/søknad/steg/Steg';
 import { Alderssteg, Fellessteg, Uføresteg } from '~src/pages/søknad/types';
 import { useAppSelector } from '~src/redux/Store';
 import { Rolle } from '~src/types/LoggedInUser';
-import { Sakstype, Søknadstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
+import { Søknadstype } from '~src/types/Søknad';
 
 const StartUtfylling = () => {
     const { søker: søkerFraStore } = useAppSelector((s) => s.søker);

--- a/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
+++ b/src/pages/søknad/steg/start-utfylling/StartUtfylling.tsx
@@ -20,7 +20,7 @@ import { Steg } from '~src/pages/søknad/steg/Steg';
 import { Alderssteg, Fellessteg, Uføresteg } from '~src/pages/søknad/types';
 import { useAppSelector } from '~src/redux/Store';
 import { Rolle } from '~src/types/LoggedInUser';
-import { Søknadstema, Søknadstype } from '~src/types/Søknad';
+import { Sakstype, Søknadstype } from '~src/types/Søknad';
 
 const StartUtfylling = () => {
     const { søker: søkerFraStore } = useAppSelector((s) => s.søker);
@@ -42,18 +42,18 @@ const StartUtfylling = () => {
     }, [step]);
 
     const steg = [
-        { step: Uføresteg.Uførevedtak, onlyIf: soknadstema === Søknadstema.Uføre },
+        { step: Uføresteg.Uførevedtak, onlyIf: soknadstema === Sakstype.Uføre },
         {
             step: Uføresteg.FlyktningstatusOppholdstillatelse,
-            onlyIf: soknadstema === Søknadstema.Uføre,
+            onlyIf: soknadstema === Sakstype.Uføre,
         },
         {
             step: Alderssteg.Alderspensjon,
-            onlyIf: soknadstema === Søknadstema.Alder,
+            onlyIf: soknadstema === Sakstype.Alder,
         },
         {
             step: Alderssteg.Oppholdstillatelse,
-            onlyIf: soknadstema === Søknadstema.Alder,
+            onlyIf: soknadstema === Sakstype.Alder,
         },
         { step: Fellessteg.BoOgOppholdINorge },
         { step: Fellessteg.DinFormue },
@@ -96,7 +96,7 @@ const StartUtfylling = () => {
             </Alert>
             <LinkAsButton
                 variant="secondary"
-                href={routes.soknadPersonSøk.createURL({ soknadstema: soknadstema ?? Søknadstema.Uføre })}
+                href={routes.soknadPersonSøk.createURL({ soknadstema: soknadstema ?? Sakstype.Uføre })}
             >
                 {formatMessage('feilmelding.knapp')}
             </LinkAsButton>
@@ -129,7 +129,7 @@ const StartUtfylling = () => {
                                                 navigate(
                                                     routes.soknadsutfylling.createURL({
                                                         step: nyttSteg.step,
-                                                        soknadstema: soknadstema ?? Søknadstema.Uføre,
+                                                        soknadstema: soknadstema ?? Sakstype.Uføre,
                                                     })
                                                 );
                                             }
@@ -153,7 +153,7 @@ const StartUtfylling = () => {
                                         step={step ?? Uføresteg.Uførevedtak}
                                         søknad={søknad}
                                         søker={søker}
-                                        soknadstema={soknadstema ?? Søknadstema.Uføre}
+                                        soknadstema={soknadstema ?? Sakstype.Uføre}
                                         erSaksbehandler={user.roller.includes(Rolle.Saksbehandler)}
                                         hjelpetekst={aktivtSteg?.hjelpetekst}
                                     />

--- a/src/pages/søknad/utils.ts
+++ b/src/pages/søknad/utils.ts
@@ -1,4 +1,4 @@
-import { Sakstype } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Sak';
 
 export function getSøknadstematekst<AlderTekst extends string, UføreTekst extends string>(
     sakstype: Sakstype,

--- a/src/pages/søknad/utils.ts
+++ b/src/pages/søknad/utils.ts
@@ -1,13 +1,13 @@
-import { Søknadstema } from '~src/types/Søknad';
+import { Sakstype } from '~src/types/Søknad';
 
 export function getSøknadstematekst<AlderTekst extends string, UføreTekst extends string>(
-    søknadstema: Søknadstema,
-    text: { [Søknadstema.Uføre]: UføreTekst; [Søknadstema.Alder]: AlderTekst }
+    søknadstema: Sakstype,
+    text: { [Sakstype.Uføre]: UføreTekst; [Sakstype.Alder]: AlderTekst }
 ): AlderTekst | UføreTekst {
     switch (søknadstema) {
-        case Søknadstema.Alder:
-            return text[Søknadstema.Alder];
-        case Søknadstema.Uføre:
-            return text[Søknadstema.Uføre];
+        case Sakstype.Alder:
+            return text[Sakstype.Alder];
+        case Sakstype.Uføre:
+            return text[Sakstype.Uføre];
     }
 }

--- a/src/pages/søknad/utils.ts
+++ b/src/pages/søknad/utils.ts
@@ -1,10 +1,10 @@
 import { Sakstype } from '~src/types/Søknad';
 
 export function getSøknadstematekst<AlderTekst extends string, UføreTekst extends string>(
-    søknadstema: Sakstype,
+    sakstype: Sakstype,
     text: { [Sakstype.Uføre]: UføreTekst; [Sakstype.Alder]: AlderTekst }
 ): AlderTekst | UføreTekst {
-    switch (søknadstema) {
+    switch (sakstype) {
         case Sakstype.Alder:
             return text[Sakstype.Alder];
         case Sakstype.Uføre:

--- a/src/types/Sak.ts
+++ b/src/types/Sak.ts
@@ -23,13 +23,23 @@ export interface Sak {
     reguleringer: Regulering[];
 }
 
+export enum Sakstype {
+    UFØRE = 'uføre',
+    ALDER = 'alder',
+}
+
 export enum KanStansesEllerGjenopptas {
     STANS = 'STANS',
     GJENOPPTA = 'GJENOPPTA',
     INGEN = 'INGEN',
 }
 
-export interface BegrensetSakinfo {
+export interface AlleredeÅpenSak {
+    uføre: ÅpenSakinfo;
+    alder: ÅpenSakinfo;
+}
+
+export interface ÅpenSakinfo {
     harÅpenSøknad: boolean;
     iverksattInnvilgetStønadsperiode: Nullable<Periode<string>>;
 }

--- a/src/types/Sak.ts
+++ b/src/types/Sak.ts
@@ -23,23 +23,18 @@ export interface Sak {
     reguleringer: Regulering[];
 }
 
-export enum Sakstype {
-    UFØRE = 'uføre',
-    ALDER = 'alder',
-}
-
 export enum KanStansesEllerGjenopptas {
     STANS = 'STANS',
     GJENOPPTA = 'GJENOPPTA',
     INGEN = 'INGEN',
 }
 
-export interface AlleredeÅpenSak {
-    uføre: ÅpenSakinfo;
-    alder: ÅpenSakinfo;
+export interface AlleredeGjeldendeSakForBruker {
+    uføre: BegrensetSakInfo;
+    alder: BegrensetSakInfo;
 }
 
-export interface ÅpenSakinfo {
+export interface BegrensetSakInfo {
     harÅpenSøknad: boolean;
     iverksattInnvilgetStønadsperiode: Nullable<Periode<string>>;
 }

--- a/src/types/Sak.ts
+++ b/src/types/Sak.ts
@@ -38,3 +38,8 @@ export interface BegrensetSakInfo {
     harÅpenSøknad: boolean;
     iverksattInnvilgetStønadsperiode: Nullable<Periode<string>>;
 }
+
+export enum Sakstype {
+    Alder = 'alder',
+    Uføre = 'uføre',
+}

--- a/src/types/Søknad.ts
+++ b/src/types/Søknad.ts
@@ -104,9 +104,9 @@ export enum Søknadstype {
     Papirsøknad = 'Papirsøknad',
 }
 
-export enum Søknadstema {
+export enum Sakstype {
     Alder = 'alder',
-    Uføre = 'ufore',
+    Uføre = 'uføre',
 }
 
 interface Formue {

--- a/src/types/Søknad.ts
+++ b/src/types/Søknad.ts
@@ -104,11 +104,6 @@ export enum Søknadstype {
     Papirsøknad = 'Papirsøknad',
 }
 
-export enum Sakstype {
-    Alder = 'alder',
-    Uføre = 'uføre',
-}
-
 interface Formue {
     borIBolig: Nullable<boolean>;
     verdiPåBolig: Nullable<number>;

--- a/src/utils/person/personUtils.ts
+++ b/src/utils/person/personUtils.ts
@@ -1,12 +1,12 @@
 import { Navn } from '~src/api/personApi';
 
-export function showName(navn: Navn) {
+export function showName(navn: Navn): string {
     const mellomnavn = navn.mellomnavn ? ` ${navn.mellomnavn} ` : ' ';
     return `${navn.fornavn}${mellomnavn}${navn.etternavn}`;
 }
 
-export function formatFnr(fnr: string) {
-    return `${fnr.substr(0, 6)} ${fnr.substr(6, 11)}`;
+export function formatFnr(fnr: string): string {
+    return `${fnr.substring(0, 6)} ${fnr.substring(6, 11)}`;
 }
 
-export const er67EllerEldre = (alder: number | null) => (alder ?? 67) >= 67;
+export const er67EllerEldre = (alder: number | null): boolean => (alder ?? 67) >= 67;


### PR DESCRIPTION
Siden man kan ha forskjellige kombinasjoner av søkere stil su og eksisterende
søknader om alder / uføre su så trenger man et mer detaljert nivå av meldinger.
Foreløpig er endringene i tekster ikke finalized.

Krever en endring i su-se-bakover på endepunktet for informasjon om eksisterende
søknader.