### PR TITLE
Skrive om søknadsbehandlingssteg til å bruke en generisk søknadsbehandlingswrapper

### DIFF
--- a/src/pages/saksbehandling/steg/uføre/UførhetForm.tsx
+++ b/src/pages/saksbehandling/steg/uføre/UførhetForm.tsx
@@ -1,25 +1,17 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
-import { RemoteData as RemoteDataType } from '@devexperts/remote-data-ts';
 import { Button } from '@navikt/ds-react';
 import * as React from 'react';
 import { useEffect } from 'react';
 import { useFieldArray, UseFormReturn } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 import { v4 as uuid } from 'uuid';
 
-import { ApiError } from '~src/api/apiClient';
 import { Uføregrunnlag } from '~src/api/revurderingApi';
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
-import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
-import { focusAfterTimeout } from '~src/lib/formUtils';
+import { ApiResult } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import { Nullable } from '~src/lib/types';
-import { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
-import { RevurderingBunnknapper } from '~src/pages/saksbehandling/revurdering/bunnknapper/RevurderingBunnknapper';
-import UtfallSomIkkeStøttes from '~src/pages/saksbehandling/revurdering/utfallSomIkkeStøttes/UtfallSomIkkeStøttes';
 import { FormData, UføreperiodeFormData } from '~src/pages/saksbehandling/steg/uføre/types';
 import { UføreperiodeForm } from '~src/pages/saksbehandling/steg/uføre/UføreperiodeForm';
 import * as styles from '~src/pages/saksbehandling/steg/uføre/uførhet.module.less';
+import { SøknadsbehandlingWrapper } from '~src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper';
 import { Behandling } from '~src/types/Behandling';
 
 import messages from './uførhet-nb';
@@ -32,13 +24,12 @@ interface Props {
     nesteUrl: string;
     avsluttUrl: string;
     onFormSubmit: (values: FormData, onSuccess: () => void) => void;
-    savingState: RemoteDataType<ApiError | undefined, Uføregrunnlag | Behandling>;
+    savingState: ApiResult<Uføregrunnlag | Behandling>;
     erSaksbehandling: boolean;
 }
 
 export const UførhetForm = ({ form, onFormSubmit, savingState, ...props }: Props) => {
     const { formatMessage } = useI18n({ messages });
-    const navigate = useNavigate();
 
     const lagTomUføreperiode = (): UføreperiodeFormData => ({
         id: uuid(),
@@ -51,14 +42,10 @@ export const UførhetForm = ({ form, onFormSubmit, savingState, ...props }: Prop
         uføregrad: '',
     });
 
-    const feiloppsummeringRef = React.useRef<HTMLDivElement>(null);
-
     const grunnlagValues = useFieldArray({
         control: form.control,
         name: 'grunnlag',
     });
-
-    const valideringsFeil = hookFormErrorsTilFeiloppsummering(form.formState.errors);
 
     useEffect(() => {
         if (grunnlagValues.fields.length === 0) {
@@ -73,64 +60,49 @@ export const UførhetForm = ({ form, onFormSubmit, savingState, ...props }: Prop
     }, [grunnlagValues.fields]);
 
     return (
-        <form
-            onSubmit={form.handleSubmit(
-                (values) => onFormSubmit(values, () => navigate(props.nesteUrl)),
-                focusAfterTimeout(feiloppsummeringRef)
-            )}
+        <SøknadsbehandlingWrapper
+            form={form}
+            save={onFormSubmit}
+            savingState={savingState}
+            avsluttUrl={props.avsluttUrl}
+            forrigeUrl={props.forrige.url}
+            visModal={props.forrige.visModal}
+            nesteUrl={props.nesteUrl}
         >
-            <ul className={styles.periodeliste}>
-                {grunnlagValues.fields.map((item, idx) => (
-                    <li key={item.id}>
-                        <UføreperiodeForm
-                            item={item}
-                            index={idx}
-                            control={form.control}
-                            minDate={props.minDate}
-                            maxDate={props.maxDate}
-                            onRemoveClick={
-                                grunnlagValues.fields.length <= 1 ? undefined : () => grunnlagValues.remove(idx)
-                            }
-                            resetUføregradOgForventetInntekt={() => {
-                                form.setValue(`grunnlag.${idx}.uføregrad`, '');
-                                form.setValue(`grunnlag.${idx}.forventetInntekt`, '');
-                            }}
-                            kanVelgeUføresakTilBehandling={props.erSaksbehandling}
-                            setValue={form.setValue}
-                            errors={form.formState.errors}
-                        />
-                    </li>
-                ))}
-            </ul>
-            <div className={styles.nyperiodeContainer}>
-                <Button
-                    variant="secondary"
-                    type="button"
-                    onClick={() => grunnlagValues.append(lagTomUføreperiode(), { shouldFocus: true })}
-                >
-                    {formatMessage('button.nyPeriode.label')}
-                </Button>
-            </div>
-            <Feiloppsummering
-                tittel={formatMessage('feiloppsummering.title')}
-                className={styles.feiloppsummering}
-                feil={valideringsFeil}
-                hidden={valideringsFeil.length === 0}
-                ref={feiloppsummeringRef}
-            />
-            {RemoteData.isFailure(savingState) && <ApiErrorAlert error={savingState.error} />}
-            {RemoteData.isSuccess(savingState) && harFeilmeldinger(savingState.value) && (
-                <UtfallSomIkkeStøttes feilmeldinger={savingState.value.feilmeldinger} />
-            )}
-            <RevurderingBunnknapper
-                tilbake={props.forrige}
-                onLagreOgFortsettSenereClick={form.handleSubmit((values: FormData) =>
-                    onFormSubmit(values, () => navigate(props.avsluttUrl))
-                )}
-                loading={RemoteData.isPending(savingState)}
-            />
-        </form>
+            <>
+                <ul className={styles.periodeliste}>
+                    {grunnlagValues.fields.map((item, idx) => (
+                        <li key={item.id}>
+                            <UføreperiodeForm
+                                item={item}
+                                index={idx}
+                                control={form.control}
+                                minDate={props.minDate}
+                                maxDate={props.maxDate}
+                                onRemoveClick={
+                                    grunnlagValues.fields.length <= 1 ? undefined : () => grunnlagValues.remove(idx)
+                                }
+                                resetUføregradOgForventetInntekt={() => {
+                                    form.setValue(`grunnlag.${idx}.uføregrad`, '');
+                                    form.setValue(`grunnlag.${idx}.forventetInntekt`, '');
+                                }}
+                                kanVelgeUføresakTilBehandling={props.erSaksbehandling}
+                                setValue={form.setValue}
+                                errors={form.formState.errors}
+                            />
+                        </li>
+                    ))}
+                </ul>
+                <div className={styles.nyperiodeContainer}>
+                    <Button
+                        variant="secondary"
+                        type="button"
+                        onClick={() => grunnlagValues.append(lagTomUføreperiode(), { shouldFocus: true })}
+                    >
+                        {formatMessage('button.nyPeriode.label')}
+                    </Button>
+                </div>
+            </>
+        </SøknadsbehandlingWrapper>
     );
 };
-
-const harFeilmeldinger = (x: Uføregrunnlag | Behandling): x is Uføregrunnlag => 'feilmeldinger' in x;

--- a/src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { ReactElement } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import * as RemoteData from '~node_modules/@devexperts/remote-data-ts';
+import { FieldValues } from '~node_modules/react-hook-form/dist/types/fields';
+import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
+import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
+import { ApiResult } from '~src/lib/hooks';
+import { useI18n } from '~src/lib/i18n';
+import { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
+import { RevurderingBunnknapper } from '~src/pages/saksbehandling/revurdering/bunnknapper/RevurderingBunnknapper';
+import * as styles from '~src/pages/saksbehandling/steg/uføre/uførhet.module.less';
+import stegSharedI18n from '~src/pages/søknad/steg/steg-shared-i18n';
+import { Behandling } from '~src/types/Behandling';
+
+interface Props<T, U> {
+    form: UseFormReturn<T>;
+    save: (values: T, onSuccess: (res?: U) => void) => void;
+    savingState: ApiResult<unknown>;
+    onSuccess?: (res: U) => void;
+    avsluttUrl: string;
+    forrigeUrl: string;
+    nesteUrl: string;
+    visModal?: boolean;
+    children: ReactElement;
+}
+
+export const SøknadsbehandlingWrapper = <T extends FieldValues, U extends Behandling>({
+    form,
+    ...props
+}: Props<T, U>) => {
+    const { formatMessage } = useI18n({ messages: stegSharedI18n });
+    const feiloppsummeringRef = React.useRef<HTMLDivElement>(null);
+    const navigate = useNavigate();
+
+    return (
+        <form
+            onSubmit={form.handleSubmit<T>((values) =>
+                props.save(values, (res) => {
+                    props.onSuccess && res ? props.onSuccess(res) : navigate(props.nesteUrl);
+                })
+            )}
+        >
+            {props.children}
+            <Feiloppsummering
+                tittel={formatMessage('feiloppsummering.title')}
+                className={styles.feiloppsummering}
+                feil={hookFormErrorsTilFeiloppsummering(form.formState.errors)}
+                hidden={hookFormErrorsTilFeiloppsummering(form.formState.errors).length === 0}
+                ref={feiloppsummeringRef}
+            />
+            {RemoteData.isFailure(props.savingState) && <ApiErrorAlert error={props.savingState.error} />}
+            <RevurderingBunnknapper
+                tilbake={{ url: props.forrigeUrl, visModal: props.visModal ?? false }}
+                onLagreOgFortsettSenereClick={form.handleSubmit<T>((values) =>
+                    props.save(values, () => navigate(props.avsluttUrl))
+                )}
+                loading={RemoteData.isPending(props.savingState)}
+            />
+        </form>
+    );
+};

--- a/src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper.tsx
@@ -25,6 +25,7 @@ interface Props<T, U> {
     nesteUrl: string;
     visModal?: boolean;
     children: ReactElement;
+    nesteKnappTekst?: string;
 }
 
 export const SøknadsbehandlingWrapper = <T extends FieldValues, U extends Behandling>({
@@ -58,6 +59,7 @@ export const SøknadsbehandlingWrapper = <T extends FieldValues, U extends Behan
                     props.save(values, () => navigate(props.avsluttUrl))
                 )}
                 loading={RemoteData.isPending(props.savingState)}
+                nesteKnappTekst={props.nesteKnappTekst}
             />
         </form>
     );

--- a/src/pages/saksbehandling/søknadsbehandling/fast-opphold-i-norge/FastOppholdINorge.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/fast-opphold-i-norge/FastOppholdINorge.tsx
@@ -54,6 +54,11 @@ const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
     );
 
     const handleSave = async (values: FormData, onSuccess: () => void) => {
+        if (eqFormData.equals(values, initialValues)) {
+            clearDraft();
+            onSuccess();
+            return;
+        }
         await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,

--- a/src/pages/saksbehandling/søknadsbehandling/fast-opphold-i-norge/FastOppholdINorge.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/fast-opphold-i-norge/FastOppholdINorge.tsx
@@ -1,30 +1,25 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Radio, RadioGroup } from '@navikt/ds-react';
 import { struct } from 'fp-ts/Eq';
 import * as S from 'fp-ts/string';
-import React, { useRef } from 'react';
+import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
-import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
 import { FastOppholdFaktablokk } from '~src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FastOppholdFaktablokk';
 import ToKolonner from '~src/components/toKolonner/ToKolonner';
 import { useSøknadsbehandlingDraftContextFor } from '~src/context/søknadsbehandlingDraftContext';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
-import { focusAfterTimeout } from '~src/lib/formUtils';
 import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { eqNullable, Nullable } from '~src/lib/types';
-import yup, { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
+import yup from '~src/lib/validering';
+import { SøknadsbehandlingWrapper } from '~src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper';
 import { Vilkårstatus } from '~src/types/Behandlingsinformasjon';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 
 import sharedI18n from '../sharedI18n-nb';
 import { VilkårsvurderingBaseProps } from '../types';
-import { Vurderingknapper } from '../vurderingknapper/Vurderingknapper';
 
 import messages from './fastOppholdINorge-nb';
 
@@ -46,8 +41,6 @@ const schema = yup
     .required();
 
 const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
-    const navigate = useNavigate();
-    const feiloppsummeringRef = useRef<HTMLDivElement>(null);
     const { formatMessage } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const [status, lagreBehandlingsinformasjon] = useAsyncActionCreator(sakSlice.lagreBehandlingsinformasjon);
 
@@ -60,36 +53,25 @@ const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
         (values) => eqFormData.equals(values, initialValues)
     );
 
-    const handleSave = (nesteUrl: string) => async (values: FormData) => {
-        if (!values.status) return;
-
-        if (eqFormData.equals(values, initialValues)) {
-            clearDraft();
-            navigate(nesteUrl);
-            return;
-        }
-
+    const handleSave = async (values: FormData, onSuccess: () => void) => {
         await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,
                 behandlingId: props.behandling.id,
                 behandlingsinformasjon: {
                     fastOppholdINorge: {
-                        status: values.status,
+                        status: values.status!,
                     },
                 },
             },
             () => {
                 clearDraft();
-                navigate(nesteUrl);
+                onSuccess();
             }
         );
     };
 
-    const {
-        formState: { isValid, isSubmitted, errors },
-        ...form
-    } = useForm({
+    const form = useForm({
         defaultValues: draft ?? initialValues,
         resolver: yupResolver(schema),
     });
@@ -100,8 +82,13 @@ const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
         <ToKolonner tittel={formatMessage('page.tittel')}>
             {{
                 left: (
-                    <form
-                        onSubmit={form.handleSubmit(handleSave(props.nesteUrl), focusAfterTimeout(feiloppsummeringRef))}
+                    <SøknadsbehandlingWrapper
+                        form={form}
+                        save={handleSave}
+                        savingState={status}
+                        avsluttUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })}
+                        forrigeUrl={props.forrigeUrl}
+                        nesteUrl={props.nesteUrl}
                     >
                         <Controller
                             control={form.control}
@@ -125,25 +112,7 @@ const FastOppholdINorge = (props: VilkårsvurderingBaseProps) => {
                                 </RadioGroup>
                             )}
                         />
-
-                        {RemoteData.isFailure(status) && <ApiErrorAlert error={status.error} />}
-                        <Feiloppsummering
-                            tittel={formatMessage('feiloppsummering.title')}
-                            hidden={!isSubmitted || isValid}
-                            feil={hookFormErrorsTilFeiloppsummering(errors)}
-                            ref={feiloppsummeringRef}
-                        />
-                        <Vurderingknapper
-                            onTilbakeClick={() => {
-                                navigate(props.forrigeUrl);
-                            }}
-                            onLagreOgFortsettSenereClick={form.handleSubmit(
-                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                focusAfterTimeout(feiloppsummeringRef)
-                            )}
-                            loading={RemoteData.isPending(status)}
-                        />
-                    </form>
+                    </SøknadsbehandlingWrapper>
                 ),
                 right: <FastOppholdFaktablokk søknadInnhold={props.behandling.søknad.søknadInnhold} />,
             }}

