### PR TITLE
Fikser slik at vi ikke skjuler feilmelding for aggressivt

### DIFF
--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -165,14 +165,6 @@ const ÅpenSøknadVarsel = ({ alleredeÅpenSakInfo }: { alleredeÅpenSakInfo: Al
                     </BodyLong>
                 </div>
             )}
-            <IverksattInnvilgetStønadsperiodeAlert
-                type={Sakstype.Uføre}
-                iverksattInnvilgetStønadsperiode={uføre.iverksattInnvilgetStønadsperiode}
-            />
-            <IverksattInnvilgetStønadsperiodeAlert
-                type={Sakstype.Alder}
-                iverksattInnvilgetStønadsperiode={alder.iverksattInnvilgetStønadsperiode}
-            />
         </>
     );
 };
@@ -199,6 +191,14 @@ const SakinfoAlertContainer = ({
     return (
         <Alert className={styles.åpenSøknadContainer} variant="warning">
             <ÅpenSøknadVarsel alleredeÅpenSakInfo={alleredeÅpenSakInfo} />
+            <IverksattInnvilgetStønadsperiodeAlert
+                type={Sakstype.Uføre}
+                iverksattInnvilgetStønadsperiode={alleredeÅpenSakInfo.uføre.iverksattInnvilgetStønadsperiode}
+            />
+            <IverksattInnvilgetStønadsperiodeAlert
+                type={Sakstype.Alder}
+                iverksattInnvilgetStønadsperiode={alleredeÅpenSakInfo.alder.iverksattInnvilgetStønadsperiode}
+            />
             <Aldersvarsel søkerAlder={søkerAlder} />
         </Alert>
     );

--- a/src/pages/søknad/steg/inngang/inngang-nb.ts
+++ b/src/pages/søknad/steg/inngang/inngang-nb.ts
@@ -31,9 +31,9 @@ export default {
     'heading.løpendeYtelse.alder': 'Løpende ytelse personer over 67 år med kort botid',
 
     'åpenSøknad.løpendeYtelse':
-        'Bruker har allerede en løpende ytelse, supplerende stønad {type} er innvilget for perioden {løpendePeriode}. Bruker kan tidligst søke om ny periode {tidligestNyPeriode}.',
+        'Bruker har allerede en løpende ytelse, {type} er innvilget for perioden {løpendePeriode}. Bruker kan tidligst søke om ny periode {tidligestNyPeriode}.',
     'åpenSøknad.løpendeYtelse.kort':
-        'Bruker har allerede en løpende ytelse, supplerende stønad {type} er innvilget for perioden {løpendePeriode}.',
+        'Bruker har allerede en løpende ytelse, {type} er innvilget for perioden {løpendePeriode}.',
 
     'finnSøker.tittel': 'Finn søker',
     'finnSøker.tekst': 'For å starte søknaden, må du skrive inn fødselsnummeret til søkeren',


### PR DESCRIPTION
Flytter renderingen av iverksatt innvilget stønadsperiode-feilen ett hakk utenfor, så den ikke forsvinner hvis det er eneste feilen.