### PR TITLE
Bytt til legacyfolder for redis prod

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -84,7 +84,7 @@ metadata:
     nais.io/run-as-group: "0" # Fix permissions for bitnami/redis
     nais.io/read-only-file-system: "false" # Fix permissions for bitnami/redis
 spec:
-  image: bitnami/redis:6.0
+  image: bitnamilegacy/redis:6.0
   port: 6379
   replicas: # A single Redis-app doesn't scale
     min: 1


### PR DESCRIPTION
se https://github.com/navikt/su-se-framover/pull/4266

imaget ble borte siden cachen utløp, er bare et tidsspørsmål før det skjer ved deploy av prod og. Denne fikser det.