### PR TITLE
Fikser navigering tilbake fra Gjenoppta-oppsummering

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -109,6 +109,7 @@ const AppRoutes = () => (
             </Route>
             <Route path={routes.gjenopptaStansRoot.path}>
                 <Route index element={<Gjenoppta />} />
+                <Route path={routes.gjenopptaStansRoute.path} element={<Gjenoppta />} />
                 <Route path={routes.gjenopptaStansOppsummeringRoute.path} element={<GjenopptaOppsummering />} />
             </Route>
             <Route>

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -790,7 +790,7 @@ export default createSlice({
         });
 
         builder.addCase(revurderingActions.opprettStans.fulfilled, (state, action) => {
-            state.sak = oppdaterRevurderingISak(state.sak, action.payload);
+            state.sak = opprettEllerOppdaterRevurderingISak(state.sak, action.payload);
         });
 
         builder.addCase(revurderingActions.gjenoppta.fulfilled, (state, action) => {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -201,13 +201,13 @@ export const stansOppsummeringRoute: Route<{ sakId: string; revurderingId: strin
 };
 
 export const gjenopptaStansRoot: Route<{ sakId: string }> = {
-    path: 'gjenoppta/',
+    path: 'gjenoppta/*',
     absPath: '/saksoversikt/:sakId/gjenoppta/',
     createURL: ({ sakId }) => `/saksoversikt/${sakId}/gjenoppta/`,
 };
 
 export const gjenopptaStansRoute: Route<{ sakId: string; revurderingId: string }> = {
-    path: '/gjenoppta/:revurderingId',
+    path: ':revurderingId',
     absPath: '/saksoversikt/:sakId/gjenoppta/:revurderingId',
     createURL: ({ sakId, revurderingId }) => `/saksoversikt/${sakId}/gjenoppta/${revurderingId ?? ''}`,
 };

--- a/src/pages/saksbehandling/sakintro/sakintro-nb.ts
+++ b/src/pages/saksbehandling/sakintro/sakintro-nb.ts
@@ -49,7 +49,7 @@ export default {
     'revurdering.iverksattDato': 'Iverksatt dato:',
     'revurdering.seOppsummering': 'Se oppsummering',
     'revurdering.type': 'Type: ',
-    'revurdering.type.stansGjenoppta.label': 'Stans/Gjenoppta av utbetaling',
+    'revurdering.type.stansGjenoppta.label': 'Stans/Gjenopptak av utbetaling',
 
     'revurdering.label.forhåndsvarselSendt': 'Forhåndsvarsel sendt',
 

--- a/src/pages/saksbehandling/sakintro/utbetalinger-nb.ts
+++ b/src/pages/saksbehandling/sakintro/utbetalinger-nb.ts
@@ -4,7 +4,7 @@ const utbetalingsTypeTekstMapper: { [key in Utbetalingstype]: string } = {
     [Utbetalingstype.NY]: ' ',
     [Utbetalingstype.OPPHØR]: 'Opphørt',
     [Utbetalingstype.STANS]: 'Stanset',
-    [Utbetalingstype.GJENOPPTA]: 'Gjenopptat',
+    [Utbetalingstype.GJENOPPTA]: 'Gjenopptatt',
 };
 
 export default {

--- a/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
+++ b/src/pages/saksbehandling/stans/gjenoppta/gjenoppta.tsx
@@ -40,7 +40,7 @@ function hentDefaultVerdier(r: Nullable<Revurdering>): FormData {
 
 const Gjenoppta = () => {
     const props = useOutletContext<AttesteringContext>();
-    const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansOppsummeringRoute>();
+    const urlParams = Routes.useRouteParams<typeof Routes.gjenopptaStansRoute>();
     const { formatMessage } = useI18n({ messages: { ...messages, ...sharedMessages } });
     const navigate = useNavigate();
 
@@ -77,10 +77,11 @@ const Gjenoppta = () => {
             årsak: values.årsak,
             begrunnelse: values.begrunnelse,
         };
-        const onSuccess = () => {
+        const onSuccess = (arg: Revurdering) => {
             navigate(
-                Routes.saksoversiktValgtSak.createURL({
+                Routes.gjenopptaStansOppsummeringRoute.createURL({
                     sakId: urlParams.sakId ?? '',
+                    revurderingId: arg.id,
                 })
             );
         };


### PR DESCRIPTION
Var en manglende konfigurasjon for nøstet route for gjenopptak,
fikset slik at det er tilsvarsende som for Stans. Passer også
på at vi henter inn ny revurdering når vi oppretter stans-revurdering