### PR TITLE
Fikset pariode-bug i revurdering. Dato ble ikke endret

### DIFF
--- a/src/pages/saksbehandling/revurdering/opplysningsplikt/Opplysningsplikt.tsx
+++ b/src/pages/saksbehandling/revurdering/opplysningsplikt/Opplysningsplikt.tsx
@@ -16,7 +16,6 @@ import { Navigasjonsknapper } from '~src/pages/saksbehandling/bunnknapper/Naviga
 import * as sharedStyles from '~src/pages/saksbehandling/revurdering/revurdering.module.less';
 import RevurderingsperiodeHeader from '~src/pages/saksbehandling/revurdering/revurderingsperiodeheader/RevurderingsperiodeHeader';
 import { OpplysningspliktBeksrivelse } from '~src/types/grunnlagsdataOgVilkårsvurderinger/opplysningsplikt/Opplysningsplikt';
-import { NullablePeriode } from '~src/types/Periode';
 import { RevurderingStegProps } from '~src/types/Revurdering';
 import { parseIsoDateOnly, sluttenAvMåneden, toIsoDateOnlyString } from '~src/utils/date/dateUtils';
 
@@ -125,22 +124,24 @@ const Opplysningsplikt = (props: RevurderingStegProps) => {
                                     )}
                                 </div>
 
-                                <PeriodeForm
+                                <Controller
                                     name={`opplysningsplikt.${index}.periode`}
-                                    value={opplysningsplikt.periode}
-                                    onChange={(periode: NullablePeriode) =>
-                                        form.setValue(`opplysningsplikt.${index}.periode`, periode)
-                                    }
-                                    error={form.formState.errors.opplysningsplikt?.[index]?.periode}
-                                    minDate={{
-                                        fraOgMed: revurderingsperiode.fraOgMed,
-                                        tilOgMed: revurderingsperiode.tilOgMed,
-                                    }}
-                                    maxDate={{
-                                        fraOgMed: revurderingsperiode.fraOgMed,
-                                        tilOgMed: revurderingsperiode.tilOgMed,
-                                    }}
-                                    size="S"
+                                    control={form.control}
+                                    render={({ field }) => (
+                                        <PeriodeForm
+                                            {...field}
+                                            error={form.formState.errors.opplysningsplikt?.[index]?.periode}
+                                            minDate={{
+                                                fraOgMed: revurderingsperiode.fraOgMed,
+                                                tilOgMed: revurderingsperiode.tilOgMed,
+                                            }}
+                                            maxDate={{
+                                                fraOgMed: revurderingsperiode.fraOgMed,
+                                                tilOgMed: revurderingsperiode.tilOgMed,
+                                            }}
+                                            size="S"
+                                        />
+                                    )}
                                 />
                             </Panel>
                         ))}

--- a/src/pages/saksbehandling/revurdering/utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/pages/saksbehandling/revurdering/utenlandsopphold/Utenlandsopphold.tsx
@@ -20,7 +20,6 @@ import revurderingmessages, { stegmessages } from '~src/pages/saksbehandling/rev
 import * as sharedStyles from '~src/pages/saksbehandling/revurdering/revurdering.module.less';
 import RevurderingsperiodeHeader from '~src/pages/saksbehandling/revurdering/revurderingsperiodeheader/RevurderingsperiodeHeader';
 import { Utenlandsoppholdstatus } from '~src/types/grunnlagsdataOgVilkårsvurderinger/utenlandsopphold/Utenlandsopphold';
-import { NullablePeriode } from '~src/types/Periode';
 import { RevurderingStegProps } from '~src/types/Revurdering';
 import { parseIsoDateOnly, sluttenAvMåneden, toIsoDateOnlyString } from '~src/utils/date/dateUtils';
 
@@ -129,22 +128,24 @@ const Utenlandsopphold = (props: RevurderingStegProps) => {
                                         </Button>
                                     )}
 
-                                    <PeriodeForm
+                                    <Controller
                                         name={`utenlandsopphold.${index}.periode`}
-                                        value={utenlandsopphold.periode}
-                                        onChange={(periode: NullablePeriode) =>
-                                            form.setValue(`utenlandsopphold.${index}.periode`, periode)
-                                        }
-                                        error={form.formState.errors.utenlandsopphold?.[index]?.periode}
-                                        minDate={{
-                                            fraOgMed: revurderingsperiode.fraOgMed,
-                                            tilOgMed: revurderingsperiode.tilOgMed,
-                                        }}
-                                        maxDate={{
-                                            fraOgMed: revurderingsperiode.fraOgMed,
-                                            tilOgMed: revurderingsperiode.tilOgMed,
-                                        }}
-                                        size="S"
+                                        control={form.control}
+                                        render={({ field }) => (
+                                            <PeriodeForm
+                                                {...field}
+                                                error={form.formState.errors.utenlandsopphold?.[index]?.periode}
+                                                minDate={{
+                                                    fraOgMed: revurderingsperiode.fraOgMed,
+                                                    tilOgMed: revurderingsperiode.tilOgMed,
+                                                }}
+                                                maxDate={{
+                                                    fraOgMed: revurderingsperiode.fraOgMed,
+                                                    tilOgMed: revurderingsperiode.tilOgMed,
+                                                }}
+                                                size="S"
+                                            />
+                                        )}
                                     />
                                 </div>
                                 <Controller


### PR DESCRIPTION
I revurdering så kunne man ikke visuelt se endringen om man valgte en ny periode for utenlandsopphold og opplysningsplikt. Fixed nu