### PR TITLE
Fiks naming for oppholdstillattelse revurdering som lovlig opphold

### DIFF
--- a/src/typeMappinger/InformasjonSomRevurderesTextMapper.ts
+++ b/src/typeMappinger/InformasjonSomRevurderesTextMapper.ts
@@ -9,7 +9,7 @@ export const InformasjonSomRevurderesTextMapper: { [key in InformasjonSomRevurde
     [InformasjonSomRevurderes.Flyktning]: 'Flyktingsstatus',
     [InformasjonSomRevurderes.FastOpphold]: 'Opphold i Norge',
     [InformasjonSomRevurderes.Opplysningsplikt]: 'Opplysningsplikt',
-    [InformasjonSomRevurderes.Oppholdstillatelse]: 'Oppholdstillatelse',
+    [InformasjonSomRevurderes.Oppholdstillatelse]: 'Lovlig opphold',
     [InformasjonSomRevurderes.PersonligOppmøte]: 'Personlig oppmøte',
     [InformasjonSomRevurderes.Institusjonsopphold]: 'Institusjonsopphold',
     [InformasjonSomRevurderes.Familiegjenforening]: 'Familiegjenforening',


### PR DESCRIPTION
saksbehandler blir forvirret da teksten her er annerledes enn i selve vurderingen og velger ofte feil vilkår