--- a/src/pages/saksbehandling/søknadsbehandling/flyktning/Flyktning.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/flyktning/Flyktning.tsx
@@ -1,32 +1,27 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Alert, Radio, RadioGroup } from '@navikt/ds-react';
-import React, { useMemo, useRef } from 'react';
+import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
-import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
 import { FlyktningFaktablokk } from '~src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/FlyktningFaktablokk';
 import ToKolonner from '~src/components/toKolonner/ToKolonner';
 import { useSøknadsbehandlingDraftContextFor } from '~src/context/søknadsbehandlingDraftContext';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
-import { focusAfterTimeout } from '~src/lib/formUtils';
 import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { Nullable } from '~src/lib/types';
-import yup, { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
+import yup from '~src/lib/validering';
+import { SøknadsbehandlingWrapper } from '~src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper';
 import { Behandling, Behandlingsstatus } from '~src/types/Behandling';
 import { Vilkårstatus } from '~src/types/Behandlingsinformasjon';
 import { UføreResultat } from '~src/types/grunnlagsdataOgVilkårsvurderinger/uføre/Uførevilkår';
 import { SøknadInnholdUføre } from '~src/types/Søknad';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
-import { erUnderkjent, erVilkårsvurderingerVurdertAvslag } from '~src/utils/behandling/behandlingUtils';
 
 import sharedI18n from '../sharedI18n-nb';
 import { VilkårsvurderingBaseProps } from '../types';
-import { Vurderingknapper } from '../vurderingknapper/Vurderingknapper';
 
 import messages from './flyktning-nb';
 import * as styles from './flyktning.module.less';
@@ -49,7 +44,6 @@ const schema = yup
 
 const Flyktning = (props: VilkårsvurderingBaseProps & { søknadInnhold: SøknadInnholdUføre }) => {
     const navigate = useNavigate();
-    const feiloppsummeringRef = useRef<HTMLDivElement>(null);
     const { formatMessage } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const [status, lagreBehandlingsinformasjon] = useAsyncActionCreator(sakSlice.lagreBehandlingsinformasjon);
 
@@ -69,13 +63,7 @@ const Flyktning = (props: VilkårsvurderingBaseProps & { søknadInnhold: Søknad
         sakId: props.sakId,
     });
 
-    const save = (values: FormData, ingenEndringPath: string, onSuccess: (behandling: Behandling) => void) => {
-        if (values.status === initialValues.status) {
-            clearDraft();
-            navigate(ingenEndringPath);
-            return;
-        }
-
+    const save = (values: FormData, onSuccess: (behandling: Behandling) => void) => {
         lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,
@@ -93,100 +81,81 @@ const Flyktning = (props: VilkårsvurderingBaseProps & { søknadInnhold: Søknad
         );
     };
 
-    const handleSubmit = (values: FormData) =>
-        save(
-            values,
-            erVilkårsvurderingerVurdertAvslag(props.behandling) || erUnderkjent(props.behandling)
-                ? vedtakUrl
-                : props.nesteUrl,
-            (behandling) =>
-                navigate(behandling.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG ? vedtakUrl : props.nesteUrl)
-        );
-
-    const {
-        formState: { errors, isSubmitted, isValid },
-        ...form
-    } = useForm({
+    const form = useForm({
         defaultValues: draft ?? initialValues,
         resolver: yupResolver(schema),
     });
 
     useDraftFormSubscribe(form.watch);
 
-    const watchStatus = form.watch('status');
-
-    const vilGiTidligAvslag = useMemo(
-        () =>
-            props.behandling.grunnlagsdataOgVilkårsvurderinger.uføre?.resultat === UføreResultat.VilkårIkkeOppfylt ||
-            watchStatus === Vilkårstatus.VilkårIkkeOppfylt,
-        [watchStatus, props.behandling.grunnlagsdataOgVilkårsvurderinger.uføre]
-    );
+    const vilGiTidligAvslag =
+        props.behandling.grunnlagsdataOgVilkårsvurderinger.uføre?.resultat === UføreResultat.VilkårIkkeOppfylt ||
+        form.watch('status') === Vilkårstatus.VilkårIkkeOppfylt;
 
     return (
         <ToKolonner tittel={formatMessage('page.tittel')}>
             {{
                 left: (
-                    <form onSubmit={form.handleSubmit(handleSubmit, focusAfterTimeout(feiloppsummeringRef))}>
-                        <Controller
-                            control={form.control}
-                            name="status"
-                            render={({ field, fieldState }) => (
-                                <RadioGroup
-                                    legend={formatMessage('radio.flyktning.legend')}
-                                    error={fieldState.error?.message}
-                                    onBlur={field.onBlur}
-                                    onChange={field.onChange}
-                                    value={field.value ?? ''}
-                                >
-                                    <Radio
-                                        id={field.name}
-                                        name={field.name}
-                                        value={Vilkårstatus.VilkårOppfylt}
-                                        ref={field.ref}
+                    <SøknadsbehandlingWrapper
+                        form={form}
+                        save={(values, onSuccess) => save(values, onSuccess)}
+                        savingState={status}
+                        avsluttUrl={saksoversiktUrl}
+                        onSuccess={(behandling) =>
+                            navigate(
+                                behandling.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG
+                                    ? vedtakUrl
+                                    : props.nesteUrl
+                            )
+                        }
+                        forrigeUrl={props.forrigeUrl}
+                        nesteUrl={props.nesteUrl}
+                    >
+                        <>
+                            <Controller
+                                control={form.control}
+                                name="status"
+                                render={({ field, fieldState }) => (
+                                    <RadioGroup
+                                        legend={formatMessage('radio.flyktning.legend')}
+                                        error={fieldState.error?.message}
+                                        onBlur={field.onBlur}
+                                        onChange={field.onChange}
+                                        value={field.value ?? ''}
                                     >
-                                        {formatMessage('radio.label.ja')}
-                                    </Radio>
-                                    <Radio
-                                        name={field.name}
-                                        onChange={() => field.onChange(Vilkårstatus.VilkårIkkeOppfylt)}
-                                        value={Vilkårstatus.VilkårIkkeOppfylt}
-                                    >
-                                        {formatMessage('radio.label.nei')}
-                                    </Radio>
-                                    <Radio
-                                        name={field.name}
-                                        onChange={() => field.onChange(Vilkårstatus.Uavklart)}
-                                        value={Vilkårstatus.Uavklart}
-                                    >
-                                        {formatMessage('radio.label.uavklart')}
-                                    </Radio>
-                                </RadioGroup>
-                            )}
-                        />
+                                        <Radio
+                                            id={field.name}
+                                            name={field.name}
+                                            value={Vilkårstatus.VilkårOppfylt}
+                                            ref={field.ref}
+                                        >
+                                            {formatMessage('radio.label.ja')}
+                                        </Radio>
+                                        <Radio
+                                            name={field.name}
+                                            onChange={() => field.onChange(Vilkårstatus.VilkårIkkeOppfylt)}
+                                            value={Vilkårstatus.VilkårIkkeOppfylt}
+                                        >
+                                            {formatMessage('radio.label.nei')}
+                                        </Radio>
+                                        <Radio
+                                            name={field.name}
+                                            onChange={() => field.onChange(Vilkårstatus.Uavklart)}
+                                            value={Vilkårstatus.Uavklart}
+                                        >
+                                            {formatMessage('radio.label.uavklart')}
+                                        </Radio>
+                                    </RadioGroup>
+                                )}
+                            />
 
-                        {RemoteData.isFailure(status) && <ApiErrorAlert error={status.error} />}
-                        {vilGiTidligAvslag && (
-                            <Alert className={styles.avslagAdvarsel} variant="info">
-                                {formatMessage('display.avslag.advarsel')}
-                            </Alert>
-                        )}
-
-                        <Feiloppsummering
-                            tittel={formatMessage('feiloppsummering.title')}
-                            hidden={!isSubmitted || isValid}
-                            feil={hookFormErrorsTilFeiloppsummering(errors)}
-                            ref={feiloppsummeringRef}
-                        />
-                        <Vurderingknapper
-                            onTilbakeClick={() => navigate(props.forrigeUrl)}
-                            onLagreOgFortsettSenereClick={form.handleSubmit(
-                                (values) => save(values, saksoversiktUrl, () => navigate(saksoversiktUrl)),
-                                focusAfterTimeout(feiloppsummeringRef)
+                            {vilGiTidligAvslag && (
+                                <Alert className={styles.avslagAdvarsel} variant="info">
+                                    {formatMessage('display.avslag.advarsel')}
+                                </Alert>
                             )}
-                            nesteKnappTekst={vilGiTidligAvslag ? formatMessage('knapp.tilVedtaket') : undefined}
-                            loading={RemoteData.isPending(status)}
-                        />
-                    </form>
+                        </>
+                    </SøknadsbehandlingWrapper>
                 ),
                 right: <FlyktningFaktablokk søknadInnhold={props.søknadInnhold} />,
             }}

--- a/src/pages/saksbehandling/søknadsbehandling/institusjonsopphold/Institusjonsopphold.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/institusjonsopphold/Institusjonsopphold.tsx
@@ -60,6 +60,12 @@ const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
     useDraftFormSubscribe(form.watch);
 
     const handleSave = async (values: InstitusjonsoppholdFormData, onSuccess: () => void) => {
+        if (eqFormData.equals(values, initialValues)) {
+            clearDraft();
+            onSuccess();
+            return;
+        }
+
         await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,

--- a/src/pages/saksbehandling/søknadsbehandling/institusjonsopphold/Institusjonsopphold.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/institusjonsopphold/Institusjonsopphold.tsx
@@ -1,30 +1,25 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Radio, RadioGroup } from '@navikt/ds-react';
 import { struct } from 'fp-ts/Eq';
 import * as S from 'fp-ts/string';
-import React, { useRef } from 'react';
+import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
-import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
 import { InstitusjonsoppholdBlokk } from '~src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/InstitusjonsoppholdBlokk';
 import ToKolonner from '~src/components/toKolonner/ToKolonner';
 import { useSøknadsbehandlingDraftContextFor } from '~src/context/søknadsbehandlingDraftContext';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
-import { focusAfterTimeout } from '~src/lib/formUtils';
 import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { eqNullable, Nullable } from '~src/lib/types';
-import yup, { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
+import yup from '~src/lib/validering';
+import { SøknadsbehandlingWrapper } from '~src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper';
 import { Vilkårstatus } from '~src/types/Behandlingsinformasjon';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 
 import sharedI18n from '../sharedI18n-nb';
 import { VilkårsvurderingBaseProps } from '../types';
-import { Vurderingknapper } from '../vurderingknapper/Vurderingknapper';
 
 import messages from './institusjonsopphold-nb';
 
@@ -46,8 +41,6 @@ const schema = yup
     .required();
 
 const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
-    const navigate = useNavigate();
-    const feiloppsummeringRef = useRef<HTMLDivElement>(null);
     const { formatMessage } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const [status, lagreBehandlingsinformasjon] = useAsyncActionCreator(sakSlice.lagreBehandlingsinformasjon);
     const initialValues = {
@@ -59,38 +52,27 @@ const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
             eqFormData.equals(values, initialValues)
         );
 
-    const {
-        formState: { isValid, isSubmitted, errors },
-        ...form
-    } = useForm({
+    const form = useForm({
         defaultValues: draft ?? initialValues,
         resolver: yupResolver(schema),
     });
 
     useDraftFormSubscribe(form.watch);
 
-    const handleSave = (nesteUrl: string) => async (values: InstitusjonsoppholdFormData) => {
-        if (!values.status) return;
-
-        if (eqFormData.equals(values, initialValues)) {
-            clearDraft();
-            navigate(nesteUrl);
-            return;
-        }
-
+    const handleSave = async (values: InstitusjonsoppholdFormData, onSuccess: () => void) => {
         await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,
                 behandlingId: props.behandling.id,
                 behandlingsinformasjon: {
                     institusjonsopphold: {
-                        status: values.status,
+                        status: values.status!,
                     },
                 },
             },
             () => {
                 clearDraft();
-                navigate(nesteUrl);
+                onSuccess();
             }
         );
     };
@@ -99,8 +81,13 @@ const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
         <ToKolonner tittel={formatMessage('page.tittel')}>
             {{
                 left: (
-                    <form
-                        onSubmit={form.handleSubmit(handleSave(props.nesteUrl), focusAfterTimeout(feiloppsummeringRef))}
+                    <SøknadsbehandlingWrapper
+                        form={form}
+                        save={handleSave}
+                        savingState={status}
+                        avsluttUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })}
+                        forrigeUrl={props.forrigeUrl}
+                        nesteUrl={props.nesteUrl}
                     >
                         <Controller
                             control={form.control}
@@ -122,25 +109,7 @@ const Institusjonsopphold = (props: VilkårsvurderingBaseProps) => {
                                 </RadioGroup>
                             )}
                         />
-
-                        {RemoteData.isFailure(status) && <ApiErrorAlert error={status.error} />}
-                        <Feiloppsummering
-                            tittel={formatMessage('feiloppsummering.title')}
-                            hidden={!isSubmitted || isValid}
-                            feil={hookFormErrorsTilFeiloppsummering(errors)}
-                            ref={feiloppsummeringRef}
-                        />
-                        <Vurderingknapper
-                            onTilbakeClick={() => {
-                                navigate(props.forrigeUrl);
-                            }}
-                            onLagreOgFortsettSenereClick={form.handleSubmit(
-                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                focusAfterTimeout(feiloppsummeringRef)
-                            )}
-                            loading={RemoteData.isPending(status)}
-                        />
-                    </form>
+                    </SøknadsbehandlingWrapper>
                 ),
                 right: <InstitusjonsoppholdBlokk søknadInnhold={props.behandling.søknad.søknadInnhold} />,
             }}

--- a/src/pages/saksbehandling/søknadsbehandling/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
@@ -53,6 +53,12 @@ const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
     );
 
     const handleSave = async (values: FormData, onSuccess: () => void) => {
+        if (eqFormData.equals(values, initialValues)) {
+            clearDraft();
+            onSuccess();
+            return;
+        }
+
         await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,

--- a/src/pages/saksbehandling/søknadsbehandling/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/lovlig-opphold-i-norge/LovligOppholdINorge.tsx
@@ -1,30 +1,25 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { RadioGroup, Radio } from '@navikt/ds-react';
+import { Radio, RadioGroup } from '@navikt/ds-react';
 import { struct } from 'fp-ts/Eq';
 import * as S from 'fp-ts/string';
-import React, { useRef } from 'react';
+import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
-import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
 import { LovligOppholdFaktablokk } from '~src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/LovligOppholdFaktablokk';
 import ToKolonner from '~src/components/toKolonner/ToKolonner';
 import { useSøknadsbehandlingDraftContextFor } from '~src/context/søknadsbehandlingDraftContext';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
-import { focusAfterTimeout } from '~src/lib/formUtils';
 import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { eqNullable, Nullable } from '~src/lib/types';
-import yup, { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
+import yup from '~src/lib/validering';
+import { SøknadsbehandlingWrapper } from '~src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper';
 import { Vilkårstatus } from '~src/types/Behandlingsinformasjon';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 
 import sharedI18n from '../sharedI18n-nb';
 import { VilkårsvurderingBaseProps } from '../types';
-import { Vurderingknapper } from '../vurderingknapper/Vurderingknapper';
 
 import messages from './lovligOppholdINorge-nb';
 
@@ -46,8 +41,6 @@ const schema = yup
     .required();
 
 const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
-    const navigate = useNavigate();
-    const feiloppsummeringRef = useRef<HTMLDivElement>(null);
     const { formatMessage } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const [status, lagreBehandlingsinformasjon] = useAsyncActionCreator(sakSlice.lagreBehandlingsinformasjon);
     const initialValues = {
@@ -59,36 +52,25 @@ const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
         (values) => eqFormData.equals(values, initialValues)
     );
 
-    const handleSave = (nesteUrl: string) => async (values: FormData) => {
-        if (!values.status) return;
-
-        if (eqFormData.equals(values, initialValues)) {
-            clearDraft();
-            navigate(nesteUrl);
-            return;
-        }
-
+    const handleSave = async (values: FormData, onSuccess: () => void) => {
         await lagreBehandlingsinformasjon(
             {
                 sakId: props.sakId,
                 behandlingId: props.behandling.id,
                 behandlingsinformasjon: {
                     lovligOpphold: {
-                        status: values.status,
+                        status: values.status!,
                     },
                 },
             },
             () => {
                 clearDraft();
-                navigate(nesteUrl);
+                onSuccess();
             }
         );
     };
 
-    const {
-        formState: { isValid, isSubmitted, errors },
-        ...form
-    } = useForm({
+    const form = useForm({
         defaultValues: draft ?? initialValues,
         resolver: yupResolver(schema),
     });
@@ -99,8 +81,13 @@ const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
         <ToKolonner tittel={formatMessage('page.tittel')}>
             {{
                 left: (
-                    <form
-                        onSubmit={form.handleSubmit(handleSave(props.nesteUrl), focusAfterTimeout(feiloppsummeringRef))}
+                    <SøknadsbehandlingWrapper
+                        form={form}
+                        save={handleSave}
+                        savingState={status}
+                        avsluttUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })}
+                        forrigeUrl={props.forrigeUrl}
+                        nesteUrl={props.nesteUrl}
                     >
                         <Controller
                             control={form.control}
@@ -123,25 +110,7 @@ const LovligOppholdINorge = (props: VilkårsvurderingBaseProps) => {
                                 </RadioGroup>
                             )}
                         />
-
-                        {RemoteData.isFailure(status) && <ApiErrorAlert error={status.error} />}
-                        <Feiloppsummering
-                            tittel={formatMessage('feiloppsummering.title')}
-                            hidden={!isSubmitted || isValid}
-                            feil={hookFormErrorsTilFeiloppsummering(errors)}
-                            ref={feiloppsummeringRef}
-                        />
-                        <Vurderingknapper
-                            onTilbakeClick={() => {
-                                navigate(props.forrigeUrl);
-                            }}
-                            onLagreOgFortsettSenereClick={form.handleSubmit(
-                                handleSave(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })),
-                                focusAfterTimeout(feiloppsummeringRef)
-                            )}
-                            loading={RemoteData.isPending(status)}
-                        />
-                    </form>
+                    </SøknadsbehandlingWrapper>
                 ),
                 right: <LovligOppholdFaktablokk søknadInnhold={props.behandling.søknad.søknadInnhold} />,
             }}

--- a/src/pages/saksbehandling/søknadsbehandling/personlig-oppmøte/PersonligOppmøte.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/personlig-oppmøte/PersonligOppmøte.tsx
@@ -1,38 +1,34 @@
-import * as RemoteData from '@devexperts/remote-data-ts';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Alert, Radio, RadioGroup } from '@navikt/ds-react';
 import { Eq, struct } from 'fp-ts/lib/Eq';
 import * as S from 'fp-ts/string';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
-import ApiErrorAlert from '~src/components/apiErrorAlert/ApiErrorAlert';
-import Feiloppsummering from '~src/components/feiloppsummering/Feiloppsummering';
 import { PersonligOppmøteFaktablokk } from '~src/components/oppsummering/vilkårsOppsummering/faktablokk/faktablokker/PersonligOppmøteFaktablokk';
 import ToKolonner from '~src/components/toKolonner/ToKolonner';
 import { useSøknadsbehandlingDraftContextFor } from '~src/context/søknadsbehandlingDraftContext';
 import * as sakSlice from '~src/features/saksoversikt/sak.slice';
-import { focusAfterTimeout } from '~src/lib/formUtils';
 import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
 import * as Routes from '~src/lib/routes';
 import { eqNullable, Nullable } from '~src/lib/types';
-import yup, { hookFormErrorsTilFeiloppsummering } from '~src/lib/validering';
-import { Behandlingsstatus } from '~src/types/Behandling';
+import yup from '~src/lib/validering';
+import { SøknadsbehandlingWrapper } from '~src/pages/saksbehandling/søknadsbehandling/SøknadsbehandlingWrapper';
+import { Behandling, Behandlingsstatus } from '~src/types/Behandling';
 import {
-    PersonligOppmøteStatus,
-    PersonligOppmøte as PersonligOppmøteType,
     Behandlingsinformasjon,
+    PersonligOppmøte as PersonligOppmøteType,
+    PersonligOppmøteStatus,
 } from '~src/types/Behandlingsinformasjon';
 import { GrunnlagsdataOgVilkårsvurderinger } from '~src/types/grunnlagsdataOgVilkårsvurderinger/grunnlagsdataOgVilkårsvurderinger';
 import { Vilkårtype, VilkårVurderingStatus } from '~src/types/Vilkårsvurdering';
 import { erVilkårsvurderingerVurdertAvslag } from '~src/utils/behandling/behandlingUtils';
-import { Vilkårsinformasjon, mapToVilkårsinformasjon } from '~src/utils/søknadsbehandling/vilkår/vilkårUtils';
+import { mapToVilkårsinformasjon, Vilkårsinformasjon } from '~src/utils/søknadsbehandling/vilkår/vilkårUtils';
 
 import sharedI18n from '../sharedI18n-nb';
 import { VilkårsvurderingBaseProps } from '../types';
-import { Vurderingknapper } from '../vurderingknapper/Vurderingknapper';
 
 import messages from './personligOppmøte-nb';
 import * as styles from './personligOppmøte.module.less';
@@ -208,7 +204,6 @@ const erFerdigbehandletMedAvslag = (vilkårsinformasjon: Vilkårsinformasjon[]):
 const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
     const navigate = useNavigate();
     const advarselRef = useRef<HTMLDivElement>(null);
-    const feiloppsummeringRef = useRef<HTMLDivElement>(null);
     const { formatMessage } = useI18n({ messages: { ...sharedI18n, ...messages } });
     const [status, lagreBehandlingsinformasjon] = useAsyncActionCreator(sakSlice.lagreBehandlingsinformasjon);
 
@@ -219,10 +214,7 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
         (values) => eqFormData.equals(values, initialValues)
     );
 
-    const {
-        formState: { isSubmitted, isValid, errors },
-        ...form
-    } = useForm({
+    const form = useForm({
         defaultValues: draft ?? initialValues,
         resolver: yupResolver(schema),
     });
@@ -241,51 +233,7 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
         [watch, props.behandling.behandlingsinformasjon, props.behandling.grunnlagsdataOgVilkårsvurderinger]
     );
 
-    useEffect(() => {
-        if (watch.møttPersonlig !== HarMøttPersonlig.Nei && watch.grunnForManglendePersonligOppmøte !== null) {
-            form.setValue('grunnForManglendePersonligOppmøte', null);
-        }
-        // Av en eller annen grunn blir ikke validering trigget riktig av seg selv, så vi gjør det manuelt
-        if (isSubmitted) {
-            form.trigger('grunnForManglendePersonligOppmøte');
-        }
-    }, [watch.møttPersonlig]);
-
-    const handleLagreOgFortsettSenere = async (values: FormData) => {
-        const personligOppmøteStatus = toPersonligOppmøteStatus(values);
-        if (!personligOppmøteStatus) {
-            return;
-        }
-
-        if (
-            eqPersonligOppmøte.equals(
-                { status: personligOppmøteStatus },
-                props.behandling.behandlingsinformasjon.personligOppmøte
-            )
-        ) {
-            clearDraft();
-            navigate(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId }));
-            return;
-        }
-
-        await lagreBehandlingsinformasjon(
-            {
-                sakId: props.sakId,
-                behandlingId: props.behandling.id,
-                behandlingsinformasjon: {
-                    personligOppmøte: {
-                        status: personligOppmøteStatus,
-                    },
-                },
-            },
-            () => {
-                clearDraft();
-                navigate(Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId }));
-            }
-        );
-    };
-
-    const handleSave = async (values: FormData) => {
+    const handleSave = async (values: FormData, onSuccess: (res: Behandling) => void) => {
         const personligOppmøteStatus = toPersonligOppmøteStatus(values);
         if (!personligOppmøteStatus) {
             return;
@@ -330,152 +278,151 @@ const PersonligOppmøte = (props: VilkårsvurderingBaseProps) => {
             },
             (res) => {
                 clearDraft();
-                if (res.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG) {
-                    navigate(
-                        Routes.saksbehandlingSendTilAttestering.createURL({
-                            sakId: props.sakId,
-                            behandlingId: props.behandling.id,
-                        })
-                    );
-                } else {
-                    navigate(props.nesteUrl);
-                }
+                onSuccess(res);
             }
         );
     };
+
+    const onSuccess = (res: Behandling) =>
+        res.status === Behandlingsstatus.VILKÅRSVURDERT_AVSLAG
+            ? navigate(
+                  Routes.saksbehandlingSendTilAttestering.createURL({
+                      sakId: props.sakId,
+                      behandlingId: props.behandling.id,
+                  })
+              )
+            : navigate(props.nesteUrl);
 
     return (
         <ToKolonner tittel={formatMessage('page.tittel')}>
             {{
                 left: (
-                    <form onSubmit={form.handleSubmit(handleSave, focusAfterTimeout(feiloppsummeringRef))}>
-                        <div className={styles.formElement}>
-                            <Controller
-                                control={form.control}
-                                name="møttPersonlig"
-                                render={({ field, fieldState }) => (
-                                    <RadioGroup
-                                        legend={formatMessage('radio.personligOppmøte.legend')}
-                                        error={fieldState.error?.message}
-                                        onBlur={field.onBlur}
-                                        name={field.name}
-                                        value={field.value ?? ''}
-                                        onChange={field.onChange}
-                                    >
-                                        <Radio id={field.name} value={HarMøttPersonlig.Ja} ref={field.ref}>
-                                            {formatMessage('radio.label.ja')}
-                                        </Radio>
-                                        <Radio value={HarMøttPersonlig.Nei}>{formatMessage('radio.label.nei')}</Radio>
-                                        <Radio value={HarMøttPersonlig.Uavklart}>
-                                            {formatMessage('radio.label.uavklart')}
-                                        </Radio>
-                                    </RadioGroup>
-                                )}
-                            />
-                        </div>
-                        {watch.møttPersonlig === HarMøttPersonlig.Nei && (
+                    <SøknadsbehandlingWrapper
+                        form={form}
+                        save={handleSave}
+                        savingState={status}
+                        avsluttUrl={Routes.saksoversiktValgtSak.createURL({ sakId: props.sakId })}
+                        forrigeUrl={props.forrigeUrl}
+                        nesteUrl={props.nesteUrl}
+                        onSuccess={onSuccess}
+                        nesteKnappTekst={
+                            oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
+                            erFerdigbehandletMedAvslag(oppdatertVilkårsinformasjon)
+                                ? formatMessage('button.tilVedtak.label')
+                                : undefined
+                        }
+                    >
+                        <>
                             <div className={styles.formElement}>
                                 <Controller
                                     control={form.control}
-                                    name="grunnForManglendePersonligOppmøte"
+                                    name="møttPersonlig"
                                     render={({ field, fieldState }) => (
                                         <RadioGroup
-                                            legend={formatMessage('radio.personligOppmøte.grunn.legend')}
+                                            legend={formatMessage('radio.personligOppmøte.legend')}
                                             error={fieldState.error?.message}
                                             onBlur={field.onBlur}
                                             name={field.name}
                                             value={field.value ?? ''}
-                                            onChange={field.onChange}
+                                            onChange={(val) => {
+                                                field.onChange(val);
+                                                val !== HarMøttPersonlig.Nei &&
+                                                    form.setValue('grunnForManglendePersonligOppmøte', null);
+                                            }}
                                         >
-                                            {[
-                                                {
-                                                    label: formatMessage(
-                                                        'radio.personligOppmøte.grunn.sykMedLegeerklæringOgFullmakt'
-                                                    ),
-                                                    radioValue:
-                                                        GrunnForManglendePersonligOppmøte.SykMedLegeerklæringOgFullmakt,
-                                                },
-                                                {
-                                                    label: formatMessage(
-                                                        'radio.personligOppmøte.grunn.oppnevntVergeSøktPerPost'
-                                                    ),
-                                                    radioValue:
-                                                        GrunnForManglendePersonligOppmøte.OppnevntVergeSøktPerPost,
-                                                },
-                                                {
-                                                    label: formatMessage(
-                                                        'radio.personligOppmøte.grunn.kortvarigSykMedLegeerklæring'
-                                                    ),
-                                                    radioValue:
-                                                        GrunnForManglendePersonligOppmøte.KortvarigSykMedLegeerklæring,
-                                                },
-                                                {
-                                                    label: formatMessage(
-                                                        'radio.personligOppmøte.grunn.midlertidigUnntakFraOppmøteplikt'
-                                                    ),
-                                                    radioValue:
-                                                        GrunnForManglendePersonligOppmøte.MidlertidigUnntakFraOppmøteplikt,
-                                                },
-                                                {
-                                                    label: formatMessage(
-                                                        'radio.personligOppmøte.grunn.brukerIkkeMøttOppfyllerIkkeVilkår'
-                                                    ),
-                                                    radioValue:
-                                                        GrunnForManglendePersonligOppmøte.BrukerIkkeMøttOppfyllerIkkeVilkår,
-                                                },
-                                            ].map(({ label, radioValue }, idx) => (
-                                                <Radio
-                                                    id={idx === 0 ? field.name : undefined}
-                                                    ref={idx === 0 ? field.ref : undefined}
-                                                    key={radioValue}
-                                                    value={radioValue}
-                                                >
-                                                    {label}
-                                                </Radio>
-                                            ))}
+                                            <Radio id={field.name} value={HarMøttPersonlig.Ja} ref={field.ref}>
+                                                {formatMessage('radio.label.ja')}
+                                            </Radio>
+                                            <Radio value={HarMøttPersonlig.Nei}>
+                                                {formatMessage('radio.label.nei')}
+                                            </Radio>
+                                            <Radio value={HarMøttPersonlig.Uavklart}>
+                                                {formatMessage('radio.label.uavklart')}
+                                            </Radio>
                                         </RadioGroup>
                                     )}
                                 />
                             </div>
-                        )}
-
-                        {RemoteData.isFailure(status) && <ApiErrorAlert error={status.error} />}
-                        <div
-                            ref={advarselRef}
-                            tabIndex={-1}
-                            aria-live="polite"
-                            aria-atomic="true"
-                            className={styles.alertstripe}
-                        >
-                            {oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
-                                erVurdertUtenAvslagMenIkkeFerdigbehandlet(oppdatertVilkårsinformasjon) && (
-                                    <Alert variant="warning">{formatMessage('alert.ikkeFerdigbehandlet')}</Alert>
-                                )}
-                        </div>
-
-                        <Feiloppsummering
-                            tittel={formatMessage('feiloppsummering.title')}
-                            hidden={!isSubmitted || isValid}
-                            feil={hookFormErrorsTilFeiloppsummering(errors)}
-                            ref={feiloppsummeringRef}
-                        />
-                        <Vurderingknapper
-                            onTilbakeClick={() => {
-                                navigate(props.forrigeUrl);
-                            }}
-                            onLagreOgFortsettSenereClick={form.handleSubmit(
-                                handleLagreOgFortsettSenere,
-                                focusAfterTimeout(feiloppsummeringRef)
+                            {watch.møttPersonlig === HarMøttPersonlig.Nei && (
+                                <div className={styles.formElement}>
+                                    <Controller
+                                        control={form.control}
+                                        name="grunnForManglendePersonligOppmøte"
+                                        render={({ field, fieldState }) => (
+                                            <RadioGroup
+                                                legend={formatMessage('radio.personligOppmøte.grunn.legend')}
+                                                error={fieldState.error?.message}
+                                                onBlur={field.onBlur}
+                                                name={field.name}
+                                                value={field.value ?? ''}
+                                                onChange={field.onChange}
+                                            >
+                                                {[
+                                                    {
+                                                        label: formatMessage(
+                                                            'radio.personligOppmøte.grunn.sykMedLegeerklæringOgFullmakt'
+                                                        ),
+                                                        radioValue:
+                                                            GrunnForManglendePersonligOppmøte.SykMedLegeerklæringOgFullmakt,
+                                                    },
+                                                    {
+                                                        label: formatMessage(
+                                                            'radio.personligOppmøte.grunn.oppnevntVergeSøktPerPost'
+                                                        ),
+                                                        radioValue:
+                                                            GrunnForManglendePersonligOppmøte.OppnevntVergeSøktPerPost,
+                                                    },
+                                                    {
+                                                        label: formatMessage(
+                                                            'radio.personligOppmøte.grunn.kortvarigSykMedLegeerklæring'
+                                                        ),
+                                                        radioValue:
+                                                            GrunnForManglendePersonligOppmøte.KortvarigSykMedLegeerklæring,
+                                                    },
+                                                    {
+                                                        label: formatMessage(
+                                                            'radio.personligOppmøte.grunn.midlertidigUnntakFraOppmøteplikt'
+                                                        ),
+                                                        radioValue:
+                                                            GrunnForManglendePersonligOppmøte.MidlertidigUnntakFraOppmøteplikt,
+                                                    },
+                                                    {
+                                                        label: formatMessage(
+                                                            'radio.personligOppmøte.grunn.brukerIkkeMøttOppfyllerIkkeVilkår'
+                                                        ),
+                                                        radioValue:
+                                                            GrunnForManglendePersonligOppmøte.BrukerIkkeMøttOppfyllerIkkeVilkår,
+                                                    },
+                                                ].map(({ label, radioValue }, idx) => (
+                                                    <Radio
+                                                        id={idx === 0 ? field.name : undefined}
+                                                        ref={idx === 0 ? field.ref : undefined}
+                                                        key={radioValue}
+                                                        value={radioValue}
+                                                    >
+                                                        {label}
+                                                    </Radio>
+                                                ))}
+                                            </RadioGroup>
+                                        )}
+                                    />
+                                </div>
                             )}
-                            nesteKnappTekst={
-                                oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
-                                erFerdigbehandletMedAvslag(oppdatertVilkårsinformasjon)
-                                    ? formatMessage('button.tilVedtak.label')
-                                    : undefined
-                            }
-                            loading={RemoteData.isPending(status)}
-                        />
-                    </form>
+
+                            <div
+                                ref={advarselRef}
+                                tabIndex={-1}
+                                aria-live="polite"
+                                aria-atomic="true"
+                                className={styles.alertstripe}
+                            >
+                                {oppdatertVilkårsinformasjon !== 'personligOppmøteIkkeVurdert' &&
+                                    erVurdertUtenAvslagMenIkkeFerdigbehandlet(oppdatertVilkårsinformasjon) && (
+                                        <Alert variant="warning">{formatMessage('alert.ikkeFerdigbehandlet')}</Alert>
+                                    )}
+                            </div>
+                        </>
+                    </SøknadsbehandlingWrapper>
                 ),
                 right: <PersonligOppmøteFaktablokk søknadInnhold={props.behandling.søknad.søknadInnhold} />,
             }}


### PR DESCRIPTION
Oppdaget da jeg skrev inn Aldersstegene i søknadsbehandlingen at det er mye Boilerplate i søknadsbehandlingsstegene. En eller annen form for dette går igjen på hvert steg
```
            <Feiloppsummering
                tittel={formatMessage('feiloppsummering.title')}
                className={styles.feiloppsummering}
                feil={valideringsFeil}
                hidden={valideringsFeil.length === 0}
                ref={feiloppsummeringRef}
            />
            {RemoteData.isFailure(savingState) && <ApiErrorAlert error={savingState.error} />}
            {RemoteData.isSuccess(savingState) && harFeilmeldinger(savingState.value) && (
                <UtfallSomIkkeStøttes feilmeldinger={savingState.value.feilmeldinger} />
            )}
            <RevurderingBunnknapper
                tilbake={props.forrige}
                onLagreOgFortsettSenereClick={form.handleSubmit((values: FormData) =>
                    onFormSubmit(values, () => navigate(props.avsluttUrl))
                )}
                loading={RemoteData.isPending(savingState)}
            />
```

Lagde derfor en wrapper som fjerner boilerplaten. Implementerte det på 4 steg i uføre, men tenkte dere kunne se på det før jeg legger det inn på resten