### PR TITLE
Scanner kun ukentlig for npm-oppdateringer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
     - package-ecosystem: npm
       directory: '/'
       schedule:
-          interval: daily
-      open-pull-requests-limit: 10
+          interval: weekly
+      open-pull-requests-limit: 20
       ignore:
           - dependency-name: yup
             versions:
@@ -18,5 +18,5 @@ updates:
     - package-ecosystem: npm
       directory: '/server'
       schedule:
-        interval: daily
-      open-pull-requests-limit: 10
+        interval: weekly
+      open-pull-requests-limit: 20


### PR DESCRIPTION
Det er en del overhead å fikse disse ~daglig, så det virker mer
hensiktsmessig å få en scan i uken og så ta de da. Vi får uansett
advarsler på security vulnerabilities løpende.