### PR TITLE
Reset innsending

### DIFF
--- a/src/features/søknad/innsending.slice.ts
+++ b/src/features/søknad/innsending.slice.ts
@@ -13,7 +13,7 @@ export const sendUføresøknad = createAsyncThunk<
     søknadApi.OpprettetSøknad,
     { søknad: UføresøknadState; søker: Person },
     { rejectValue: ApiError }
->('innsending/fetch', async ({ søknad, søker }, thunkApi) => {
+>('innsending/sendUføresøknad', async ({ søknad, søker }, thunkApi) => {
     const søknadDto = toUføreinnsending(søknad, søker.fnr);
 
     const res = await søknadApi.sendUføresøknad(søknadDto);
@@ -27,7 +27,7 @@ export const sendAldersøknad = createAsyncThunk<
     søknadApi.OpprettetSøknad,
     { søknad: AlderssøknadState; søker: Person },
     { rejectValue: ApiError }
->('innsending/fetch', async ({ søknad, søker }, thunkApi) => {
+>('innsending/sendAldersøknad', async ({ søknad, søker }, thunkApi) => {
     const søknadDto = toAldersinnsending(søknad, søker.fnr);
 
     const res = await søknadApi.sendAlderssøknad(søknadDto);
@@ -46,9 +46,22 @@ const initialState: InnsendingState = {
 export default createSlice({
     name: 'innsending',
     initialState,
-    reducers: {},
+    reducers: {
+        resetInnsending: () => initialState,
+    },
     extraReducers: (builder) => {
         handleAsyncThunk(builder, sendUføresøknad, {
+            pending: (state) => {
+                state.søknad = RemoteData.pending;
+            },
+            fulfilled: (state, action) => {
+                state.søknad = RemoteData.success(action.payload);
+            },
+            rejected: (state, action) => {
+                state.søknad = simpleRejectedActionToRemoteData(action);
+            },
+        });
+        handleAsyncThunk(builder, sendAldersøknad, {
             pending: (state) => {
                 state.søknad = RemoteData.pending;
             },

--- a/src/pages/søknad/kvittering/Kvittering.tsx
+++ b/src/pages/søknad/kvittering/Kvittering.tsx
@@ -10,6 +10,7 @@ import { OpprettetSøknad } from '~src/api/søknadApi';
 import { SuccessIcon } from '~src/assets/Icons';
 import CircleWithIcon from '~src/components/circleWithIcon/CircleWithIcon';
 import * as personSlice from '~src/features/person/person.slice';
+import innsendingSlice from '~src/features/søknad/innsending.slice';
 import * as søknadslice from '~src/features/søknad/søknad.slice';
 import { pipe } from '~src/lib/fp';
 import { useI18n } from '~src/lib/i18n';
@@ -35,6 +36,7 @@ const Kvittering = () => {
     const handleAvsluttSøknad = (sakId: Nullable<string>) => {
         dispatch(personSlice.default.actions.resetSøkerData());
         dispatch(søknadslice.default.actions.resetSøknad());
+        dispatch(innsendingSlice.actions.resetInnsending());
 
         if (søknadstype === Søknadstype.Papirsøknad && sakId) {
             navigate(Routes.saksoversiktValgtSak.createURL({ sakId: sakId }));

--- a/src/pages/søknad/steg/inngang/Inngang.tsx
+++ b/src/pages/søknad/steg/inngang/Inngang.tsx
@@ -12,6 +12,7 @@ import { LinkAsButton } from '~src/components/linkAsButton/LinkAsButton';
 import { BekreftSøknadModal } from '~src/components/modal/BekreftSøknadModal.tsx';
 import Personsøk from '~src/components/Personsøk/Personsøk';
 import * as personSlice from '~src/features/person/person.slice';
+import innsendingSlice from '~src/features/søknad/innsending.slice';
 import søknadSlice from '~src/features/søknad/søknad.slice';
 import { pipe } from '~src/lib/fp';
 import { useApiCall, useAsyncActionCreator } from '~src/lib/hooks';
@@ -237,6 +238,7 @@ const Inngang = () => {
 
     useEffect(() => {
         dispatch(søknadSlice.actions.resetSøknad());
+        dispatch(innsendingSlice.actions.resetInnsending());
     }, [søker]);
 
     const [hentPersonStatus, hentPerson] = useAsyncActionCreator(personSlice.fetchPerson);
@@ -263,6 +265,7 @@ const Inngang = () => {
         if (!isFormValid) {
             return;
         }
+        dispatch(innsendingSlice.actions.resetInnsending());
         dispatch(søknadSlice.actions.startSøknad(isPapirsøknad ? Søknadstype.Papirsøknad : Søknadstype.DigitalSøknad));
         navigate(startstegUrl);
     };


### PR DESCRIPTION
Frontend lagret innsendingstatus i Redux som innsending.søknad.

Når en søknad ble sendt inn, ble denne satt til success. Men når man avsluttet kvitteringen eller startet ny søknad, ble bare søker/skjemadata resetta. innsending.søknad ble liggende som success.
og når man har fylt ut på nytt da vil ikke knappen reagere.


flyt:

1. Søknad A sendes inn.
2. innsending.søknad = success.
3. Man starter søknad B i samme browser-session.
4. På oppsummering tror frontend fortsatt at søknaden allerede er sendt inn.
5. UI kan vise “Søknaden er sendt inn”.
6. Submit stopper tidlig og sender ikke B.