### PR TITLE
Ikke kjør på merge til master, Deploy til prod-gcp ved merge til mast…

### DIFF
--- a/.github/workflows/build-push-deploy-to-dev-gcp.yml
+++ b/.github/workflows/build-push-deploy-to-dev-gcp.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
     build-push-docker-image:
+        if: github.event_name == 'workflow_dispatch'
         name: build-push-docker-image
         runs-on: ubuntu-latest
         outputs:


### PR DESCRIPTION
…er deployer auto til dev.

Fjernre dobbeltbygging av docker image.