### PR TITLE
Utbedret informasjon om søkers alder + saksbehandler må bekrefte stønadsperiode ved gitte tilfeller 

### DIFF
--- a/src/api/behandlingApi.ts
+++ b/src/api/behandlingApi.ts
@@ -38,7 +38,12 @@ export async function lagreVirkningstidspunkt(arg: {
     behandlingId: string;
     fraOgMed: string;
     tilOgMed: string;
-}): Promise<ApiClientResult<{ søknadsbehandling: Søknadsbehandling; måKontrolleres: boolean }>> {
+}): Promise<
+    ApiClientResult<{
+        aldersvilkårMåKontrolleresManuelt: boolean;
+        søknadsbehandling: Søknadsbehandling;
+    }>
+> {
     return apiClient({
         url: `/saker/${arg.sakId}/behandlinger/${arg.behandlingId}/stønadsperiode`,
         method: 'POST',

--- a/src/api/behandlingApi.ts
+++ b/src/api/behandlingApi.ts
@@ -38,17 +38,14 @@ export async function lagreVirkningstidspunkt(arg: {
     behandlingId: string;
     fraOgMed: string;
     tilOgMed: string;
-}): Promise<
-    ApiClientResult<{
-        aldersvilkårMåKontrolleresManuelt: boolean;
-        søknadsbehandling: Søknadsbehandling;
-    }>
-> {
+    harSaksbehandlerAvgjort: boolean;
+}): Promise<ApiClientResult<Søknadsbehandling>> {
     return apiClient({
         url: `/saker/${arg.sakId}/behandlinger/${arg.behandlingId}/stønadsperiode`,
         method: 'POST',
         body: {
             periode: { fraOgMed: arg.fraOgMed, tilOgMed: arg.tilOgMed },
+            harSaksbehandlerAvgjort: arg.harSaksbehandlerAvgjort,
         },
     });
 }

--- a/src/api/personApi.ts
+++ b/src/api/personApi.ts
@@ -61,7 +61,6 @@ export interface Person {
     navn: Navn;
     kjønn: Nullable<Kjønn>;
     fødsel: Nullable<Fødsel>;
-    alder: Nullable<number>;
     telefonnummer: {
         landskode: string;
         nummer: string;
@@ -82,9 +81,10 @@ export interface Person {
     dødsdato: Nullable<string>;
 }
 
-interface Fødsel {
+export interface Fødsel {
     dato: Nullable<string>;
     år: number;
+    alder: number;
 }
 
 export async function fetchPerson(fnr: string): Promise<ApiClientResult<Person>> {

--- a/src/components/personkort/Personkort.tsx
+++ b/src/components/personkort/Personkort.tsx
@@ -23,13 +23,13 @@ export const Personkort = (props: { person: Person; variant?: 'normal' | 'wide' 
                         <span className={styles.horizontalSeparator}>–</span>
                         <span>{formatFnr(props.person.fnr)}</span>
                         <span className={styles.horizontalSeparator}>–</span>
-                        <span>{props.person.alder} år</span>
+                        <span>{props.person.fødsel?.alder} år</span>
                         <PersonAdvarsel person={props.person} />
                     </>
                 ) : (
                     <>
                         <span>{showName(props.person.navn)}</span>
-                        <span>{`${formatFnr(props.person.fnr)}, ${props.person.alder} år`}</span>
+                        <span>{`${formatFnr(props.person.fnr)}, ${props.person.fødsel?.alder} år`}</span>
                         <PersonAdvarsel person={props.person} />
                     </>
                 )}

--- a/src/features/SøknadsbehandlingActions.ts
+++ b/src/features/SøknadsbehandlingActions.ts
@@ -20,7 +20,10 @@ export const startBehandling = createAsyncThunk<
 });
 
 export const lagreVirkningstidspunkt = createApiCallAsyncThunk<
-    { søknadsbehandling: Søknadsbehandling; måKontrolleres: boolean },
+    {
+        aldersvilkårMåKontrolleresManuelt: boolean;
+        søknadsbehandling: Søknadsbehandling;
+    },
     { sakId: string; behandlingId: string; fraOgMed: string; tilOgMed: string }
 >('behandling/lagreVirkningstidspunk', behandlingApi.lagreVirkningstidspunkt);
 

--- a/src/features/SøknadsbehandlingActions.ts
+++ b/src/features/SøknadsbehandlingActions.ts
@@ -20,11 +20,8 @@ export const startBehandling = createAsyncThunk<
 });
 
 export const lagreVirkningstidspunkt = createApiCallAsyncThunk<
-    {
-        aldersvilkårMåKontrolleresManuelt: boolean;
-        søknadsbehandling: Søknadsbehandling;
-    },
-    { sakId: string; behandlingId: string; fraOgMed: string; tilOgMed: string }
+    Søknadsbehandling,
+    { sakId: string; behandlingId: string; fraOgMed: string; tilOgMed: string; harSaksbehandlerAvgjort: boolean }
 >('behandling/lagreVirkningstidspunk', behandlingApi.lagreVirkningstidspunkt);
 
 export const startBeregning = createAsyncThunk<

--- a/src/features/person/person.slice.ts
+++ b/src/features/person/person.slice.ts
@@ -45,8 +45,8 @@ export default createSlice({
                 fødsel: {
                     dato: null,
                     år: 2000,
+                    alder: 23,
                 },
-                alder: null,
                 telefonnummer: {
                     landskode: '+47',
                     nummer: '2225555',

--- a/src/features/saksoversikt/sak.slice.ts
+++ b/src/features/saksoversikt/sak.slice.ts
@@ -151,7 +151,7 @@ export default createSlice({
         });
 
         builder.addCase(SøknadsbehandlingActions.lagreVirkningstidspunkt.fulfilled, (state, action) => {
-            state.sak = oppdaterSøknadsbehandlingISak(state.sak, action.payload.søknadsbehandling);
+            state.sak = oppdaterSøknadsbehandlingISak(state.sak, action.payload);
         });
 
         builder.addCase(SøknadsbehandlingActions.startBeregning.fulfilled, (state, action) => {

--- a/src/pages/saksbehandling/revurdering/bosituasjon/bosituasjonPage.tsx
+++ b/src/pages/saksbehandling/revurdering/bosituasjon/bosituasjonPage.tsx
@@ -136,7 +136,7 @@ const BosituasjonPage = (props: RevurderingStegProps) => {
                                                                 getHentetPerson={(person) => {
                                                                     form.setValue(`${nameAndIdx}`, {
                                                                         ...watch,
-                                                                        epsAlder: person?.alder ?? null,
+                                                                        epsAlder: person?.fødsel?.alder ?? null,
                                                                     });
                                                                 }}
                                                             />

--- a/src/pages/saksbehandling/søknadsbehandling/sats/Sats.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/sats/Sats.tsx
@@ -58,8 +58,8 @@ interface SatsProps extends VilkårsvurderingBaseProps {
 }
 
 const tilBosituasjonsValg = (values: FormData, eps: Nullable<Person>): Nullable<BosituasjonsValg> => {
-    if (eps && eps.alder) {
-        if (eps.alder >= 67) {
+    if (eps && eps.fødsel?.alder) {
+        if (eps.fødsel.alder >= 67) {
             return BosituasjonsValg.EPS_67_ELLER_OVER;
         }
 
@@ -122,7 +122,7 @@ const getValidationSchema = (eps: Nullable<Person>) => {
                     'eps mottar SU',
                     'Du må velge om ektefelle/samboer mottar supplerende stønad',
                     function (mottarSu) {
-                        if (eps && eps.alder && eps.alder < 67) {
+                        if (eps && eps.fødsel?.alder && eps.fødsel.alder < 67) {
                             return mottarSu !== null;
                         }
 
@@ -187,7 +187,9 @@ const Sats = (props: VilkårsvurderingBaseProps) => {
 };
 
 function mottarEktemakeEllerSamboerSUInitialValue(eps: Nullable<Person>, bosituasjon: Nullable<Bosituasjon>) {
-    return eps && eps.alder && eps.alder >= 67 ? null : bosituasjon?.ektemakeEllerSamboerUførFlyktning ?? null;
+    return eps && eps.fødsel?.alder && eps.fødsel.alder >= 67
+        ? null
+        : bosituasjon?.ektemakeEllerSamboerUførFlyktning ?? null;
 }
 
 function getInitialValues(eps: Nullable<Person>, bosituasjon: Nullable<Bosituasjon>) {
@@ -218,7 +220,7 @@ const SatsForm = (props: SatsProps) => {
 
     const watch = form.watch();
 
-    const sats = useMemo(() => utledSats(watch, Boolean(eps), eps?.alder), [eps, watch]);
+    const sats = useMemo(() => utledSats(watch, Boolean(eps), eps?.fødsel?.alder), [eps, watch]);
 
     const handleSave = async (values: FormData, onSuccess: () => void) => {
         const bosituasjonsvalg = tilBosituasjonsValg(values, eps);
@@ -277,7 +279,7 @@ const SatsForm = (props: SatsProps) => {
                                     )}
                                 />
                             )}
-                            {eps?.alder && eps.alder < 67 && (
+                            {eps?.fødsel?.alder && eps.fødsel.alder < 67 && (
                                 <Controller
                                     control={form.control}
                                     name="mottarEktemakeEllerSamboerSU"

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -1,10 +1,11 @@
 import * as RemoteData from '@devexperts/remote-data-ts';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Heading, Loader } from '@navikt/ds-react';
+import { Alert, Heading, Loader } from '@navikt/ds-react';
 import * as DateFns from 'date-fns';
 import * as React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import { Fødsel } from '~src/api/personApi';
 import DatePicker from '~src/components/datePicker/DatePicker';
 import { OppsummeringPar } from '~src/components/oppsummering/oppsummeringpar/OppsummeringPar';
 import ToKolonner from '~src/components/toKolonner/ToKolonner';
@@ -13,12 +14,18 @@ import * as SøknadsbehandlingActions from '~src/features/SøknadsbehandlingActi
 import { nullableMap, pipe } from '~src/lib/fp';
 import { useAsyncActionCreator } from '~src/lib/hooks';
 import { useI18n } from '~src/lib/i18n';
+import { Nullable } from '~src/lib/types';
 import { getDateErrorMessage } from '~src/lib/validering';
 import { FormWrapper } from '~src/pages/saksbehandling/søknadsbehandling/FormWrapper';
 import { useAppSelector } from '~src/redux/Store';
 import { Vilkårtype } from '~src/types/Vilkårsvurdering';
 import * as DateUtils from '~src/utils/date/dateUtils';
 import { formatDate } from '~src/utils/date/dateUtils';
+import {
+    alderSomPersonFyllerIÅr,
+    alderSomPersonFyllerIÅrDate,
+    alderSomPersonFyllerPåDato,
+} from '~src/utils/person/personUtils';
 
 import sharedMessages from '../sharedI18n-nb';
 import { VilkårsvurderingBaseProps } from '../types';
@@ -32,6 +39,54 @@ import {
     virkningstidspunktSchema,
 } from './VirkningstidspunktUtils';
 
+const SaksbehandlerMåKontrollereStønadsperioden = (props: {
+    stønadsperiodeTilOgMed: Nullable<Date>;
+    søkersFødselsinformasjon: Nullable<Fødsel>;
+}) => {
+    const { formatMessage } = useI18n({ messages: { ...sharedMessages, ...messages } });
+
+    if (!props.søkersFødselsinformasjon) {
+        return (
+            <div>
+                <Alert className={styles.alert} variant="warning">
+                    {formatMessage('person.harIkkeFødselsinformasjon')}
+                </Alert>
+            </div>
+        );
+    } else if (!props.stønadsperiodeTilOgMed) {
+        return <div></div>;
+    }
+
+    if (props.søkersFødselsinformasjon.dato) {
+        if (
+            alderSomPersonFyllerPåDato(props.stønadsperiodeTilOgMed, new Date(props.søkersFødselsinformasjon.dato)) >=
+                67 &&
+            props.stønadsperiodeTilOgMed.getMonth() > new Date(props.søkersFødselsinformasjon.dato).getMonth()
+        ) {
+            return (
+                <div>
+                    <Alert className={styles.alert} variant="warning">
+                        {formatMessage('person.medFødselsdato.fyller67VedAngittStønadsperiode')}
+                    </Alert>
+                </div>
+            );
+        } else return <div></div>;
+    }
+    if (
+        alderSomPersonFyllerIÅrDate(props.stønadsperiodeTilOgMed.getFullYear(), props.søkersFødselsinformasjon.år) >= 67
+    ) {
+        return (
+            <div>
+                <Alert className={styles.alert} variant="warning">
+                    {formatMessage('person.utenFødselsdato.fyller67VedAngittStønadsperiode')}
+                </Alert>
+            </div>
+        );
+    }
+
+    return <div></div>;
+};
+
 const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
     const { formatMessage } = useI18n({ messages: { ...sharedMessages, ...messages } });
 
@@ -41,6 +96,7 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
         fraOgMed: nullableMap(props.behandling.stønadsperiode?.periode.fraOgMed ?? null, DateUtils.parseIsoDateOnly),
         tilOgMed: nullableMap(props.behandling.stønadsperiode?.periode.tilOgMed ?? null, DateUtils.parseIsoDateOnly),
     };
+
     const { draft, clearDraft, useDraftFormSubscribe } =
         useSøknadsbehandlingDraftContextFor<VirkningstidspunktFormData>(Vilkårtype.Virkningstidspunkt, (values) =>
             eqBehandlingsperiode.equals(values, initialValues)
@@ -58,7 +114,7 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                 sakId: props.sakId,
                 behandlingId: props.behandling.id,
                 fraOgMed: DateFns.formatISO(data.fraOgMed!, { representation: 'date' }),
-                tilOgMed: DateFns.formatISO(DateFns.endOfMonth(data.tilOgMed!), { representation: 'date' }),
+                tilOgMed: DateFns.formatISO(data.tilOgMed!, { representation: 'date' }),
             },
             () => {
                 clearDraft();
@@ -66,6 +122,7 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
             }
         );
 
+    console.log(form.getValues());
     return (
         <>
             {pipe(
@@ -93,6 +150,11 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                                         }}
                                     >
                                         <>
+                                            <SaksbehandlerMåKontrollereStønadsperioden
+                                                stønadsperiodeTilOgMed={form.watch('tilOgMed')}
+                                                søkersFødselsinformasjon={søker.fødsel}
+                                            />
+
                                             <Controller
                                                 control={form.control}
                                                 name="fraOgMed"
@@ -128,7 +190,11 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                                                 render={({ field, fieldState }) => (
                                                     <DatePicker
                                                         name={field.name}
-                                                        onChange={field.onChange}
+                                                        onChange={(date) =>
+                                                            date
+                                                                ? field.onChange(DateFns.endOfMonth(date))
+                                                                : field.onChange(date)
+                                                        }
                                                         value={field.value}
                                                         className={styles.dato}
                                                         id="tilOgMed"
@@ -153,9 +219,35 @@ const Virkningstidspunkt = (props: VilkårsvurderingBaseProps) => {
                                             verdi={
                                                 søker.fødsel?.dato
                                                     ? formatDate(søker.fødsel?.dato)
-                                                    : formatMessage('feil.fantIkkeFnr')
+                                                    : formatMessage('feil.harIkkeFødselsdato')
                                             }
                                         />
+                                        <OppsummeringPar
+                                            label={formatMessage('søker.fødselsår')}
+                                            verdi={
+                                                søker.fødsel?.år
+                                                    ? søker.fødsel.år
+                                                    : formatMessage('feil.harIkkeFødselsår')
+                                            }
+                                        />
+                                        {søker.fødsel?.alder ? (
+                                            <OppsummeringPar
+                                                label={formatMessage('søker.alder')}
+                                                verdi={søker.fødsel.alder}
+                                            />
+                                        ) : (
+                                            <OppsummeringPar
+                                                label={formatMessage('søker.alder')}
+                                                verdi={
+                                                    søker.fødsel?.år
+                                                        ? formatMessage('søker.årSøkerFyller', {
+                                                              år: alderSomPersonFyllerIÅr(søker.fødsel.år),
+                                                              detteÅret: new Date().getFullYear(),
+                                                          })
+                                                        : formatMessage('feil.kunneIkkeAvgjøreAlder')
+                                                }
+                                            />
+                                        )}
                                     </div>
                                 ),
                             }}

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/Virkningstidspunkt.tsx
@@ -248,10 +248,12 @@ const SaksbehandlerMåKontrollereStønadsperioden = (props: {
     }
 
     if (props.søkersFødselsinformasjon.dato) {
-        <FødselsdatoHandler
-            periodeTilOgMed={props.stønadsperiodeTilOgMed}
-            fødselsdato={props.søkersFødselsinformasjon.dato}
-        />;
+        return (
+            <FødselsdatoHandler
+                periodeTilOgMed={props.stønadsperiodeTilOgMed}
+                fødselsdato={props.søkersFødselsinformasjon.dato}
+            />
+        );
     }
     if (fyller67PlusVedStønadsperiodeTilOgMed(props.stønadsperiodeTilOgMed, props.søkersFødselsinformasjon.år)) {
         return (

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/VirkningstidspunktUtils.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/VirkningstidspunktUtils.ts
@@ -4,6 +4,7 @@ import { struct } from 'fp-ts/lib/Eq';
 
 import { eqNullable, Nullable } from '~src/lib/types';
 import yup from '~src/lib/validering';
+import { alderSomPersonFyllerIÅrDate, alderSomPersonFyllerPåDato } from '~src/utils/person/personUtils';
 
 export interface VirkningstidspunktFormData {
     fraOgMed: Nullable<Date>;
@@ -15,6 +16,16 @@ export const eqBehandlingsperiode = struct<VirkningstidspunktFormData>({
     fraOgMed: eqNullable(D.Eq),
     tilOgMed: eqNullable(D.Eq),
 });
+
+export const er67PlusOgStønadsperiodeTilOgMedErLengerEnnFødselsmåned = (
+    stønadsperiodeTilOgMed: Date,
+    fødselsdato: Date
+) =>
+    alderSomPersonFyllerPåDato(stønadsperiodeTilOgMed, new Date(fødselsdato)) >= 67 &&
+    stønadsperiodeTilOgMed.getMonth() > new Date(fødselsdato).getMonth();
+
+export const fyller67PlusVedStønadsperiodeTilOgMed = (stønadsperiodeTilOgMed: Date, fødselsår: number) =>
+    alderSomPersonFyllerIÅrDate(stønadsperiodeTilOgMed.getFullYear(), fødselsår) >= 67;
 
 export const virkningstidspunktSchema = yup
     .object<VirkningstidspunktFormData>({

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/VirkningstidspunktUtils.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/VirkningstidspunktUtils.ts
@@ -41,21 +41,19 @@ export const virkningstidspunktSchema = yup
             .boolean()
             .defined()
             .test('Saksbehandler må bekrefte stønadsperiode', 'Bekreftelse av stønadsperiode påkrevd', function (val) {
-                if (
-                    this.options.context &&
-                    'søknadsbehandling' in this.options.context &&
-                    behovForSaksbehandlerAvgjørelse(this.options.context.søknadsbehandling as Søknadsbehandling) &&
-                    val
-                ) {
+                if (!this.options.context || !('søknadsbehandling' in this.options.context)) {
+                    throw new Error('Har ikke søknadsbehandling i validerings-contexten. Se Virkningstidspunkt.tsx');
+                }
+
+                const søknadsbehandling = this.options.context.søknadsbehandling as Søknadsbehandling;
+
+                if (val === true) {
                     return true;
                 }
-                if (
-                    this.options.context &&
-                    'søknadsbehandling' in this.options.context &&
-                    !harSøknadsbehandlingBehovForSaksbehandlerAvgjørelse(
-                        this.options.context.søknadsbehandling as Søknadsbehandling
-                    )
-                ) {
+                if (behovForSaksbehandlerAvgjørelse(søknadsbehandling) && val) {
+                    return true;
+                }
+                if (!harSøknadsbehandlingBehovForSaksbehandlerAvgjørelse(søknadsbehandling)) {
                     return true;
                 }
                 return false;

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/VirkningstidspunktUtils.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/VirkningstidspunktUtils.ts
@@ -1,20 +1,25 @@
 import * as DateFns from 'date-fns';
+import * as B from 'fp-ts/boolean';
 import * as D from 'fp-ts/lib/Date';
 import { struct } from 'fp-ts/lib/Eq';
 
 import { eqNullable, Nullable } from '~src/lib/types';
 import yup from '~src/lib/validering';
+import { Søknadsbehandling } from '~src/types/Søknadsbehandling';
 import { alderSomPersonFyllerIÅrDate, alderSomPersonFyllerPåDato } from '~src/utils/person/personUtils';
+import { harSøknadsbehandlingBehovForSaksbehandlerAvgjørelse } from '~src/utils/SøknadsbehandlingUtils';
 
 export interface VirkningstidspunktFormData {
     fraOgMed: Nullable<Date>;
     tilOgMed: Nullable<Date>;
+    harSaksbehandlerAvgjort: boolean;
 }
 
 export const TIDLIGST_MULIG_START_DATO = new Date(2021, 0, 1);
 export const eqBehandlingsperiode = struct<VirkningstidspunktFormData>({
     fraOgMed: eqNullable(D.Eq),
     tilOgMed: eqNullable(D.Eq),
+    harSaksbehandlerAvgjort: B.Eq,
 });
 
 export const er67PlusOgStønadsperiodeTilOgMedErLengerEnnFødselsmåned = (
@@ -27,8 +32,34 @@ export const er67PlusOgStønadsperiodeTilOgMedErLengerEnnFødselsmåned = (
 export const fyller67PlusVedStønadsperiodeTilOgMed = (stønadsperiodeTilOgMed: Date, fødselsår: number) =>
     alderSomPersonFyllerIÅrDate(stønadsperiodeTilOgMed.getFullYear(), fødselsår) >= 67;
 
+export const behovForSaksbehandlerAvgjørelse = (s: Søknadsbehandling) =>
+    harSøknadsbehandlingBehovForSaksbehandlerAvgjørelse(s) && s.aldersvurdering?.harSaksbehandlerAvgjort === false;
+
 export const virkningstidspunktSchema = yup
     .object<VirkningstidspunktFormData>({
+        harSaksbehandlerAvgjort: yup
+            .boolean()
+            .defined()
+            .test('Saksbehandler må bekrefte stønadsperiode', 'Bekreftelse av stønadsperiode påkrevd', function (val) {
+                if (
+                    this.options.context &&
+                    'søknadsbehandling' in this.options.context &&
+                    behovForSaksbehandlerAvgjørelse(this.options.context.søknadsbehandling as Søknadsbehandling) &&
+                    val
+                ) {
+                    return true;
+                }
+                if (
+                    this.options.context &&
+                    'søknadsbehandling' in this.options.context &&
+                    !harSøknadsbehandlingBehovForSaksbehandlerAvgjørelse(
+                        this.options.context.søknadsbehandling as Søknadsbehandling
+                    )
+                ) {
+                    return true;
+                }
+                return false;
+            }),
         fraOgMed: yup
             .date()
             .nullable()

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt-nb.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt-nb.ts
@@ -6,6 +6,17 @@ export default {
 
     'søker.personalia': 'Søkers personalia',
     'søker.fødselsdato': 'Fødselsdato',
+    'søker.fødselsår': 'Fødselsår',
+    'søker.alder': 'Alder',
+    'søker.årSøkerFyller': 'Fyller {år} i {detteÅret}',
 
-    'feil.fantIkkeFnr': 'Fant ikke fødseslnummer',
+    'feil.harIkkeFødselsdato': 'Fødselsdato er ikke registrert',
+    'feil.harIkkeFødselsår': 'Fødselsår er ikke registrert',
+    'feil.kunneIkkeAvgjøreAlder': 'Kan ikke regne ut søkers alder',
+
+    'person.harIkkeFødselsinformasjon': 'Søker har ikke registrerts fødselsinformasjon. Behov for manuell sjekk',
+    'person.medFødselsdato.fyller67VedAngittStønadsperiode':
+        'Søker er fyllt 67 ved angitt stønadsperiode. Dem kan få stønad til og med måneden dem blir 67. Juster stønadsperioden',
+    'person.utenFødselsdato.fyller67VedAngittStønadsperiode':
+        'Søker har ikke en registrert fødselsdato. Basert på fødselsåret, fyller søker, eller har allerede fylt 67 dette året. Behov for manuell sjekk. Juster så stønadsperioden deretter',
 };

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt-nb.ts
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt-nb.ts
@@ -14,9 +14,13 @@ export default {
     'feil.harIkkeFødselsår': 'Fødselsår er ikke registrert',
     'feil.kunneIkkeAvgjøreAlder': 'Kan ikke regne ut søkers alder',
 
-    'person.harIkkeFødselsinformasjon': 'Søker har ikke registrerts fødselsinformasjon. Behov for manuell sjekk',
+    'stønadsperiode.advarsel.checkbox.måBekreftes': 'Jeg bekrefter angitt stønadsperiode',
+    'stønadsperiode.advarsel.tekst':
+        'Systemet har identifisert at søker er over 67, eller mangler fødselsinformasjon for å kunne gjøre en vurdering med angitt stønadsperiode',
+
+    'person.harIkkeFødselsinformasjon': 'Søker har ikke registrerts fødselsinformasjon',
     'person.medFødselsdato.fyller67VedAngittStønadsperiode':
-        'Søker er fyllt 67 ved angitt stønadsperiode. Dem kan få stønad til og med måneden dem blir 67. Juster stønadsperioden',
+        'Søker er fyllt 67 ved angitt stønadsperiode. Dem kan få stønad til og med måneden dem blir 67',
     'person.utenFødselsdato.fyller67VedAngittStønadsperiode':
-        'Søker har ikke en registrert fødselsdato. Basert på fødselsåret, fyller søker, eller har allerede fylt 67 dette året. Behov for manuell sjekk. Juster så stønadsperioden deretter',
+        'Søker har ikke en registrert fødselsdato. Basert på fødselsåret, fyller søker, eller har allerede fylt 67 dette året',
 };

--- a/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt.module.less
+++ b/src/pages/saksbehandling/søknadsbehandling/virkningstidspunkt/virkningstidspunkt.module.less
@@ -4,6 +4,10 @@
     margin-bottom: @spacing;
 }
 
+.confirmationPanel {
+    margin-bottom: @spacing-s;
+}
+
 .container {
     > :not(:last-child) {
         margin-bottom: @spacing;

--- a/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
+++ b/src/pages/søknad/steg/bo-og-opphold-i-norge/EktefellePartnerSamboer.tsx
@@ -47,7 +47,7 @@ const EktefellePartnerSamboer = (props: Props) => {
                     props.onChange({
                         ...epsFormData,
                         eps: person,
-                        alder: person?.alder ?? null,
+                        alder: person?.fødsel?.alder ?? null,
                     });
                 }}
             />

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -313,11 +313,11 @@ const Inngang = () => {
                     />
                     {pipe(
                         RemoteData.combine(sakinfo, hentPersonStatus),
-                        RemoteData.map(([begrensetSakInfo, { alder }]) => (
+                        RemoteData.map(([begrensetSakInfo, { fødsel }]) => (
                             <SakinfoAlertContainer
-                                key={alder}
+                                key={fødsel?.alder}
                                 alleredeÅpenSakInfo={begrensetSakInfo}
-                                søkerAlder={alder}
+                                søkerAlder={fødsel?.alder ?? null}
                             />
                         )),
                         RemoteData.getOrElse(() => null as React.ReactNode)

--- a/src/types/Aldersvurdering.ts
+++ b/src/types/Aldersvurdering.ts
@@ -1,0 +1,12 @@
+export interface Aldersvurdering {
+    harSaksbehandlerAvgjort: boolean;
+    maskinellVurderingsresultat: MaskinellVurderingsresultat;
+}
+
+export enum MaskinellVurderingsresultat {
+    RETT_PÅ_ALDER = 'RETT_PÅ_ALDER',
+    RETT_PÅ_UFØRE = 'RETT_PÅ_UFØRE',
+    UKJENT = 'UKJENT',
+    HISTORISK = 'HISTORISK',
+    SKAL_IKKE_VURDERES = 'SKAL_IKKE_VURDERES',
+}

--- a/src/types/Søknadsbehandling.ts
+++ b/src/types/Søknadsbehandling.ts
@@ -2,6 +2,7 @@ import { Nullable } from '~src/lib/types';
 import { Periode } from '~src/types/Periode';
 import { Simulering } from '~src/types/Simulering';
 
+import { Aldersvurdering } from './Aldersvurdering';
 import { Behandling } from './Behandling';
 import { Beregning } from './Beregning';
 import { Søknad } from './Søknad';
@@ -16,6 +17,7 @@ export interface Søknadsbehandling extends Behandling<SøknadsbehandlingStatus>
     fritekstTilBrev: string;
     simuleringForAvkortingsvarsel: Nullable<Simulering>;
     erLukket: boolean;
+    aldersvurdering: Nullable<Aldersvurdering>;
 }
 
 export interface Stønadsperiode {

--- a/src/utils/SøknadsbehandlingUtils.ts
+++ b/src/utils/SøknadsbehandlingUtils.ts
@@ -1,3 +1,4 @@
+import { Aldersvurdering, MaskinellVurderingsresultat } from '~src/types/Aldersvurdering';
 import { FormueStatus } from '~src/types/grunnlagsdataOgVilkårsvurderinger/formue/Formuevilkår';
 import { UføreResultat } from '~src/types/grunnlagsdataOgVilkårsvurderinger/uføre/Uførevilkår';
 import { Utenlandsoppholdstatus } from '~src/types/grunnlagsdataOgVilkårsvurderinger/utenlandsopphold/Utenlandsopphold';
@@ -144,3 +145,10 @@ export const splitStatusOgResultatFraSøkandsbehandling = (
             return { status: 'Iverksatt', resultat: 'Innvilget' };
     }
 };
+
+export const harSøknadsbehandlingBehovForSaksbehandlerAvgjørelse = (s: Søknadsbehandling) =>
+    s.aldersvurdering !== null && maskinellVurderingGirBehovForSaksbehandlerAvgjørelse(s.aldersvurdering);
+
+const maskinellVurderingGirBehovForSaksbehandlerAvgjørelse = (aldersvurdering: Aldersvurdering) =>
+    aldersvurdering.maskinellVurderingsresultat === MaskinellVurderingsresultat.RETT_PÅ_ALDER ||
+    aldersvurdering.maskinellVurderingsresultat === MaskinellVurderingsresultat.UKJENT;

--- a/src/utils/person/personUtils.ts
+++ b/src/utils/person/personUtils.ts
@@ -1,3 +1,5 @@
+import * as DateFns from 'date-fns';
+
 import { Navn } from '~src/api/personApi';
 import { Nullable } from '~src/lib/types';
 
@@ -10,5 +12,9 @@ export function formatFnr(fnr: string): string {
     return `${fnr.substring(0, 6)} ${fnr.substring(6, 11)}`;
 }
 
-export const er67EllerEldre = (alder: number | null): boolean => (alder ?? 67) >= 67;
-export const er66EllerEldre = (alder: Nullable<number>): boolean => alder !== null && alder >= 66;
+export const er67EllerEldre = (alder: Nullable<number>): boolean => (alder ?? 67) >= 67;
+export const alderSomPersonFyllerIÅr = (år: number) => new Date().getFullYear() - år;
+export const alderSomPersonFyllerPåDato = (datoSomSjekkes: Date, fødselsmåned: Date) => {
+    return DateFns.differenceInYears(datoSomSjekkes, fødselsmåned);
+};
+export const alderSomPersonFyllerIÅrDate = (årSomSjekkes: number, årFødt: number) => årSomSjekkes - årFødt;


### PR DESCRIPTION
Tilfeller: 
 - Su-se-bakover kan ikke garantere at søker er innenfor alderen 18-67 under hele stønadsperioden
 - Su-se-bakover identifiserer at søker er over 67 ved angitt stønadsperiode

I så tilfelle: vil su-se-framover kreve at saksbehandler huker av checkbox
